### PR TITLE
New plugin snmp_dm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ console.log
 test.conf
 /cache.d
 /trace.d
+install/README_backup.md

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -410,7 +410,7 @@ func (a *Agent) testRunInputs(
 			case "cpu", "mongodb", "procstat":
 				nulAcc := NewAccumulator(input, nul)
 				nulAcc.SetPrecision(getPrecision(precision, interval))
-				if err := input.Input.Gather(nulAcc); err != nil {
+				if err := input.Input.Gather(ctx, nulAcc); err != nil {
 					nulAcc.AddError(err)
 				}
 
@@ -420,7 +420,7 @@ func (a *Agent) testRunInputs(
 			acc := NewAccumulator(input, unit.dst)
 			acc.SetPrecision(getPrecision(precision, interval))
 
-			if err := input.Input.Gather(acc); err != nil {
+			if err := input.Input.Gather(ctx, acc); err != nil {
 				acc.AddError(err)
 			}
 		}(input)
@@ -479,7 +479,7 @@ func (a *Agent) gatherOnce(
 ) error {
 	done := make(chan error)
 	go func() {
-		done <- input.Gather(acc)
+		done <- input.Gather(context.Background(), acc)
 	}()
 
 	// Only warn after interval seconds, even if the interval is started late.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -127,11 +127,6 @@ func (a *Agent) Run(ctx context.Context) error {
 		}
 
 		next, au = a.startAggregators(aggC, next, a.Config.Aggregators)
-		// startAggregators always returns nil err
-		// next, au, err = a.startAggregators(aggC, next, a.Config.Aggregators)
-		// if err != nil {
-		// 	return err
-		// }
 	}
 
 	var pu []*processorUnit
@@ -152,11 +147,6 @@ func (a *Agent) Run(ctx context.Context) error {
 	go func() {
 		defer wg.Done()
 		a.runOutputs(ou)
-		// runOutputs always returns nil
-		// err := a.runOutputs(ou)
-		// if err != nil {
-		// 	log.Printf("E! [agent] Error running outputs: %v", err)
-		// }
 	}()
 
 	if au != nil {
@@ -164,22 +154,12 @@ func (a *Agent) Run(ctx context.Context) error {
 		go func() {
 			defer wg.Done()
 			a.runProcessors(apu)
-			// runProcessors always returns nil
-			// err := a.runProcessors(apu)
-			// if err != nil {
-			// 	log.Printf("E! [agent] Error running processors: %v", err)
-			// }
 		}()
 
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			a.runAggregators(startTime, au)
-			// runAggregators always returns nil
-			// err := a.runAggregators(startTime, au)
-			// if err != nil {
-			// 	log.Printf("E! [agent] Error running aggregators: %v", err)
-			// }
 		}()
 	}
 
@@ -188,11 +168,6 @@ func (a *Agent) Run(ctx context.Context) error {
 		go func() {
 			defer wg.Done()
 			a.runProcessors(pu)
-			// runProcessors always returns nil
-			// err := a.runProcessors(pu)
-			// if err != nil {
-			// 	log.Printf("E! [agent] Error running processors: %v", err)
-			// }
 		}()
 	}
 
@@ -200,10 +175,6 @@ func (a *Agent) Run(ctx context.Context) error {
 	go func() {
 		defer wg.Done()
 		a.runInputs(ctx, startTime, iu)
-		// runInputs always returns nil
-		// if err != nil {
-		// 	log.Printf("E! [agent] Error running inputs: %v", err)
-		// }
 	}()
 
 	wg.Wait()
@@ -459,7 +430,7 @@ func (a *Agent) gatherLoop(
 	for {
 		select {
 		case <-ticker.Elapsed():
-			err := a.gatherOnce(acc, input, ticker, interval)
+			err := a.gatherOnce(ctx, acc, input, ticker, interval)
 			if err != nil {
 				acc.AddError(err)
 			}
@@ -472,6 +443,7 @@ func (a *Agent) gatherLoop(
 // gatherOnce runs the input's Gather function once, logging a warning each
 // interval it fails to complete before.
 func (a *Agent) gatherOnce(
+	ctx context.Context,
 	acc cua.Accumulator,
 	input *models.RunningInput,
 	ticker Ticker,
@@ -479,7 +451,7 @@ func (a *Agent) gatherOnce(
 ) error {
 	done := make(chan error)
 	go func() {
-		done <- input.Gather(context.Background(), acc)
+		done <- input.Gather(ctx, acc)
 	}()
 
 	// Only warn after interval seconds, even if the interval is started late.
@@ -911,11 +883,6 @@ func (a *Agent) test(ctx context.Context, wait time.Duration, outputC chan<- cua
 		}
 
 		next, au = a.startAggregators(procC, next, a.Config.Aggregators)
-		// startAggregators always return nil err
-		// next, au, err = a.startAggregators(procC, next, a.Config.Aggregators)
-		// if err != nil {
-		// 	return err
-		// }
 	}
 
 	var pu []*processorUnit
@@ -927,11 +894,6 @@ func (a *Agent) test(ctx context.Context, wait time.Duration, outputC chan<- cua
 	}
 
 	iu := a.testStartInputs(next, a.Config.Inputs)
-	// testStartInputs always returns nil
-	// iu, err := a.testStartInputs(next, a.Config.Inputs)
-	// if err != nil {
-	// 	return err
-	// }
 
 	var wg sync.WaitGroup
 
@@ -940,22 +902,12 @@ func (a *Agent) test(ctx context.Context, wait time.Duration, outputC chan<- cua
 		go func() {
 			defer wg.Done()
 			a.runProcessors(apu)
-			// runProcessors always returns nil
-			// err := a.runProcessors(apu)
-			// if err != nil {
-			// 	log.Printf("E! [agent] Error running processors: %v", err)
-			// }
 		}()
 
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			a.runAggregators(startTime, au)
-			// runAggregators always returns nil
-			// err := a.runAggregators(startTime, au)
-			// if err != nil {
-			// 	log.Printf("E! [agent] Error running aggregators: %v", err)
-			// }
 		}()
 	}
 
@@ -964,11 +916,6 @@ func (a *Agent) test(ctx context.Context, wait time.Duration, outputC chan<- cua
 		go func() {
 			defer wg.Done()
 			a.runProcessors(pu)
-			// runProcessors always returns nil
-			// err := a.runProcessors(pu)
-			// if err != nil {
-			// 	log.Printf("E! [agent] Error running processors: %v", err)
-			// }
 		}()
 	}
 
@@ -976,11 +923,6 @@ func (a *Agent) test(ctx context.Context, wait time.Duration, outputC chan<- cua
 	go func() {
 		defer wg.Done()
 		a.testRunInputs(ctx, wait, iu)
-		// testRunInputs always returns nil
-		// err := a.testRunInputs(ctx, wait, iu)
-		// if err != nil {
-		// 	log.Printf("E! [agent] Error running inputs: %v", err)
-		// }
 	}()
 
 	wg.Wait()

--- a/build_lint.sh
+++ b/build_lint.sh
@@ -5,4 +5,6 @@ echo "Running Lint (Linux specific)"
 GOOS=linux golangci-lint run || exit 1
 echo "Running Lint (Windows specific)"
 GOOS=windows golangci-lint run || exit 1
+echo "Running Lint (FreeBSD specific)"
+GOOS=freebsd golangci-lint run || exit 1
 

--- a/cua/input.go
+++ b/cua/input.go
@@ -1,11 +1,13 @@
 package cua
 
+import "context"
+
 type Input interface {
 	PluginDescriber
 
 	// Gather takes in an accumulator and adds the metrics that the Input
 	// gathers. This is called every agent.interval
-	Gather(Accumulator) error
+	Gather(context.Context, Accumulator) error
 }
 
 type ServiceInput interface {

--- a/internal/circonus/dm_helpers.go
+++ b/internal/circonus/dm_helpers.go
@@ -1,0 +1,56 @@
+package circonus
+
+import (
+	"time"
+
+	"github.com/maier/go-trapmetrics"
+)
+
+// Contains helpers for direct metric input plugins
+
+func AddMetricToDest(dest *trapmetrics.TrapMetrics, pluginID, metricGroup, metricName string, metricTags map[string]string, value interface{}, ts time.Time) error {
+
+	tags := ConvertTags(pluginID, metricGroup, metricTags)
+
+	switch v := value.(type) {
+	case string:
+		if err := dest.TextSet(metricName, tags, v, &ts); err != nil {
+			return err
+		}
+	default:
+		if err := dest.GaugeSet(metricName, tags, v, &ts); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func ConvertTags(pluginID, metricGroup string, tags map[string]string) trapmetrics.Tags {
+	var ctags trapmetrics.Tags
+
+	if len(tags) == 0 && pluginID == "" {
+		return ctags
+	}
+
+	ctags = make(trapmetrics.Tags, 0)
+	haveInputMetricGroup := false
+
+	for key, val := range tags {
+		if key == "input_metric_group" {
+			haveInputMetricGroup = true
+		}
+		ctags = append(ctags, trapmetrics.Tag{Category: key, Value: val})
+	}
+
+	if pluginID != "" {
+		ctags = append(ctags, trapmetrics.Tag{Category: "input_plugin", Value: pluginID})
+	}
+	if !haveInputMetricGroup {
+		if pluginID != "" && pluginID != metricGroup {
+			ctags = append(ctags, trapmetrics.Tag{Category: "input_metric_group", Value: metricGroup})
+		}
+	}
+
+	return ctags
+}

--- a/models/running_input.go
+++ b/models/running_input.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -126,9 +127,9 @@ func (r *RunningInput) MakeMetric(metric cua.Metric) cua.Metric {
 	return m
 }
 
-func (r *RunningInput) Gather(acc cua.Accumulator) error {
+func (r *RunningInput) Gather(ctx context.Context, acc cua.Accumulator) error {
 	start := time.Now()
-	err := r.Input.Gather(acc)
+	err := r.Input.Gather(ctx, acc)
 	elapsed := time.Since(start)
 	r.GatherTime.Incr(elapsed.Nanoseconds())
 	if err != nil {

--- a/models/running_input_test.go
+++ b/models/running_input_test.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -288,6 +289,6 @@ func TestMetricErrorCounters(t *testing.T) {
 
 type testInput struct{}
 
-func (t *testInput) Description() string              { return "" }
-func (t *testInput) SampleConfig() string             { return "" }
-func (t *testInput) Gather(acc cua.Accumulator) error { return nil }
+func (t *testInput) Description() string                                   { return "" }
+func (t *testInput) SampleConfig() string                                  { return "" }
+func (t *testInput) Gather(ctx context.Context, acc cua.Accumulator) error { return nil }

--- a/plugins/common/shim/config_test.go
+++ b/plugins/common/shim/config_test.go
@@ -1,6 +1,7 @@
 package shim
 
 import (
+	"context"
 	"os"
 	"testing"
 	"time"
@@ -81,7 +82,7 @@ func (i *testDurationInput) SampleConfig() string {
 func (i *testDurationInput) Description() string {
 	return ""
 }
-func (i *testDurationInput) Gather(acc cua.Accumulator) error {
+func (i *testDurationInput) Gather(ctx context.Context, acc cua.Accumulator) error {
 	return nil
 }
 

--- a/plugins/common/shim/goshim_test.go
+++ b/plugins/common/shim/goshim_test.go
@@ -2,6 +2,7 @@ package shim
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"io"
 	"log"
@@ -66,7 +67,7 @@ func (i *erroringInput) Description() string {
 	return ""
 }
 
-func (i *erroringInput) Gather(acc cua.Accumulator) error {
+func (i *erroringInput) Gather(ctx context.Context, acc cua.Accumulator) error {
 	acc.AddError(errors.New("intentional"))
 	return nil
 }

--- a/plugins/common/shim/input.go
+++ b/plugins/common/shim/input.go
@@ -88,11 +88,11 @@ func (s *Shim) startGathering(ctx context.Context, input cua.Input, acc cua.Accu
 		case <-ctx.Done():
 			return
 		case <-s.gatherPromptCh:
-			if err := input.Gather(acc); err != nil {
+			if err := input.Gather(ctx, acc); err != nil {
 				fmt.Fprintf(s.stderr, "failed to gather metrics: %s\n", err)
 			}
 		case <-t.C:
-			if err := input.Gather(acc); err != nil {
+			if err := input.Gather(ctx, acc); err != nil {
 				fmt.Fprintf(s.stderr, "failed to gather metrics: %s\n", err)
 			}
 		}

--- a/plugins/common/shim/input_test.go
+++ b/plugins/common/shim/input_test.go
@@ -2,6 +2,7 @@ package shim
 
 import (
 	"bufio"
+	"context"
 	"io"
 	"strings"
 	"testing"
@@ -88,7 +89,7 @@ func (i *testInput) Description() string {
 	return "test"
 }
 
-func (i *testInput) Gather(acc cua.Accumulator) error {
+func (i *testInput) Gather(ctx context.Context, acc cua.Accumulator) error {
 	acc.AddFields("measurement",
 		map[string]interface{}{
 			"field": 1,
@@ -121,7 +122,7 @@ func (i *serviceInput) Description() string {
 	return ""
 }
 
-func (i *serviceInput) Gather(acc cua.Accumulator) error {
+func (i *serviceInput) Gather(ctx context.Context, acc cua.Accumulator) error {
 	acc.AddFields("measurement",
 		map[string]interface{}{
 			"field": 1,

--- a/plugins/inputs/activemq/activemq.go
+++ b/plugins/inputs/activemq/activemq.go
@@ -1,6 +1,7 @@
 package activemq
 
 import (
+	"context"
 	"encoding/xml"
 	"fmt"
 	"io"
@@ -247,7 +248,7 @@ func (a *ActiveMQ) GatherSubscribersMetrics(acc cua.Accumulator, subscribers Sub
 	}
 }
 
-func (a *ActiveMQ) Gather(acc cua.Accumulator) error {
+func (a *ActiveMQ) Gather(ctx context.Context, acc cua.Accumulator) error {
 	dataQueues, err := a.GetMetrics(a.QueuesURL())
 	if err != nil {
 		return err

--- a/plugins/inputs/activemq/activemq_test.go
+++ b/plugins/inputs/activemq/activemq_test.go
@@ -1,6 +1,7 @@
 package activemq
 
 import (
+	"context"
 	"encoding/xml"
 	"net/http"
 	"net/http/httptest"
@@ -179,7 +180,7 @@ func TestURLs(t *testing.T) {
 	require.NoError(t, err)
 
 	var acc testutil.Accumulator
-	err = plugin.Gather(&acc)
+	err = plugin.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	require.Len(t, acc.GetCUAMetrics(), 0)

--- a/plugins/inputs/aerospike/aerospike.go
+++ b/plugins/inputs/aerospike/aerospike.go
@@ -1,6 +1,7 @@
 package aerospike
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"math"
@@ -88,7 +89,7 @@ func (a *Aerospike) Description() string {
 	return "Read stats from aerospike server(s)"
 }
 
-func (a *Aerospike) Gather(acc cua.Accumulator) error {
+func (a *Aerospike) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if !a.initialized {
 		tlsConfig, err := a.ClientConfig.TLSConfig()
 		if err != nil {

--- a/plugins/inputs/all/all.go
+++ b/plugins/inputs/all/all.go
@@ -147,6 +147,7 @@ import (
 	_ "github.com/circonus-labs/circonus-unified-agent/plugins/inputs/sflow"
 	_ "github.com/circonus-labs/circonus-unified-agent/plugins/inputs/smart"
 	_ "github.com/circonus-labs/circonus-unified-agent/plugins/inputs/snmp"
+	_ "github.com/circonus-labs/circonus-unified-agent/plugins/inputs/snmp_dm"
 	_ "github.com/circonus-labs/circonus-unified-agent/plugins/inputs/snmp_trap"
 	_ "github.com/circonus-labs/circonus-unified-agent/plugins/inputs/socket_listener"
 	_ "github.com/circonus-labs/circonus-unified-agent/plugins/inputs/solr"

--- a/plugins/inputs/amqp_consumer/amqp_consumer.go
+++ b/plugins/inputs/amqp_consumer/amqp_consumer.go
@@ -177,7 +177,7 @@ func (a *AMQPConsumer) SetParser(parser parsers.Parser) {
 }
 
 // All gathering is done in the Start function
-func (a *AMQPConsumer) Gather(_ cua.Accumulator) error {
+func (a *AMQPConsumer) Gather(_ context.Context, _ cua.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/apache/apache.go
+++ b/plugins/inputs/apache/apache.go
@@ -2,6 +2,7 @@ package apache
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -56,7 +57,7 @@ func (n *Apache) Description() string {
 	return "Read Apache status information (mod_status)"
 }
 
-func (n *Apache) Gather(acc cua.Accumulator) error {
+func (n *Apache) Gather(ctx context.Context, acc cua.Accumulator) error {
 	var wg sync.WaitGroup
 
 	if len(n.Urls) == 0 {

--- a/plugins/inputs/apcupsd/apcupsd.go
+++ b/plugins/inputs/apcupsd/apcupsd.go
@@ -40,8 +40,7 @@ func (*ApcUpsd) SampleConfig() string {
 	return sampleConfig
 }
 
-func (h *ApcUpsd) Gather(acc cua.Accumulator) error {
-	ctx := context.Background()
+func (h *ApcUpsd) Gather(ctx context.Context, acc cua.Accumulator) error {
 
 	for _, addr := range h.Servers {
 		addrBits, err := url.Parse(addr)
@@ -52,10 +51,10 @@ func (h *ApcUpsd) Gather(acc cua.Accumulator) error {
 			addrBits.Scheme = "tcp"
 		}
 
-		ctx, cancel := context.WithTimeout(ctx, h.Timeout.Duration)
+		gctx, cancel := context.WithTimeout(ctx, h.Timeout.Duration)
 		defer cancel()
 
-		status, err := fetchStatus(ctx, addrBits)
+		status, err := fetchStatus(gctx, addrBits)
 		if err != nil {
 			return err
 		}

--- a/plugins/inputs/apcupsd/apcupsd_test.go
+++ b/plugins/inputs/apcupsd/apcupsd_test.go
@@ -96,7 +96,7 @@ func TestConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			apc.Servers = tt.servers
 
-			err := apc.Gather(&acc)
+			err := apc.Gather(context.Background(), &acc)
 			if tt.err {
 				require.Error(t, err)
 			} else {
@@ -168,7 +168,7 @@ func TestApcupsdGather(t *testing.T) {
 
 			apc.Servers = []string{"tcp://" + lAddr}
 
-			err = apc.Gather(&acc)
+			err = apc.Gather(context.Background(), &acc)
 			if tt.err {
 				require.Error(t, err)
 			} else {

--- a/plugins/inputs/aurora/aurora.go
+++ b/plugins/inputs/aurora/aurora.go
@@ -87,7 +87,7 @@ func (a *Aurora) Description() string {
 	return "Gather metrics from Apache Aurora schedulers"
 }
 
-func (a *Aurora) Gather(acc cua.Accumulator) error {
+func (a *Aurora) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if a.client == nil {
 		err := a.initialize()
 		if err != nil {

--- a/plugins/inputs/aurora/aurora_test.go
+++ b/plugins/inputs/aurora/aurora_test.go
@@ -1,6 +1,7 @@
 package aurora
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -203,7 +204,7 @@ func TestAurora(t *testing.T) {
 			plugin := &Aurora{}
 			plugin.Schedulers = []string{u.String()}
 			plugin.Roles = tt.roles
-			err := plugin.Gather(&acc)
+			err := plugin.Gather(context.Background(), &acc)
 			tt.check(t, err, &acc)
 		})
 	}
@@ -254,7 +255,7 @@ func TestBasicAuth(t *testing.T) {
 			plugin.Schedulers = []string{u.String()}
 			plugin.Username = tt.username
 			plugin.Password = tt.password
-			err := plugin.Gather(&acc)
+			err := plugin.Gather(context.Background(), &acc)
 			require.NoError(t, err)
 		})
 	}

--- a/plugins/inputs/azure_storage_queue/azure_storage_queue.go
+++ b/plugins/inputs/azure_storage_queue/azure_storage_queue.go
@@ -84,13 +84,11 @@ func (a *AzureStorageQueue) GatherQueueMetrics(acc cua.Accumulator, queueItem az
 	acc.AddFields("azure_storage_queues", fields, tags)
 }
 
-func (a *AzureStorageQueue) Gather(acc cua.Accumulator) error {
+func (a *AzureStorageQueue) Gather(ctx context.Context, acc cua.Accumulator) error {
 	serviceURL, err := a.GetServiceURL()
 	if err != nil {
 		return err
 	}
-
-	ctx := context.TODO()
 
 	for marker := (azqueue.Marker{}); marker.NotDone(); {
 		a.Log.Debugf("Listing queues of storage account '%s'", a.StorageAccountName)

--- a/plugins/inputs/bcache/bcache.go
+++ b/plugins/inputs/bcache/bcache.go
@@ -5,6 +5,7 @@ package bcache
 // bcache doesn't aim for Windows
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -112,7 +113,7 @@ func (b *Bcache) gatherBcache(bdev string, acc cua.Accumulator) error {
 	return nil
 }
 
-func (b *Bcache) Gather(acc cua.Accumulator) error {
+func (b *Bcache) Gather(ctx context.Context, acc cua.Accumulator) error {
 	bcacheDevsChecked := make(map[string]bool)
 	var restrictDevs bool
 	if len(b.BcacheDevs) != 0 {

--- a/plugins/inputs/bcache/bcache_test.go
+++ b/plugins/inputs/bcache/bcache_test.go
@@ -3,6 +3,7 @@
 package bcache
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -97,14 +98,14 @@ func TestBcacheGeneratesMetrics(t *testing.T) {
 	// all devs
 	b := &Bcache{BcachePath: testBcachePath}
 
-	err = b.Gather(&acc)
+	err = b.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 	acc.AssertContainsTaggedFields(t, "bcache", fields, tags)
 
 	// one exist dev
 	b = &Bcache{BcachePath: testBcachePath, BcacheDevs: []string{"bcache0"}}
 
-	err = b.Gather(&acc)
+	err = b.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 	acc.AssertContainsTaggedFields(t, "bcache", fields, tags)
 

--- a/plugins/inputs/beanstalkd/beanstalkd.go
+++ b/plugins/inputs/beanstalkd/beanstalkd.go
@@ -1,6 +1,7 @@
 package beanstalkd
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/textproto"
@@ -33,7 +34,7 @@ func (b *Beanstalkd) SampleConfig() string {
 	return sampleConfig
 }
 
-func (b *Beanstalkd) Gather(acc cua.Accumulator) error {
+func (b *Beanstalkd) Gather(ctx context.Context, acc cua.Accumulator) error {
 	connection, err := textproto.Dial("tcp", b.Server)
 	if err != nil {
 		return fmt.Errorf("dial: %w", err)

--- a/plugins/inputs/bind/bind.go
+++ b/plugins/inputs/bind/bind.go
@@ -1,6 +1,7 @@
 package bind
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -42,7 +43,7 @@ func (b *Bind) SampleConfig() string {
 	return sampleConfig
 }
 
-func (b *Bind) Gather(acc cua.Accumulator) error {
+func (b *Bind) Gather(ctx context.Context, acc cua.Accumulator) error {
 	var wg sync.WaitGroup
 
 	if len(b.Urls) == 0 {

--- a/plugins/inputs/bond/bond.go
+++ b/plugins/inputs/bond/bond.go
@@ -2,6 +2,7 @@ package bond
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -42,7 +43,7 @@ func (bond *Bond) SampleConfig() string {
 	return sampleConfig
 }
 
-func (bond *Bond) Gather(acc cua.Accumulator) error {
+func (bond *Bond) Gather(ctx context.Context, acc cua.Accumulator) error {
 	// load proc path, get default value if config value and env variable are empty
 	bond.loadPath()
 	// list bond interfaces from bonding directory or gather all interfaces.

--- a/plugins/inputs/burrow/burrow.go
+++ b/plugins/inputs/burrow/burrow.go
@@ -1,6 +1,7 @@
 package burrow
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -141,7 +142,7 @@ func (b *burrow) Description() string {
 	return "Collect Kafka topics and consumers status from Burrow HTTP API."
 }
 
-func (b *burrow) Gather(acc cua.Accumulator) error {
+func (b *burrow) Gather(ctx context.Context, acc cua.Accumulator) error {
 	var wg sync.WaitGroup
 
 	if len(b.Servers) == 0 {

--- a/plugins/inputs/burrow/burrow_test.go
+++ b/plugins/inputs/burrow/burrow_test.go
@@ -1,6 +1,7 @@
 package burrow
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -71,7 +72,7 @@ func TestBurrowTopic(t *testing.T) {
 
 	plugin := &burrow{Servers: []string{s.URL}}
 	acc := &testutil.Accumulator{}
-	_ = plugin.Gather(acc)
+	_ = plugin.Gather(context.Background(), acc)
 
 	fields := []map[string]interface{}{
 		// topicA
@@ -102,7 +103,7 @@ func TestBurrowPartition(t *testing.T) {
 		Servers: []string{s.URL},
 	}
 	acc := &testutil.Accumulator{}
-	_ = plugin.Gather(acc)
+	_ = plugin.Gather(context.Background(), acc)
 
 	fields := []map[string]interface{}{
 		{
@@ -150,7 +151,7 @@ func TestBurrowGroup(t *testing.T) {
 		Servers: []string{s.URL},
 	}
 	acc := &testutil.Accumulator{}
-	_ = plugin.Gather(acc)
+	_ = plugin.Gather(context.Background(), acc)
 
 	fields := []map[string]interface{}{
 		{
@@ -188,7 +189,7 @@ func TestMultipleServers(t *testing.T) {
 		Servers: []string{s1.URL, s2.URL},
 	}
 	acc := &testutil.Accumulator{}
-	_ = plugin.Gather(acc)
+	_ = plugin.Gather(context.Background(), acc)
 
 	require.Exactly(t, 14, len(acc.Metrics))
 	require.Empty(t, acc.Errors)
@@ -204,7 +205,7 @@ func TestMultipleRuns(t *testing.T) {
 	}
 	for i := 0; i < 4; i++ {
 		acc := &testutil.Accumulator{}
-		_ = plugin.Gather(acc)
+		_ = plugin.Gather(context.Background(), acc)
 
 		require.Exactly(t, 7, len(acc.Metrics))
 		require.Empty(t, acc.Errors)
@@ -223,7 +224,7 @@ func TestBasicAuthConfig(t *testing.T) {
 	}
 
 	acc := &testutil.Accumulator{}
-	_ = plugin.Gather(acc)
+	_ = plugin.Gather(context.Background(), acc)
 
 	require.Exactly(t, 7, len(acc.Metrics))
 	require.Empty(t, acc.Errors)
@@ -240,7 +241,7 @@ func TestFilterClusters(t *testing.T) {
 	}
 
 	acc := &testutil.Accumulator{}
-	_ = plugin.Gather(acc)
+	_ = plugin.Gather(context.Background(), acc)
 
 	// no match by cluster
 	require.Exactly(t, 0, len(acc.Metrics))
@@ -259,7 +260,7 @@ func TestFilterGroups(t *testing.T) {
 	}
 
 	acc := &testutil.Accumulator{}
-	_ = plugin.Gather(acc)
+	_ = plugin.Gather(context.Background(), acc)
 
 	require.Exactly(t, 1, len(acc.Metrics))
 	require.Empty(t, acc.Errors)
@@ -277,7 +278,7 @@ func TestFilterTopics(t *testing.T) {
 	}
 
 	acc := &testutil.Accumulator{}
-	_ = plugin.Gather(acc)
+	_ = plugin.Gather(context.Background(), acc)
 
 	require.Exactly(t, 3, len(acc.Metrics))
 	require.Empty(t, acc.Errors)

--- a/plugins/inputs/ceph/ceph.go
+++ b/plugins/inputs/ceph/ceph.go
@@ -2,6 +2,7 @@ package ceph
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -84,7 +85,7 @@ func (c *Ceph) SampleConfig() string {
 	return sampleConfig
 }
 
-func (c *Ceph) Gather(acc cua.Accumulator) error {
+func (c *Ceph) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if c.GatherAdminSocketStats {
 		if err := c.gatherAdminSocketStats(acc); err != nil {
 			return err

--- a/plugins/inputs/ceph/ceph_test.go
+++ b/plugins/inputs/ceph/ceph_test.go
@@ -1,6 +1,7 @@
 package ceph
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -103,7 +104,7 @@ func TestGather(t *testing.T) {
 
 	acc := &testutil.Accumulator{}
 	c := &Ceph{}
-	_ = c.Gather(acc)
+	_ = c.Gather(context.Background(), acc)
 
 }
 

--- a/plugins/inputs/cgroup/cgroup_linux.go
+++ b/plugins/inputs/cgroup/cgroup_linux.go
@@ -15,7 +15,7 @@ import (
 
 const metricName = "cgroup"
 
-func (g *CGroup) Gather(acc cua.Accumulator) error {
+func (g *CGroup) Gather(ctx context.Context, acc cua.Accumulator) error {
 	list := make(chan pathInfo)
 	go g.generateDirs(list)
 

--- a/plugins/inputs/cgroup/cgroup_linux.go
+++ b/plugins/inputs/cgroup/cgroup_linux.go
@@ -3,6 +3,7 @@
 package cgroup
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path"

--- a/plugins/inputs/cgroup/cgroup_notlinux.go
+++ b/plugins/inputs/cgroup/cgroup_notlinux.go
@@ -2,8 +2,12 @@
 
 package cgroup
 
-import "github.com/circonus-labs/circonus-unified-agent/cua"
+import (
+	"context"
 
-func (g *CGroup) Gather(acc cua.Accumulator) error {
+	"github.com/circonus-labs/circonus-unified-agent/cua"
+)
+
+func (g *CGroup) Gather(_ context.Context, _ cua.Accumulator) error {
 	return nil
 }

--- a/plugins/inputs/chrony/chrony.go
+++ b/plugins/inputs/chrony/chrony.go
@@ -1,6 +1,7 @@
 package chrony
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os/exec"
@@ -42,7 +43,7 @@ func (c *Chrony) Init() error {
 	return nil
 }
 
-func (c *Chrony) Gather(acc cua.Accumulator) error {
+func (c *Chrony) Gather(ctx context.Context, acc cua.Accumulator) error {
 	flags := []string{}
 	if !c.DNSLookup {
 		flags = append(flags, "-n")

--- a/plugins/inputs/chrony/chrony_test.go
+++ b/plugins/inputs/chrony/chrony_test.go
@@ -1,6 +1,7 @@
 package chrony
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -18,7 +19,7 @@ func TestGather(t *testing.T) {
 	defer func() { execCommand = exec.Command }()
 	var acc testutil.Accumulator
 
-	err := c.Gather(&acc)
+	err := c.Gather(context.Background(), &acc)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,7 +45,7 @@ func TestGather(t *testing.T) {
 
 	// test with dns lookup
 	c.DNSLookup = true
-	err = c.Gather(&acc)
+	err = c.Gather(context.Background(), &acc)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
+++ b/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
@@ -2,6 +2,7 @@ package ciscotelemetrymdt
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -547,7 +548,7 @@ func (c *CiscoTelemetryMDT) Description() string {
 }
 
 // Gather plugin measurements (unused)
-func (c *CiscoTelemetryMDT) Gather(_ cua.Accumulator) error {
+func (c *CiscoTelemetryMDT) Gather(_ context.Context, _ cua.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/clickhouse/clickhouse.go
+++ b/plugins/inputs/clickhouse/clickhouse.go
@@ -2,6 +2,7 @@ package clickhouse
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -151,7 +152,7 @@ func (ch *ClickHouse) Start(cua.Accumulator) error {
 }
 
 // Gather collect data from ClickHouse server
-func (ch *ClickHouse) Gather(acc cua.Accumulator) (err error) {
+func (ch *ClickHouse) Gather(ctx context.Context, acc cua.Accumulator) (err error) {
 	var (
 		connects []connect
 		exists   = func(host string) bool {

--- a/plugins/inputs/clickhouse/clickhouse_test.go
+++ b/plugins/inputs/clickhouse/clickhouse_test.go
@@ -1,6 +1,7 @@
 package clickhouse
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -294,7 +295,7 @@ func TestGather(t *testing.T) {
 		acc = &testutil.Accumulator{}
 	)
 	defer ts.Close()
-	_ = ch.Gather(acc)
+	_ = ch.Gather(context.Background(), acc)
 
 	acc.AssertContainsTaggedFields(t, "clickhouse_tables",
 		map[string]interface{}{
@@ -467,7 +468,7 @@ func TestGatherWithSomeTablesNotExists(t *testing.T) {
 		acc = &testutil.Accumulator{}
 	)
 	defer ts.Close()
-	_ = ch.Gather(acc)
+	_ = ch.Gather(context.Background(), acc)
 
 	acc.AssertDoesNotContainMeasurement(t, "clickhouse_zookeeper")
 	acc.AssertDoesNotContainMeasurement(t, "clickhouse_replication_queue")
@@ -495,7 +496,7 @@ func TestWrongJSONMarshalling(t *testing.T) {
 		acc = &testutil.Accumulator{}
 	)
 	defer ts.Close()
-	_ = ch.Gather(acc)
+	_ = ch.Gather(context.Background(), acc)
 
 	assert.Equal(t, 0, len(acc.Metrics))
 	allMeasurements := []string{
@@ -528,7 +529,7 @@ func TestOfflineServer(t *testing.T) {
 			},
 		}
 	)
-	_ = ch.Gather(acc)
+	_ = ch.Gather(context.Background(), acc)
 
 	assert.Equal(t, 0, len(acc.Metrics))
 	allMeasurements := []string{
@@ -580,7 +581,7 @@ func TestAutoDiscovery(t *testing.T) {
 	acc := &testutil.Accumulator{}
 
 	defer ts.Close()
-	if err := ch.Gather(acc); err != nil {
+	if err := ch.Gather(context.Background(), acc); err != nil {
 		assert.NoError(t, err, "gather error")
 	}
 }

--- a/plugins/inputs/cloud_pubsub/pubsub.go
+++ b/plugins/inputs/cloud_pubsub/pubsub.go
@@ -67,7 +67,7 @@ func (ps *PubSub) SampleConfig() string {
 }
 
 // Gather does nothing for this service input.
-func (ps *PubSub) Gather(acc cua.Accumulator) error {
+func (ps *PubSub) Gather(_ context.Context, _ cua.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/cloud_pubsub_push/pubsub_push.go
+++ b/plugins/inputs/cloud_pubsub_push/pubsub_push.go
@@ -121,7 +121,7 @@ func (p *PubSubPush) Description() string {
 	return "Google Cloud Pub/Sub Push HTTP listener"
 }
 
-func (p *PubSubPush) Gather(_ cua.Accumulator) error {
+func (p *PubSubPush) Gather(_ context.Context, _ cua.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/cloudwatch/cloudwatch.go
+++ b/plugins/inputs/cloudwatch/cloudwatch.go
@@ -1,6 +1,7 @@
 package cloudwatch
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -177,7 +178,7 @@ func (c *CloudWatch) Description() string {
 
 // Gather takes in an accumulator and adds the metrics that the Input
 // gathers. This is called every "interval".
-func (c *CloudWatch) Gather(acc cua.Accumulator) error {
+func (c *CloudWatch) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if c.statFilter == nil {
 		var err error
 		// Set config level filter (won't change throughout life of plugin).

--- a/plugins/inputs/conntrack/conntrack.go
+++ b/plugins/inputs/conntrack/conntrack.go
@@ -3,6 +3,7 @@
 package conntrack
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"

--- a/plugins/inputs/conntrack/conntrack.go
+++ b/plugins/inputs/conntrack/conntrack.go
@@ -68,7 +68,7 @@ func (c *Conntrack) SampleConfig() string {
 	return sampleConfig
 }
 
-func (c *Conntrack) Gather(acc cua.Accumulator) error {
+func (c *Conntrack) Gather(ctx context.Context, acc cua.Accumulator) error {
 	c.setDefaults()
 
 	var metricKey string

--- a/plugins/inputs/conntrack/conntrack_test.go
+++ b/plugins/inputs/conntrack/conntrack_test.go
@@ -3,6 +3,7 @@
 package conntrack
 
 import (
+	"context"
 	"os"
 	"path"
 	"strconv"

--- a/plugins/inputs/conntrack/conntrack_test.go
+++ b/plugins/inputs/conntrack/conntrack_test.go
@@ -25,7 +25,7 @@ func TestNoFilesFound(t *testing.T) {
 	dfltDirs = []string{"./foo/bar"}
 	c := &Conntrack{}
 	acc := &testutil.Accumulator{}
-	err := c.Gather(acc)
+	err := c.Gather(context.Background(), acc)
 
 	assert.EqualError(t, err, "Conntrack input failed to collect metrics. "+
 		"Is the conntrack kernel module loaded?")
@@ -50,7 +50,7 @@ func TestDefaultsUsed(t *testing.T) {
 	c := &Conntrack{}
 	acc := &testutil.Accumulator{}
 
-	_ = c.Gather(acc)
+	_ = c.Gather(context.Background(), acc)
 	acc.AssertContainsFields(t, inputName, map[string]interface{}{
 		fname: float64(count)})
 }
@@ -79,7 +79,7 @@ func TestConfigsUsed(t *testing.T) {
 	c := &Conntrack{}
 	acc := &testutil.Accumulator{}
 
-	_ = c.Gather(acc)
+	_ = c.Gather(context.Background(), acc)
 
 	fix := func(s string) string {
 		return strings.Replace(s, "nf_", "ip_", 1)

--- a/plugins/inputs/consul/consul.go
+++ b/plugins/inputs/consul/consul.go
@@ -1,6 +1,7 @@
 package consul
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -164,7 +165,7 @@ func (c *Consul) GatherHealthCheck(acc cua.Accumulator, checks []*api.HealthChec
 	}
 }
 
-func (c *Consul) Gather(acc cua.Accumulator) error {
+func (c *Consul) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if c.client == nil {
 		newClient, err := c.createAPIClient()
 

--- a/plugins/inputs/couchbase/couchbase.go
+++ b/plugins/inputs/couchbase/couchbase.go
@@ -1,6 +1,7 @@
 package couchbase
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"sync"
@@ -39,7 +40,7 @@ func (r *Couchbase) Description() string {
 
 // Reads stats from all configured clusters. Accumulates stats.
 // Returns one of the errors encountered while gathering stats (if any).
-func (r *Couchbase) Gather(acc cua.Accumulator) error {
+func (r *Couchbase) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if len(r.Servers) == 0 {
 		_ = r.gatherServer("http://localhost:8091/", acc, nil)
 		return nil

--- a/plugins/inputs/couchdb/couchdb.go
+++ b/plugins/inputs/couchdb/couchdb.go
@@ -1,6 +1,7 @@
 package couchdb
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -104,7 +105,7 @@ func (*CouchDB) SampleConfig() string {
 `
 }
 
-func (c *CouchDB) Gather(accumulator cua.Accumulator) error {
+func (c *CouchDB) Gather(ctx context.Context, accumulator cua.Accumulator) error {
 	var wg sync.WaitGroup
 	for _, u := range c.Hosts {
 		wg.Add(1)

--- a/plugins/inputs/cpu/cpu.go
+++ b/plugins/inputs/cpu/cpu.go
@@ -1,6 +1,7 @@
 package cpu
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -47,7 +48,7 @@ func (*Stats) SampleConfig() string {
 	return sampleConfig
 }
 
-func (s *Stats) Gather(acc cua.Accumulator) error {
+func (s *Stats) Gather(ctx context.Context, acc cua.Accumulator) error {
 	times, err := s.ps.CPUTimes(s.PerCPU, s.TotalCPU)
 	if err != nil {
 		return fmt.Errorf("error getting CPU info: %w", err)

--- a/plugins/inputs/cpu/cpu_test.go
+++ b/plugins/inputs/cpu/cpu_test.go
@@ -1,6 +1,7 @@
 package cpu
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -52,7 +53,7 @@ func TestCPUStats(t *testing.T) {
 		"cpu": "cpu0",
 	}
 
-	err := cs.Gather(&acc)
+	err := cs.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	// Computed values are checked with delta > 0 because of floating point arithmetic
@@ -74,7 +75,7 @@ func TestCPUStats(t *testing.T) {
 	cs.ps = &mps2
 
 	// Should have added cpu percentages too
-	err = cs.Gather(&acc)
+	err = cs.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	assertContainsTaggedFloat(t, &acc, "cpu", "time_user", 24.9, 0, cputags)
@@ -168,7 +169,7 @@ func TestCPUCountIncrease(t *testing.T) {
 			},
 		}, nil)
 
-	err = cs.Gather(&acc)
+	err = cs.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	mps2.On("CPUTimes").Return(
@@ -182,7 +183,7 @@ func TestCPUCountIncrease(t *testing.T) {
 		}, nil)
 	cs.ps = &mps2
 
-	err = cs.Gather(&acc)
+	err = cs.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 }
 
@@ -222,7 +223,7 @@ func TestCPUTimesDecrease(t *testing.T) {
 		"cpu": "cpu0",
 	}
 
-	err := cs.Gather(&acc)
+	err := cs.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	// Computed values are checked with delta > 0 because of floating point arithmetic
@@ -236,14 +237,14 @@ func TestCPUTimesDecrease(t *testing.T) {
 	cs.ps = &mps2
 
 	// CPU times decreased. An error should be raised
-	err = cs.Gather(&acc)
+	err = cs.Gather(context.Background(), &acc)
 	require.Error(t, err)
 
 	mps3 := system.MockPS{}
 	mps3.On("CPUTimes").Return([]cpu.TimesStat{cts3}, nil)
 	cs.ps = &mps3
 
-	err = cs.Gather(&acc)
+	err = cs.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	assertContainsTaggedFloat(t, &acc, "cpu", "time_user", 56, 0, cputags)

--- a/plugins/inputs/dcos/dcos.go
+++ b/plugins/inputs/dcos/dcos.go
@@ -122,13 +122,11 @@ func (d *DCOS) SampleConfig() string {
 	return sampleConfig
 }
 
-func (d *DCOS) Gather(acc cua.Accumulator) error {
+func (d *DCOS) Gather(ctx context.Context, acc cua.Accumulator) error {
 	err := d.init()
 	if err != nil {
 		return err
 	}
-
-	ctx := context.Background()
 
 	token, err := d.creds.Token(ctx, d.client)
 	if err != nil {

--- a/plugins/inputs/dcos/dcos_test.go
+++ b/plugins/inputs/dcos/dcos_test.go
@@ -435,7 +435,7 @@ func TestGatherFilterNode(t *testing.T) {
 				NodeExclude: tt.nodeExclude,
 				client:      tt.client,
 			}
-			err := dcos.Gather(&acc)
+			err := dcos.Gather(context.Background(), &acc)
 			require.NoError(t, err)
 			for i, ok := range tt.check(&acc) {
 				require.True(t, ok, fmt.Sprintf("Index was not true: %d", i))

--- a/plugins/inputs/disk/disk.go
+++ b/plugins/inputs/disk/disk.go
@@ -1,6 +1,7 @@
 package disk
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -36,7 +37,7 @@ func (*Stats) SampleConfig() string {
 	return diskSampleConfig
 }
 
-func (s *Stats) Gather(acc cua.Accumulator) error {
+func (s *Stats) Gather(ctx context.Context, acc cua.Accumulator) error {
 	// Legacy support:
 	if len(s.Mountpoints) != 0 {
 		s.MountPoints = s.Mountpoints

--- a/plugins/inputs/disk/disk_test.go
+++ b/plugins/inputs/disk/disk_test.go
@@ -1,6 +1,7 @@
 package disk
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -67,7 +68,7 @@ func TestDiskUsage(t *testing.T) {
 	mps.On("PSDiskUsage", "/").Return(&duAll[0], nil)
 	mps.On("PSDiskUsage", "/home").Return(&duAll[1], nil)
 
-	err = (&Stats{ps: mps}).Gather(&acc)
+	err = (&Stats{ps: mps}).Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	numDiskMetrics := acc.NFields()
@@ -110,12 +111,12 @@ func TestDiskUsage(t *testing.T) {
 
 	// We expect 6 more DiskMetrics to show up with an explicit match on "/"
 	// and /home not matching the /dev in MountPoints
-	_ = (&Stats{ps: &mps, MountPoints: []string{"/", "/dev"}}).Gather(&acc)
+	_ = (&Stats{ps: &mps, MountPoints: []string{"/", "/dev"}}).Gather(context.Background(), &acc)
 	assert.Equal(t, expectedAllDiskMetrics+7, acc.NFields())
 
 	// We should see all the diskpoints as MountPoints includes both
 	// / and /home
-	_ = (&Stats{ps: &mps, MountPoints: []string{"/", "/home"}}).Gather(&acc)
+	_ = (&Stats{ps: &mps, MountPoints: []string{"/", "/home"}}).Gather(context.Background(), &acc)
 	assert.Equal(t, 2*expectedAllDiskMetrics+7, acc.NFields())
 }
 
@@ -246,7 +247,7 @@ func TestDiskUsageHostMountPrefix(t *testing.T) {
 
 			mps.On("OSGetenv", "HOST_MOUNT_PREFIX").Return(tt.hostMountPrefix)
 
-			err = (&Stats{ps: mps}).Gather(&acc)
+			err = (&Stats{ps: mps}).Gather(context.Background(), &acc)
 			require.NoError(t, err)
 
 			acc.AssertContainsTaggedFields(t, "disk", tt.expectedFields, tt.expectedTags)
@@ -323,7 +324,7 @@ func TestDiskStats(t *testing.T) {
 	mps.On("DiskUsage", []string{"/", "/dev"}, []string(nil)).Return(duFiltered, psFiltered, nil)
 	mps.On("DiskUsage", []string{"/", "/home"}, []string(nil)).Return(duAll, psAll, nil)
 
-	err = (&Stats{ps: &mps}).Gather(&acc)
+	err = (&Stats{ps: &mps}).Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	numDiskMetrics := acc.NFields()
@@ -366,11 +367,11 @@ func TestDiskStats(t *testing.T) {
 
 	// We expect 6 more DiskMetrics to show up with an explicit match on "/"
 	// and /home not matching the /dev in MountPoints
-	_ = (&Stats{ps: &mps, MountPoints: []string{"/", "/dev"}}).Gather(&acc)
+	_ = (&Stats{ps: &mps, MountPoints: []string{"/", "/dev"}}).Gather(context.Background(), &acc)
 	assert.Equal(t, expectedAllDiskMetrics+7, acc.NFields())
 
 	// We should see all the diskpoints as MountPoints includes both
 	// / and /home
-	_ = (&Stats{ps: &mps, MountPoints: []string{"/", "/home"}}).Gather(&acc)
+	_ = (&Stats{ps: &mps, MountPoints: []string{"/", "/home"}}).Gather(context.Background(), &acc)
 	assert.Equal(t, 2*expectedAllDiskMetrics+7, acc.NFields())
 }

--- a/plugins/inputs/diskio/diskio.go
+++ b/plugins/inputs/diskio/diskio.go
@@ -1,6 +1,7 @@
 package diskio
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strings"
@@ -85,7 +86,7 @@ func (s *DiskIO) init() error {
 	return nil
 }
 
-func (s *DiskIO) Gather(acc cua.Accumulator) error {
+func (s *DiskIO) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if !s.initialized {
 		err := s.init()
 		if err != nil {

--- a/plugins/inputs/diskio/diskio_test.go
+++ b/plugins/inputs/diskio/diskio_test.go
@@ -1,6 +1,7 @@
 package diskio
 
 import (
+	"context"
 	"testing"
 
 	"github.com/circonus-labs/circonus-unified-agent/plugins/inputs/system"
@@ -112,7 +113,7 @@ func TestDiskIO(t *testing.T) {
 				ps:      &mps,
 				Devices: tt.devices,
 			}
-			err := diskio.Gather(&acc)
+			err := diskio.Gather(context.Background(), &acc)
 			require.Equal(t, tt.err, err)
 
 			for _, metric := range tt.metrics {

--- a/plugins/inputs/disque/disque.go
+++ b/plugins/inputs/disque/disque.go
@@ -2,6 +2,7 @@ package disque
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -64,7 +65,7 @@ var ErrProtocolError = errors.New("disque protocol error")
 
 // Reads stats from all configured servers accumulates stats.
 // Returns one of the errors encountered while gather stats (if any).
-func (r *Disque) Gather(acc cua.Accumulator) error {
+func (r *Disque) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if len(r.Servers) == 0 {
 		url := &url.URL{
 			Host: ":7711",

--- a/plugins/inputs/dmcache/dmcache_linux.go
+++ b/plugins/inputs/dmcache/dmcache_linux.go
@@ -3,6 +3,7 @@
 package dmcache
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os/exec"

--- a/plugins/inputs/dmcache/dmcache_linux.go
+++ b/plugins/inputs/dmcache/dmcache_linux.go
@@ -33,7 +33,7 @@ type cacheStatus struct {
 	dirty             int64
 }
 
-func (c *DMCache) Gather(acc cua.Accumulator) error {
+func (c *DMCache) Gather(ctx context.Context, acc cua.Accumulator) error {
 	outputLines, err := c.getCurrentStatus()
 	if err != nil {
 		return err

--- a/plugins/inputs/dmcache/dmcache_linux_test.go
+++ b/plugins/inputs/dmcache/dmcache_linux_test.go
@@ -3,6 +3,7 @@
 package dmcache
 
 import (
+	"context"
 	"errors"
 	"testing"
 

--- a/plugins/inputs/dmcache/dmcache_linux_test.go
+++ b/plugins/inputs/dmcache/dmcache_linux_test.go
@@ -28,7 +28,7 @@ func TestPerDeviceGoodOutput(t *testing.T) {
 		},
 	}
 
-	err := plugin.Gather(&acc)
+	err := plugin.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	tags1 := map[string]string{
@@ -105,7 +105,7 @@ func TestNotPerDeviceGoodOutput(t *testing.T) {
 		},
 	}
 
-	err := plugin.Gather(&acc)
+	err := plugin.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	tags := map[string]string{
@@ -140,7 +140,7 @@ func TestNoDevicesOutput(t *testing.T) {
 		},
 	}
 
-	err := plugin.Gather(&acc)
+	err := plugin.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 }
 
@@ -153,7 +153,7 @@ func TestErrorDuringGettingStatus(t *testing.T) {
 		},
 	}
 
-	err := plugin.Gather(&acc)
+	err := plugin.Gather(context.Background(), &acc)
 	require.Error(t, err)
 }
 
@@ -166,6 +166,6 @@ func TestBadFormatOfStatus(t *testing.T) {
 		},
 	}
 
-	err := plugin.Gather(&acc)
+	err := plugin.Gather(context.Background(), &acc)
 	require.Error(t, err)
 }

--- a/plugins/inputs/dmcache/dmcache_notlinux.go
+++ b/plugins/inputs/dmcache/dmcache_notlinux.go
@@ -2,9 +2,13 @@
 
 package dmcache
 
-import "github.com/circonus-labs/circonus-unified-agent/cua"
+import (
+	"context"
 
-func (c *DMCache) Gather(acc cua.Accumulator) error {
+	"github.com/circonus-labs/circonus-unified-agent/cua"
+)
+
+func (c *DMCache) Gather(_ context.Context, _ cua.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/dns_query/dns_query.go
+++ b/plugins/inputs/dns_query/dns_query.go
@@ -1,6 +1,7 @@
 package dnsquery
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -69,7 +70,7 @@ func (d *DNSQuery) SampleConfig() string {
 func (d *DNSQuery) Description() string {
 	return "Query given DNS server and gives statistics"
 }
-func (d *DNSQuery) Gather(acc cua.Accumulator) error {
+func (d *DNSQuery) Gather(ctx context.Context, acc cua.Accumulator) error {
 	var wg sync.WaitGroup
 	d.setDefaultValues()
 

--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -280,7 +280,7 @@ func TestDocker_WindowsMemoryContainerStats(t *testing.T) {
 			}, nil
 		},
 	}
-	err := d.Gather(&acc)
+	err := d.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 }
 
@@ -399,7 +399,7 @@ func TestContainerLabels(t *testing.T) {
 				LabelExclude: tt.exclude,
 			}
 
-			err := d.Gather(&acc)
+			err := d.Gather(context.Background(), &acc)
 			require.NoError(t, err)
 
 			// Grab tags from a container metric
@@ -522,7 +522,7 @@ func TestContainerNames(t *testing.T) {
 				ContainerExclude: tt.exclude,
 			}
 
-			err := d.Gather(&acc)
+			err := d.Gather(context.Background(), &acc)
 			require.NoError(t, err)
 
 			// Set of expected names
@@ -736,7 +736,7 @@ func TestContainerStatus(t *testing.T) {
 				now = time.Now
 			}()
 
-			err := d.Gather(&acc)
+			err := d.Gather(context.Background(), &acc)
 			require.NoError(t, err)
 
 			actual := FilterMetrics(acc.GetCUAMetrics(), func(m cua.Metric) bool {
@@ -907,7 +907,7 @@ func TestDockerGatherSwarmInfo(t *testing.T) {
 	err := acc.GatherError(d.Gather)
 	require.NoError(t, err)
 
-	_ = d.gatherSwarmInfo(&acc)
+	_ = d.gatherSwarmInfo(context.Background(), &acc)
 
 	// test docker_container_net measurement
 	acc.AssertContainsTaggedFields(t,
@@ -1015,7 +1015,7 @@ func TestContainerStateFilter(t *testing.T) {
 				ContainerStateExclude: tt.exclude,
 			}
 
-			err := d.Gather(&acc)
+			err := d.Gather(context.Background(), &acc)
 			require.NoError(t, err)
 		})
 	}
@@ -1076,7 +1076,7 @@ func TestContainerName(t *testing.T) {
 				newClient: tt.clientFunc,
 			}
 			var acc testutil.Accumulator
-			err := d.Gather(&acc)
+			err := d.Gather(context.Background(), &acc)
 			require.NoError(t, err)
 
 			for _, metric := range acc.Metrics {

--- a/plugins/inputs/docker_log/docker_log.go
+++ b/plugins/inputs/docker_log/docker_log.go
@@ -201,8 +201,7 @@ func (d *DockerLogs) matchedContainerName(names []string) string {
 	return ""
 }
 
-func (d *DockerLogs) Gather(acc cua.Accumulator) error {
-	ctx := context.Background()
+func (d *DockerLogs) Gather(ctx context.Context, acc cua.Accumulator) error {
 	acc.SetPrecision(time.Nanosecond)
 
 	ctx, cancel := context.WithTimeout(ctx, d.Timeout.Duration)

--- a/plugins/inputs/docker_log/docker_log_test.go
+++ b/plugins/inputs/docker_log/docker_log_test.go
@@ -175,7 +175,7 @@ func Test(t *testing.T) {
 			err := plugin.Init()
 			require.NoError(t, err)
 
-			err = plugin.Gather(&acc)
+			err = plugin.Gather(context.Background(), &acc)
 			require.NoError(t, err)
 
 			acc.Wait(len(tt.expected))

--- a/plugins/inputs/dovecot/dovecot.go
+++ b/plugins/inputs/dovecot/dovecot.go
@@ -2,6 +2,7 @@ package dovecot
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -51,7 +52,7 @@ func (d *Dovecot) SampleConfig() string { return sampleConfig }
 // const defaultPort = "24242"
 
 // Reads stats from all configured servers.
-func (d *Dovecot) Gather(acc cua.Accumulator) error {
+func (d *Dovecot) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if !validQuery[d.Type] {
 		return fmt.Errorf("%s is not a valid query type", d.Type)
 	}

--- a/plugins/inputs/ecs/ecs.go
+++ b/plugins/inputs/ecs/ecs.go
@@ -1,6 +1,7 @@
 package ecs
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -84,7 +85,7 @@ func (ecs *Ecs) SampleConfig() string {
 }
 
 // Gather is the entrypoint for cua metrics collection
-func (ecs *Ecs) Gather(acc cua.Accumulator) error {
+func (ecs *Ecs) Gather(ctx context.Context, acc cua.Accumulator) error {
 	err := initSetup(ecs)
 	if err != nil {
 		return err

--- a/plugins/inputs/elasticsearch/elasticsearch.go
+++ b/plugins/inputs/elasticsearch/elasticsearch.go
@@ -1,6 +1,7 @@
 package elasticsearch
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -219,7 +220,7 @@ func (e *Elasticsearch) Description() string {
 
 // Gather reads the stats from Elasticsearch and writes it to the
 // Accumulator.
-func (e *Elasticsearch) Gather(acc cua.Accumulator) error {
+func (e *Elasticsearch) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if e.client == nil {
 		client, err := e.createHTTPClient()
 

--- a/plugins/inputs/ethtool/ethtool_linux.go
+++ b/plugins/inputs/ethtool/ethtool_linux.go
@@ -3,6 +3,7 @@
 package ethtool
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"sync"

--- a/plugins/inputs/ethtool/ethtool_linux.go
+++ b/plugins/inputs/ethtool/ethtool_linux.go
@@ -18,7 +18,7 @@ type CommandEthtool struct {
 	ethtool *ethtool.Ethtool
 }
 
-func (e *Ethtool) Gather(acc cua.Accumulator) error {
+func (e *Ethtool) Gather(ctx context.Context, acc cua.Accumulator) error {
 
 	// Get the list of interfaces
 	interfaces, err := e.command.Interfaces()

--- a/plugins/inputs/ethtool/ethtool_notlinux.go
+++ b/plugins/inputs/ethtool/ethtool_notlinux.go
@@ -3,6 +3,8 @@
 package ethtool
 
 import (
+	"context"
+
 	"github.com/circonus-labs/circonus-unified-agent/cua"
 	"github.com/circonus-labs/circonus-unified-agent/plugins/inputs"
 )
@@ -12,7 +14,7 @@ func (e *Ethtool) Init() error {
 	return nil
 }
 
-func (e *Ethtool) Gather(acc cua.Accumulator) error {
+func (e *Ethtool) Gather(_ context.Context, _ cua.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/ethtool/ethtool_test.go
+++ b/plugins/inputs/ethtool/ethtool_test.go
@@ -3,6 +3,7 @@
 package ethtool
 
 import (
+	"context"
 	"net"
 	"testing"
 

--- a/plugins/inputs/ethtool/ethtool_test.go
+++ b/plugins/inputs/ethtool/ethtool_test.go
@@ -305,7 +305,7 @@ func TestGather(t *testing.T) {
 	setup()
 	var acc testutil.Accumulator
 
-	err := command.Gather(&acc)
+	err := command.Gather(context.Background(), &acc)
 	assert.NoError(t, err)
 	assert.Len(t, acc.Metrics, 2)
 
@@ -330,7 +330,7 @@ func TestGatherIncludeInterfaces(t *testing.T) {
 
 	command.InterfaceInclude = append(command.InterfaceInclude, "eth1")
 
-	err := command.Gather(&acc)
+	err := command.Gather(context.Background(), &acc)
 	assert.NoError(t, err)
 	assert.Len(t, acc.Metrics, 1)
 
@@ -358,7 +358,7 @@ func TestGatherIgnoreInterfaces(t *testing.T) {
 
 	command.InterfaceExclude = append(command.InterfaceExclude, "eth1")
 
-	err := command.Gather(&acc)
+	err := command.Gather(context.Background(), &acc)
 	assert.NoError(t, err)
 	assert.Len(t, acc.Metrics, 1)
 

--- a/plugins/inputs/eventhub_consumer/eventhub_consumer.go
+++ b/plugins/inputs/eventhub_consumer/eventhub_consumer.go
@@ -154,7 +154,7 @@ func (e *EventHub) SetParser(parser parsers.Parser) {
 }
 
 // Gather function is unused
-func (*EventHub) Gather(cua.Accumulator) error {
+func (*EventHub) Gather(_ context.Context, _ cua.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/exec/exec.go
+++ b/plugins/inputs/exec/exec.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os/exec"
 	"path/filepath"
@@ -185,7 +186,7 @@ func (e *Exec) SetParser(parser parsers.Parser) {
 	e.parser = parser
 }
 
-func (e *Exec) Gather(acc cua.Accumulator) error {
+func (e *Exec) Gather(ctx context.Context, acc cua.Accumulator) error {
 	var wg sync.WaitGroup
 	// Legacy single command support
 	if e.Command != "" {

--- a/plugins/inputs/execd/execd_posix.go
+++ b/plugins/inputs/execd/execd_posix.go
@@ -3,6 +3,7 @@
 package execd
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -12,7 +13,7 @@ import (
 	"github.com/circonus-labs/circonus-unified-agent/cua"
 )
 
-func (e *Execd) Gather(acc cua.Accumulator) error {
+func (e *Execd) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if e.process == nil || e.process.Cmd == nil {
 		return nil
 	}

--- a/plugins/inputs/execd/execd_test.go
+++ b/plugins/inputs/execd/execd_test.go
@@ -2,6 +2,7 @@ package execd
 
 import (
 	"bufio"
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -58,7 +59,7 @@ func TestExternalInputWorks(t *testing.T) {
 	acc := agent.NewAccumulator(&TestMetricMaker{}, metrics)
 
 	require.NoError(t, e.Start(acc))
-	require.NoError(t, e.Gather(acc))
+	require.NoError(t, e.Gather(context.Background(), acc))
 
 	// grab a metric and make sure it's a thing
 	m := readChanWithTimeout(t, metrics, 10*time.Second)

--- a/plugins/inputs/execd/execd_windows.go
+++ b/plugins/inputs/execd/execd_windows.go
@@ -11,7 +11,7 @@ import (
 	"github.com/circonus-labs/circonus-unified-agent/cua"
 )
 
-func (e *Execd) Gather(acc cua.Accumulator) error {
+func (e *Execd) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if e.process == nil {
 		return nil
 	}

--- a/plugins/inputs/execd/execd_windows.go
+++ b/plugins/inputs/execd/execd_windows.go
@@ -3,6 +3,7 @@
 package execd
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"

--- a/plugins/inputs/fail2ban/fail2ban.go
+++ b/plugins/inputs/fail2ban/fail2ban.go
@@ -1,6 +1,7 @@
 package fail2ban
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os/exec"
@@ -47,7 +48,7 @@ func (f *Fail2ban) SampleConfig() string {
 	return sampleConfig
 }
 
-func (f *Fail2ban) Gather(acc cua.Accumulator) error {
+func (f *Fail2ban) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if len(f.path) == 0 {
 		return errors.New("fail2ban-client not found: verify that fail2ban is installed and that fail2ban-client is in your PATH")
 	}

--- a/plugins/inputs/fail2ban/fail2ban_test.go
+++ b/plugins/inputs/fail2ban/fail2ban_test.go
@@ -1,6 +1,7 @@
 package fail2ban
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -50,7 +51,7 @@ func TestGather(t *testing.T) {
 	execCommand = fakeExecCommand
 	defer func() { execCommand = exec.Command }()
 	var acc testutil.Accumulator
-	err := f.Gather(&acc)
+	err := f.Gather(context.Background(), &acc)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/inputs/fibaro/fibaro.go
+++ b/plugins/inputs/fibaro/fibaro.go
@@ -1,6 +1,7 @@
 package fibaro
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -117,7 +118,7 @@ func (f *Fibaro) getJSON(path string, dataStruct interface{}) error {
 }
 
 // Gather fetches all required information to output metrics
-func (f *Fibaro) Gather(acc cua.Accumulator) error {
+func (f *Fibaro) Gather(ctx context.Context, acc cua.Accumulator) error {
 
 	if f.client == nil {
 		f.client = &http.Client{

--- a/plugins/inputs/file/file.go
+++ b/plugins/inputs/file/file.go
@@ -1,6 +1,7 @@
 package file
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -64,7 +65,7 @@ func (f *File) Init() error {
 	return fmt.Errorf("new decoder: %w", err)
 }
 
-func (f *File) Gather(acc cua.Accumulator) error {
+func (f *File) Gather(ctx context.Context, acc cua.Accumulator) error {
 	err := f.refreshFilePaths()
 	if err != nil {
 		return err

--- a/plugins/inputs/file/file_test.go
+++ b/plugins/inputs/file/file_test.go
@@ -5,6 +5,7 @@ package file
 // TODO: Windows - should be enabled for Windows when super asterisk is fixed on Windows
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -49,7 +50,7 @@ func TestFileTag(t *testing.T) {
 	assert.NoError(t, err)
 	r.parser = nParser
 
-	err = r.Gather(&acc)
+	err = r.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	for _, m := range acc.Metrics {
@@ -76,7 +77,7 @@ func TestJSONParserCompile(t *testing.T) {
 	assert.NoError(t, err)
 	r.parser = nParser
 
-	_ = r.Gather(&acc)
+	_ = r.Gather(context.Background(), &acc)
 	assert.Equal(t, map[string]string{"parent_ignored_child": "hi"}, acc.Metrics[0].Tags)
 	assert.Equal(t, 5, len(acc.Metrics[0].Fields))
 }
@@ -99,7 +100,7 @@ func TestGrokParser(t *testing.T) {
 	r.parser = nParser
 	assert.NoError(t, err)
 
-	_ = r.Gather(&acc)
+	_ = r.Gather(context.Background(), &acc)
 	assert.Equal(t, len(acc.Metrics), 2)
 }
 
@@ -245,7 +246,7 @@ func TestCharacterEncoding(t *testing.T) {
 			tt.plugin.SetParser(parser)
 
 			var acc testutil.Accumulator
-			err = tt.plugin.Gather(&acc)
+			err = tt.plugin.Gather(context.Background(), &acc)
 			require.NoError(t, err)
 
 			testutil.RequireMetricsEqual(t, expected, acc.GetCUAMetrics(), testutil.IgnoreTime())

--- a/plugins/inputs/filecount/filecount.go
+++ b/plugins/inputs/filecount/filecount.go
@@ -1,6 +1,7 @@
 package filecount
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -245,7 +246,7 @@ func (fc *FileCount) filter(file os.FileInfo) (bool, error) {
 	return true, nil
 }
 
-func (fc *FileCount) Gather(acc cua.Accumulator) error {
+func (fc *FileCount) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if fc.globPaths == nil {
 		fc.initGlobPaths(acc)
 	}

--- a/plugins/inputs/filecount/filecount_test.go
+++ b/plugins/inputs/filecount/filecount_test.go
@@ -3,6 +3,7 @@
 package filecount
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -144,7 +145,7 @@ func TestDirectoryWithTrailingSlash(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	err := plugin.Gather(&acc)
+	err := plugin.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expected := []cua.Metric{

--- a/plugins/inputs/filestat/filestat.go
+++ b/plugins/inputs/filestat/filestat.go
@@ -1,6 +1,7 @@
 package filestat
 
 import (
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"io"
@@ -49,7 +50,7 @@ func (*FileStat) Description() string {
 
 func (*FileStat) SampleConfig() string { return sampleConfig }
 
-func (f *FileStat) Gather(acc cua.Accumulator) error {
+func (f *FileStat) Gather(ctx context.Context, acc cua.Accumulator) error {
 	var err error
 
 	for _, filepath := range f.Files {

--- a/plugins/inputs/fireboard/fireboard.go
+++ b/plugins/inputs/fireboard/fireboard.go
@@ -1,6 +1,7 @@
 package fireboard
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -87,7 +88,7 @@ func (r *Fireboard) Init() error {
 }
 
 // Gather Reads stats from all configured servers.
-func (r *Fireboard) Gather(acc cua.Accumulator) error {
+func (r *Fireboard) Gather(ctx context.Context, acc cua.Accumulator) error {
 
 	// Perform the GET request to the fireboard servers
 	req, err := http.NewRequest("GET", r.URL, nil)

--- a/plugins/inputs/fireboard/fireboard_test.go
+++ b/plugins/inputs/fireboard/fireboard_test.go
@@ -1,6 +1,7 @@
 package fireboard
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -33,7 +34,7 @@ func TestFireboard(t *testing.T) {
 	acc := &testutil.Accumulator{}
 
 	// Gather data from the test server
-	err = fireboard.Gather(acc)
+	err = fireboard.Gather(context.Background(), acc)
 	require.NoError(t, err)
 
 	// Expect the correct values for all known keys

--- a/plugins/inputs/fluentd/fluentd.go
+++ b/plugins/inputs/fluentd/fluentd.go
@@ -1,6 +1,7 @@
 package fluentd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -78,7 +79,7 @@ func (h *Fluentd) Description() string { return description }
 func (h *Fluentd) SampleConfig() string { return sampleConfig }
 
 // Gather - Main code responsible for gathering, processing and creating metrics
-func (h *Fluentd) Gather(acc cua.Accumulator) error {
+func (h *Fluentd) Gather(ctx context.Context, acc cua.Accumulator) error {
 
 	_, err := url.Parse(h.Endpoint)
 	if err != nil {

--- a/plugins/inputs/fluentd/fluentd_test.go
+++ b/plugins/inputs/fluentd/fluentd_test.go
@@ -1,6 +1,7 @@
 package fluentd
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -139,7 +140,7 @@ func Test_Gather(t *testing.T) {
 
 	var acc testutil.Accumulator
 
-	err := fluentdTest.Gather(&acc)
+	err := fluentdTest.Gather(context.Background(), &acc)
 	if err != nil {
 		t.Error(err)
 	}

--- a/plugins/inputs/github/github.go
+++ b/plugins/inputs/github/github.go
@@ -93,8 +93,7 @@ func (g *GitHub) newGithubClient(httpClient *http.Client) (*github.Client, error
 }
 
 // Gather GitHub Metrics
-func (g *GitHub) Gather(acc cua.Accumulator) error {
-	ctx := context.Background()
+func (g *GitHub) Gather(ctx context.Context, acc cua.Accumulator) error {
 
 	if g.githubClient == nil {
 		githubClient, err := g.createGitHubClient(ctx)

--- a/plugins/inputs/gnmi/gnmi.go
+++ b/plugins/inputs/gnmi/gnmi.go
@@ -550,7 +550,7 @@ func (c *GNMI) Description() string {
 }
 
 // Gather plugin measurements (unused)
-func (c *GNMI) Gather(_ cua.Accumulator) error {
+func (c *GNMI) Gather(_ context.Context, _ cua.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/graylog/graylog.go
+++ b/plugins/inputs/graylog/graylog.go
@@ -2,6 +2,7 @@ package graylog
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -120,7 +121,7 @@ func (h *GrayLog) Description() string {
 }
 
 // Gathers data for all servers.
-func (h *GrayLog) Gather(acc cua.Accumulator) error {
+func (h *GrayLog) Gather(ctx context.Context, acc cua.Accumulator) error {
 	var wg sync.WaitGroup
 
 	if h.client.HTTPClient() == nil {

--- a/plugins/inputs/haproxy/haproxy.go
+++ b/plugins/inputs/haproxy/haproxy.go
@@ -1,6 +1,7 @@
 package haproxy
 
 import (
+	"context"
 	"encoding/csv"
 	"errors"
 	"fmt"
@@ -72,7 +73,7 @@ func (*haproxy) Description() string {
 
 // Reads stats from all configured servers accumulates stats.
 // Returns one of the errors encountered while gather stats (if any).
-func (h *haproxy) Gather(acc cua.Accumulator) error {
+func (h *haproxy) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if len(h.Servers) == 0 {
 		return h.gatherServer("http://127.0.0.1:1936/haproxy?stats", acc)
 	}

--- a/plugins/inputs/haproxy/haproxy_test.go
+++ b/plugins/inputs/haproxy/haproxy_test.go
@@ -1,6 +1,7 @@
 package haproxy
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/binary"
 	"fmt"
@@ -64,9 +65,7 @@ func TestHaproxyGeneratesMetricsWithAuthentication(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-
-	err := r.Gather(&acc)
-	require.NoError(t, err)
+	require.NoError(t, acc.GatherError(r.Gather))
 
 	tags := map[string]string{
 		"server": ts.Listener.Addr().String(),
@@ -83,7 +82,7 @@ func TestHaproxyGeneratesMetricsWithAuthentication(t *testing.T) {
 		Servers: []string{ts.URL},
 	}
 
-	_ = r.Gather(&acc)
+	_ = r.Gather(context.Background(), &acc)
 	require.NotEmpty(t, acc.Errors)
 }
 
@@ -98,9 +97,7 @@ func TestHaproxyGeneratesMetricsWithoutAuthentication(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-
-	err := r.Gather(&acc)
-	require.NoError(t, err)
+	require.NoError(t, acc.GatherError(r.Gather))
 
 	tags := map[string]string{
 		"server": ts.Listener.Addr().String(),
@@ -141,7 +138,7 @@ func TestHaproxyGeneratesMetricsUsingSocket(t *testing.T) {
 
 	var acc testutil.Accumulator
 
-	err := r.Gather(&acc)
+	err := r.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	fields := HaproxyGetFieldValues()
@@ -160,7 +157,7 @@ func TestHaproxyGeneratesMetricsUsingSocket(t *testing.T) {
 	// This mask should not match any socket
 	r.Servers = []string{_badmask}
 
-	_ = r.Gather(&acc)
+	_ = r.Gather(context.Background(), &acc)
 	require.NotEmpty(t, acc.Errors)
 }
 
@@ -171,7 +168,7 @@ func TestHaproxyDefaultGetFromLocalhost(t *testing.T) {
 
 	var acc testutil.Accumulator
 
-	err := r.Gather(&acc)
+	err := r.Gather(context.Background(), &acc)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "127.0.0.1:1936/haproxy?stats/;csv")
 }
@@ -189,7 +186,7 @@ func TestHaproxyKeepFieldNames(t *testing.T) {
 
 	var acc testutil.Accumulator
 
-	err := r.Gather(&acc)
+	err := r.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	tags := map[string]string{

--- a/plugins/inputs/hddtemp/hddtemp.go
+++ b/plugins/inputs/hddtemp/hddtemp.go
@@ -1,6 +1,7 @@
 package hddtemp
 
 import (
+	"context"
 	"fmt"
 	"net"
 
@@ -41,7 +42,7 @@ func (*HDDTemp) SampleConfig() string {
 	return hddtempSampleConfig
 }
 
-func (h *HDDTemp) Gather(acc cua.Accumulator) error {
+func (h *HDDTemp) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if h.fetcher == nil {
 		h.fetcher = gohddtemp.New()
 	}

--- a/plugins/inputs/hddtemp/hddtemp_test.go
+++ b/plugins/inputs/hddtemp/hddtemp_test.go
@@ -41,9 +41,7 @@ func TestFetch(t *testing.T) {
 	}
 
 	acc := &testutil.Accumulator{}
-	err := hddtemp.Gather(acc)
-
-	require.NoError(t, err)
+	require.NoError(t, acc.GatherError(hddtemp.Gather))
 	assert.Equal(t, acc.NFields(), 2)
 
 	var tests = []struct {

--- a/plugins/inputs/http/http.go
+++ b/plugins/inputs/http/http.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -136,7 +137,7 @@ func (h *HTTP) Init() error {
 
 // Gather takes in an accumulator and adds the metrics that the Input
 // gathers. This is called every "interval"
-func (h *HTTP) Gather(acc cua.Accumulator) error {
+func (h *HTTP) Gather(ctx context.Context, acc cua.Accumulator) error {
 	var wg sync.WaitGroup
 	for _, u := range h.URLs {
 		wg.Add(1)

--- a/plugins/inputs/http/http_test.go
+++ b/plugins/inputs/http/http_test.go
@@ -247,8 +247,7 @@ func TestBodyAndContentEncoding(t *testing.T) {
 
 			var acc testutil.Accumulator
 			_ = tt.plugin.Init()
-			err = tt.plugin.Gather(&acc)
-			require.NoError(t, err)
+			require.NoError(t, acc.GatherError(tt.plugin.Gather))
 		})
 	}
 }

--- a/plugins/inputs/http_listener_v2/http_listener_v2.go
+++ b/plugins/inputs/http_listener_v2/http_listener_v2.go
@@ -2,6 +2,7 @@ package httplistenerv2
 
 import (
 	"compress/gzip"
+	"context"
 	"crypto/subtle"
 	"crypto/tls"
 	"fmt"
@@ -115,7 +116,7 @@ func (h *HTTPListenerV2) Description() string {
 	return "Generic HTTP write listener"
 }
 
-func (h *HTTPListenerV2) Gather(_ cua.Accumulator) error {
+func (h *HTTPListenerV2) Gather(_ context.Context, _ cua.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/http_listener_v2/http_listener_v2_test.go
+++ b/plugins/inputs/http_listener_v2/http_listener_v2_test.go
@@ -2,6 +2,7 @@ package httplistenerv2
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"net/http"
@@ -334,7 +335,7 @@ func TestWriteHTTPHighTraffic(t *testing.T) {
 	}
 
 	wg.Wait()
-	_ = listener.Gather(acc)
+	_ = listener.Gather(context.Background(), acc)
 
 	acc.Wait(25000)
 	require.Equal(t, int64(25000), int64(acc.NMetrics()))

--- a/plugins/inputs/http_response/http_response.go
+++ b/plugins/inputs/http_response/http_response.go
@@ -1,6 +1,7 @@
 package httpresponse
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -405,7 +406,7 @@ func (h *HTTPResponse) setBodyReadError(errorMsg string, bodyBytes []byte, field
 }
 
 // Gather gets all metric fields and tags and returns any errors it encounters
-func (h *HTTPResponse) Gather(acc cua.Accumulator) error {
+func (h *HTTPResponse) Gather(ctx context.Context, acc cua.Accumulator) error {
 	// Compile the body regex if it exist
 	if h.compiledStringMatch == nil {
 		var err error

--- a/plugins/inputs/http_response/http_response_test.go
+++ b/plugins/inputs/http_response/http_response_test.go
@@ -3,6 +3,7 @@
 package httpresponse
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -172,7 +173,7 @@ func TestHeaders(t *testing.T) {
 		},
 	}
 	var acc testutil.Accumulator
-	err := h.Gather(&acc)
+	err := h.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expectedFields := map[string]interface{}{
@@ -210,7 +211,7 @@ func TestFields(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	err := h.Gather(&acc)
+	err := h.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expectedFields := map[string]interface{}{
@@ -249,7 +250,7 @@ func TestResponseBodyField(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	err := h.Gather(&acc)
+	err := h.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expectedFields := map[string]interface{}{
@@ -284,7 +285,7 @@ func TestResponseBodyField(t *testing.T) {
 	}
 
 	acc = testutil.Accumulator{}
-	err = h.Gather(&acc)
+	err = h.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expectedFields = map[string]interface{}{
@@ -318,7 +319,7 @@ func TestResponseBodyMaxSize(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	err := h.Gather(&acc)
+	err := h.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expectedFields := map[string]interface{}{
@@ -352,7 +353,7 @@ func TestHTTPHeaderTags(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	err := h.Gather(&acc)
+	err := h.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expectedFields := map[string]interface{}{
@@ -387,7 +388,7 @@ func TestHTTPHeaderTags(t *testing.T) {
 	}
 
 	acc = testutil.Accumulator{}
-	err = h.Gather(&acc)
+	err = h.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expectedTags = map[string]interface{}{
@@ -410,7 +411,7 @@ func TestHTTPHeaderTags(t *testing.T) {
 	}
 
 	acc = testutil.Accumulator{}
-	err = h.Gather(&acc)
+	err = h.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expectedFields = map[string]interface{}{
@@ -469,7 +470,7 @@ func TestInterface(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	err = h.Gather(&acc)
+	err = h.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expectedFields := map[string]interface{}{
@@ -506,7 +507,7 @@ func TestRedirects(t *testing.T) {
 		FollowRedirects: true,
 	}
 	var acc testutil.Accumulator
-	err := h.Gather(&acc)
+	err := h.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expectedFields := map[string]interface{}{
@@ -537,7 +538,7 @@ func TestRedirects(t *testing.T) {
 		FollowRedirects: true,
 	}
 	acc = testutil.Accumulator{}
-	err = h.Gather(&acc)
+	err = h.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expectedFields = map[string]interface{}{
@@ -574,7 +575,7 @@ func TestMethod(t *testing.T) {
 		FollowRedirects: true,
 	}
 	var acc testutil.Accumulator
-	err := h.Gather(&acc)
+	err := h.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expectedFields := map[string]interface{}{
@@ -605,7 +606,7 @@ func TestMethod(t *testing.T) {
 		FollowRedirects: true,
 	}
 	acc = testutil.Accumulator{}
-	err = h.Gather(&acc)
+	err = h.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expectedFields = map[string]interface{}{
@@ -637,7 +638,7 @@ func TestMethod(t *testing.T) {
 		FollowRedirects: true,
 	}
 	acc = testutil.Accumulator{}
-	err = h.Gather(&acc)
+	err = h.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expectedFields = map[string]interface{}{
@@ -674,7 +675,7 @@ func TestBody(t *testing.T) {
 		FollowRedirects: true,
 	}
 	var acc testutil.Accumulator
-	err := h.Gather(&acc)
+	err := h.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expectedFields := map[string]interface{}{
@@ -704,7 +705,7 @@ func TestBody(t *testing.T) {
 		FollowRedirects: true,
 	}
 	acc = testutil.Accumulator{}
-	err = h.Gather(&acc)
+	err = h.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expectedFields = map[string]interface{}{
@@ -740,7 +741,7 @@ func TestStringMatch(t *testing.T) {
 		FollowRedirects: true,
 	}
 	var acc testutil.Accumulator
-	err := h.Gather(&acc)
+	err := h.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expectedFields := map[string]interface{}{
@@ -778,7 +779,7 @@ func TestStringMatchJson(t *testing.T) {
 		FollowRedirects: true,
 	}
 	var acc testutil.Accumulator
-	err := h.Gather(&acc)
+	err := h.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expectedFields := map[string]interface{}{
@@ -817,7 +818,7 @@ func TestStringMatchFail(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	err := h.Gather(&acc)
+	err := h.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expectedFields := map[string]interface{}{
@@ -858,7 +859,7 @@ func TestTimeout(t *testing.T) {
 		FollowRedirects: true,
 	}
 	var acc testutil.Accumulator
-	err := h.Gather(&acc)
+	err := h.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expectedFields := map[string]interface{}{
@@ -894,7 +895,7 @@ func TestBadRegex(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	err := h.Gather(&acc)
+	err := h.Gather(context.Background(), &acc)
 	require.Error(t, err)
 
 	absentFields := []string{"http_response_code", "response_time", "content_length", "response_string_match", "result_type", "result_code"}
@@ -914,7 +915,7 @@ func TestNetworkErrors(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	err := h.Gather(&acc)
+	err := h.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expectedFields := map[string]interface{}{
@@ -941,7 +942,7 @@ func TestNetworkErrors(t *testing.T) {
 	}
 
 	acc = testutil.Accumulator{}
-	err = h.Gather(&acc)
+	err = h.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expectedFields = map[string]interface{}{
@@ -975,7 +976,7 @@ func TestContentLength(t *testing.T) {
 		FollowRedirects: true,
 	}
 	var acc testutil.Accumulator
-	err := h.Gather(&acc)
+	err := h.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expectedFields := map[string]interface{}{
@@ -1006,7 +1007,7 @@ func TestContentLength(t *testing.T) {
 		FollowRedirects: true,
 	}
 	acc = testutil.Accumulator{}
-	err = h.Gather(&acc)
+	err = h.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expectedFields = map[string]interface{}{
@@ -1042,7 +1043,7 @@ func TestRedirect(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	err := plugin.Gather(&acc)
+	err := plugin.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expected := []cua.Metric{
@@ -1095,7 +1096,7 @@ func TestBasicAuth(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	err := h.Gather(&acc)
+	err := h.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expectedFields := map[string]interface{}{
@@ -1128,7 +1129,7 @@ func TestStatusCodeMatchFail(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	err := h.Gather(&acc)
+	err := h.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expectedFields := map[string]interface{}{
@@ -1161,7 +1162,7 @@ func TestStatusCodeMatch(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	err := h.Gather(&acc)
+	err := h.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expectedFields := map[string]interface{}{
@@ -1195,7 +1196,7 @@ func TestStatusCodeAndStringMatch(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	err := h.Gather(&acc)
+	err := h.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expectedFields := map[string]interface{}{
@@ -1230,7 +1231,7 @@ func TestStatusCodeAndStringMatchFail(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	err := h.Gather(&acc)
+	err := h.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expectedFields := map[string]interface{}{

--- a/plugins/inputs/icinga2/icinga2.go
+++ b/plugins/inputs/icinga2/icinga2.go
@@ -1,6 +1,7 @@
 package icinga2
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -133,7 +134,7 @@ func (i *Icinga2) createHTTPClient() (*http.Client, error) {
 	return client, nil
 }
 
-func (i *Icinga2) Gather(acc cua.Accumulator) error {
+func (i *Icinga2) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if i.ResponseTimeout.Duration < time.Second {
 		i.ResponseTimeout.Duration = time.Second * 5
 	}

--- a/plugins/inputs/infiniband/infiniband_linux.go
+++ b/plugins/inputs/infiniband/infiniband_linux.go
@@ -3,6 +3,7 @@
 package infiniband
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 

--- a/plugins/inputs/infiniband/infiniband_linux.go
+++ b/plugins/inputs/infiniband/infiniband_linux.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Gather statistics from our infiniband cards
-func (*Infiniband) Gather(acc cua.Accumulator) error {
+func (*Infiniband) Gather(ctx context.Context, acc cua.Accumulator) error {
 
 	rdmaDevices := rdmamap.GetRdmaDeviceList()
 

--- a/plugins/inputs/infiniband/infiniband_notlinux.go
+++ b/plugins/inputs/infiniband/infiniband_notlinux.go
@@ -3,6 +3,8 @@
 package infiniband
 
 import (
+	"context"
+
 	"github.com/circonus-labs/circonus-unified-agent/cua"
 	"github.com/circonus-labs/circonus-unified-agent/plugins/inputs"
 )
@@ -12,7 +14,7 @@ func (i *Infiniband) Init() error {
 	return nil
 }
 
-func (*Infiniband) Gather(acc cua.Accumulator) error {
+func (*Infiniband) Gather(_ context.Context, _ cua.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/influxdb/influxdb.go
+++ b/plugins/inputs/influxdb/influxdb.go
@@ -2,6 +2,7 @@ package influxdb
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -75,7 +76,7 @@ func (*InfluxDB) SampleConfig() string {
 `
 }
 
-func (i *InfluxDB) Gather(acc cua.Accumulator) error {
+func (i *InfluxDB) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if len(i.URLs) == 0 {
 		i.URLs = []string{"http://localhost:8086/debug/vars"}
 	}

--- a/plugins/inputs/influxdb/influxdb_test.go
+++ b/plugins/inputs/influxdb/influxdb_test.go
@@ -1,6 +1,7 @@
 package influxdb_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -193,7 +194,7 @@ func TestErrorResponse(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	err := plugin.Gather(&acc)
+	err := plugin.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expected := []error{

--- a/plugins/inputs/influxdb_listener/influxdb_listener.go
+++ b/plugins/inputs/influxdb_listener/influxdb_listener.go
@@ -106,7 +106,7 @@ func (h *InfluxDBListener) Description() string {
 	return "Accept metrics over InfluxDB 1.x HTTP API"
 }
 
-func (h *InfluxDBListener) Gather(_ cua.Accumulator) error {
+func (h *InfluxDBListener) Gather(_ context.Context, _ cua.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/influxdb_listener/influxdb_listener_test.go
+++ b/plugins/inputs/influxdb_listener/influxdb_listener_test.go
@@ -2,6 +2,7 @@ package influxdblistener
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"net/http"
@@ -458,7 +459,7 @@ func TestWriteHighTraffic(t *testing.T) {
 	}
 
 	wg.Wait()
-	_ = listener.Gather(acc)
+	_ = listener.Gather(context.Background(), acc)
 
 	acc.Wait(25000)
 	require.Equal(t, int64(25000), int64(acc.NMetrics()))

--- a/plugins/inputs/influxdb_v2_listener/influxdb_v2_listener.go
+++ b/plugins/inputs/influxdb_v2_listener/influxdb_v2_listener.go
@@ -102,7 +102,7 @@ func (h *InfluxDBV2Listener) Description() string {
 	return "Accept metrics over InfluxDB 2.x HTTP API"
 }
 
-func (h *InfluxDBV2Listener) Gather(_ cua.Accumulator) error {
+func (h *InfluxDBV2Listener) Gather(_ context.Context, _ cua.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/influxdb_v2_listener/influxdb_v2_listener_test.go
+++ b/plugins/inputs/influxdb_v2_listener/influxdb_v2_listener_test.go
@@ -2,6 +2,7 @@ package influxdbv2listener
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -416,7 +417,7 @@ func TestWriteHighTraffic(t *testing.T) {
 	}
 
 	wg.Wait()
-	_ = listener.Gather(acc)
+	_ = listener.Gather(context.Background(), acc)
 
 	acc.Wait(25000)
 	require.Equal(t, int64(25000), int64(acc.NMetrics()))

--- a/plugins/inputs/intel_rdt/intel_rdt.go
+++ b/plugins/inputs/intel_rdt/intel_rdt.go
@@ -63,7 +63,7 @@ type processMeasurement struct {
 }
 
 // All gathering is done in the Start function
-func (*IntelRDT) Gather(_ cua.Accumulator) error {
+func (*IntelRDT) Gather(_ context.Context, _ cua.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/internal/internal.go
+++ b/plugins/inputs/internal/internal.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"context"
 	"runtime"
 	"strings"
 
@@ -32,7 +33,7 @@ func (s *Self) SampleConfig() string {
 	return sampleConfig
 }
 
-func (s *Self) Gather(acc cua.Accumulator) error {
+func (s *Self) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if s.CollectMemstats {
 		m := &runtime.MemStats{}
 		runtime.ReadMemStats(m)

--- a/plugins/inputs/internal/internal_test.go
+++ b/plugins/inputs/internal/internal_test.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"context"
 	"testing"
 
 	"github.com/circonus-labs/circonus-unified-agent/selfstat"
@@ -13,14 +14,14 @@ func TestSelfPlugin(t *testing.T) {
 	s := NewSelf()
 	acc := &testutil.Accumulator{}
 
-	_ = s.Gather(acc)
+	_ = s.Gather(context.Background(), acc)
 	assert.True(t, acc.HasMeasurement("internal_memstats"))
 
 	// test that a registered stat is incremented
 	stat := selfstat.Register("mytest", "test", map[string]string{"test": "foo"})
 	stat.Incr(1)
 	stat.Incr(2)
-	_ = s.Gather(acc)
+	_ = s.Gather(context.Background(), acc)
 	acc.AssertContainsTaggedFields(t, "internal_mytest",
 		map[string]interface{}{
 			"test": int64(3),
@@ -34,7 +35,7 @@ func TestSelfPlugin(t *testing.T) {
 
 	// test that a registered stat is set properly
 	stat.Set(101)
-	_ = s.Gather(acc)
+	_ = s.Gather(context.Background(), acc)
 	acc.AssertContainsTaggedFields(t, "internal_mytest",
 		map[string]interface{}{
 			"test": int64(101),
@@ -51,7 +52,7 @@ func TestSelfPlugin(t *testing.T) {
 	timing := selfstat.RegisterTiming("mytest", "test_ns", map[string]string{"test": "foo"})
 	timing.Incr(100)
 	timing.Incr(200)
-	_ = s.Gather(acc)
+	_ = s.Gather(context.Background(), acc)
 	acc.AssertContainsTaggedFields(t, "internal_mytest",
 		map[string]interface{}{
 			"test":    int64(101),

--- a/plugins/inputs/interrupts/interrupts.go
+++ b/plugins/inputs/interrupts/interrupts.go
@@ -2,6 +2,7 @@ package interrupts
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -108,7 +109,7 @@ func gatherTagsFields(irq IRQ) (map[string]string, map[string]interface{}) {
 	return tags, fields
 }
 
-func (s *Interrupts) Gather(acc cua.Accumulator) error {
+func (s *Interrupts) Gather(ctx context.Context, acc cua.Accumulator) error {
 	for measurement, file := range map[string]string{"interrupts": "/proc/interrupts", "soft_interrupts": "/proc/softirqs"} {
 		f, err := os.Open(file)
 		if err != nil {

--- a/plugins/inputs/ipmi_sensor/ipmi.go
+++ b/plugins/inputs/ipmi_sensor/ipmi.go
@@ -3,6 +3,7 @@ package ipmisensor
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"log"
 	"os/exec"
@@ -78,7 +79,7 @@ func (m *Ipmi) Description() string {
 }
 
 // Gather is the main execution function for the plugin
-func (m *Ipmi) Gather(acc cua.Accumulator) error {
+func (m *Ipmi) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if len(m.Path) == 0 {
 		return fmt.Errorf("ipmitool not found: verify that ipmitool is installed and that ipmitool is in your PATH")
 	}

--- a/plugins/inputs/ipset/ipset.go
+++ b/plugins/inputs/ipset/ipset.go
@@ -3,6 +3,7 @@ package ipset
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"os/exec"
 	"strconv"
@@ -46,7 +47,7 @@ func (ipset *Ipset) SampleConfig() string {
 `
 }
 
-func (ipset *Ipset) Gather(acc cua.Accumulator) error {
+func (ipset *Ipset) Gather(ctx context.Context, acc cua.Accumulator) error {
 	out, e := ipset.lister(ipset.Timeout, ipset.UseSudo)
 	if e != nil {
 		acc.AddError(e)

--- a/plugins/inputs/iptables/iptables.go
+++ b/plugins/inputs/iptables/iptables.go
@@ -3,6 +3,7 @@
 package iptables
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os/exec"

--- a/plugins/inputs/iptables/iptables.go
+++ b/plugins/inputs/iptables/iptables.go
@@ -52,7 +52,7 @@ func (ipt *Iptables) SampleConfig() string {
 }
 
 // Gather gathers iptables packets and bytes throughput from the configured tables and chains.
-func (ipt *Iptables) Gather(acc cua.Accumulator) error {
+func (ipt *Iptables) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if ipt.Table == "" || len(ipt.Chains) == 0 {
 		return nil
 	}

--- a/plugins/inputs/ipvs/ipvs.go
+++ b/plugins/inputs/ipvs/ipvs.go
@@ -3,6 +3,7 @@
 package ipvs
 
 import (
+	"context"
 	"fmt"
 	"math/bits"
 	"strconv"

--- a/plugins/inputs/ipvs/ipvs.go
+++ b/plugins/inputs/ipvs/ipvs.go
@@ -31,7 +31,7 @@ func (i *IPVS) SampleConfig() string {
 }
 
 // Gather gathers the stats
-func (i *IPVS) Gather(acc cua.Accumulator) error {
+func (i *IPVS) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if i.handle == nil {
 		h, err := ipvs.New("") // TODO: make the namespace configurable
 		if err != nil {

--- a/plugins/inputs/jenkins/jenkins.go
+++ b/plugins/inputs/jenkins/jenkins.go
@@ -106,7 +106,7 @@ func (j *Jenkins) Description() string {
 }
 
 // Gather implements Input interface
-func (j *Jenkins) Gather(acc cua.Accumulator) error {
+func (j *Jenkins) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if j.client == nil {
 		client, err := j.newHTTPClient()
 		if err != nil {

--- a/plugins/inputs/jolokia2/client_test.go
+++ b/plugins/inputs/jolokia2/client_test.go
@@ -1,6 +1,7 @@
 package jolokia2
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -40,7 +41,7 @@ func TestJolokia2_ClientAuthRequest(t *testing.T) {
 	`, server.URL))
 
 	var acc testutil.Accumulator
-	_ = plugin.Gather(&acc)
+	_ = plugin.Gather(context.Background(), &acc)
 
 	if username != "sally" {
 		t.Errorf("Expected to post with username %s, but was %s", "sally", username)
@@ -93,7 +94,7 @@ func TestJolokia2_ClientProxyAuthRequest(t *testing.T) {
 	`, server.URL))
 
 	var acc testutil.Accumulator
-	_ = plugin.Gather(&acc)
+	_ = plugin.Gather(context.Background(), &acc)
 
 	if username != "sally" {
 		t.Errorf("Expected to post with username %s, but was %s", "sally", username)

--- a/plugins/inputs/jolokia2/jolokia_agent.go
+++ b/plugins/inputs/jolokia2/jolokia_agent.go
@@ -1,6 +1,7 @@
 package jolokia2
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -56,7 +57,7 @@ func (ja *JolokiaAgent) Description() string {
 	return "Read JMX metrics from a Jolokia REST agent endpoint"
 }
 
-func (ja *JolokiaAgent) Gather(acc cua.Accumulator) error {
+func (ja *JolokiaAgent) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if ja.gatherer == nil {
 		ja.gatherer = NewGatherer(ja.createMetrics())
 	}

--- a/plugins/inputs/jolokia2/jolokia_proxy.go
+++ b/plugins/inputs/jolokia2/jolokia_proxy.go
@@ -1,6 +1,8 @@
 package jolokia2
 
 import (
+	"context"
+
 	"github.com/circonus-labs/circonus-unified-agent/cua"
 	"github.com/circonus-labs/circonus-unified-agent/internal"
 	"github.com/circonus-labs/circonus-unified-agent/plugins/common/tls"
@@ -70,7 +72,7 @@ func (jp *JolokiaProxy) Description() string {
 	return "Read JMX metrics from a Jolokia REST proxy endpoint"
 }
 
-func (jp *JolokiaProxy) Gather(acc cua.Accumulator) error {
+func (jp *JolokiaProxy) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if jp.gatherer == nil {
 		jp.gatherer = NewGatherer(jp.createMetrics())
 	}

--- a/plugins/inputs/jolokia2/jolokia_test.go
+++ b/plugins/inputs/jolokia2/jolokia_test.go
@@ -1,6 +1,7 @@
 package jolokia2
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -79,7 +80,7 @@ func TestJolokia2_ScalarValues(t *testing.T) {
 	plugin := setupPlugin(t, fmt.Sprintf(config, server.URL))
 
 	var acc testutil.Accumulator
-	assert.NoError(t, plugin.Gather(&acc))
+	assert.NoError(t, plugin.Gather(context.Background(), &acc))
 
 	acc.AssertContainsTaggedFields(t, "scalar_without_attribute", map[string]interface{}{
 		"value": 123.0,
@@ -239,7 +240,7 @@ func TestJolokia2_ObjectValues(t *testing.T) {
 	plugin := setupPlugin(t, fmt.Sprintf(config, server.URL))
 
 	var acc testutil.Accumulator
-	assert.NoError(t, plugin.Gather(&acc))
+	assert.NoError(t, plugin.Gather(context.Background(), &acc))
 
 	acc.AssertContainsTaggedFields(t, "object_without_attribute", map[string]interface{}{
 		"biz": 123.0,
@@ -327,7 +328,7 @@ func TestJolokia2_StatusCodes(t *testing.T) {
 	plugin := setupPlugin(t, fmt.Sprintf(config, server.URL))
 
 	var acc testutil.Accumulator
-	assert.NoError(t, plugin.Gather(&acc))
+	assert.NoError(t, plugin.Gather(context.Background(), &acc))
 
 	acc.AssertContainsTaggedFields(t, "ok", map[string]interface{}{
 		"value": 1.0,
@@ -377,7 +378,7 @@ func TestJolokia2_TagRenaming(t *testing.T) {
 	plugin := setupPlugin(t, fmt.Sprintf(config, server.URL))
 
 	var acc testutil.Accumulator
-	assert.NoError(t, plugin.Gather(&acc))
+	assert.NoError(t, plugin.Gather(context.Background(), &acc))
 
 	acc.AssertContainsTaggedFields(t, "default_tag_prefix", map[string]interface{}{
 		"value": 123.0,
@@ -470,7 +471,7 @@ func TestJolokia2_FieldRenaming(t *testing.T) {
 	plugin := setupPlugin(t, fmt.Sprintf(config, server.URL))
 
 	var acc testutil.Accumulator
-	assert.NoError(t, plugin.Gather(&acc))
+	assert.NoError(t, plugin.Gather(context.Background(), &acc))
 
 	acc.AssertContainsTaggedFields(t, "default_field_modifiers", map[string]interface{}{
 		"DEFAULT_PREFIX_hello_DEFAULT_SEPARATOR_world": 123.0,
@@ -578,7 +579,7 @@ func TestJolokia2_MetricMbeanMatching(t *testing.T) {
 	plugin := setupPlugin(t, fmt.Sprintf(config, server.URL))
 
 	var acc testutil.Accumulator
-	assert.NoError(t, plugin.Gather(&acc))
+	assert.NoError(t, plugin.Gather(context.Background(), &acc))
 
 	acc.AssertContainsTaggedFields(t, "mbean_name_and_object_keys", map[string]interface{}{
 		"value": 123.0,
@@ -671,7 +672,7 @@ func TestJolokia2_MetricCompaction(t *testing.T) {
 	plugin := setupPlugin(t, fmt.Sprintf(config, server.URL))
 
 	var acc testutil.Accumulator
-	assert.NoError(t, plugin.Gather(&acc))
+	assert.NoError(t, plugin.Gather(context.Background(), &acc))
 
 	acc.AssertContainsTaggedFields(t, "compact_metric", map[string]interface{}{
 		"value": 123.0,
@@ -732,7 +733,7 @@ func TestJolokia2_ProxyTargets(t *testing.T) {
 	plugin := setupPlugin(t, fmt.Sprintf(config, server.URL))
 
 	var acc testutil.Accumulator
-	assert.NoError(t, plugin.Gather(&acc))
+	assert.NoError(t, plugin.Gather(context.Background(), &acc))
 
 	acc.AssertContainsTaggedFields(t, "hello", map[string]interface{}{
 		"value": 123.0,

--- a/plugins/inputs/jti_openconfig_telemetry/openconfig_telemetry.go
+++ b/plugins/inputs/jti_openconfig_telemetry/openconfig_telemetry.go
@@ -102,7 +102,7 @@ func (m *OpenConfigTelemetry) Description() string {
 	return "Read JTI OpenConfig Telemetry from listed sensors"
 }
 
-func (m *OpenConfigTelemetry) Gather(acc cua.Accumulator) error {
+func (m *OpenConfigTelemetry) Gather(_ context.Context, _ cua.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/kafka_consumer/kafka_consumer.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer.go
@@ -254,7 +254,7 @@ func (k *KafkaConsumer) Start(acc cua.Accumulator) error {
 	return nil
 }
 
-func (k *KafkaConsumer) Gather(acc cua.Accumulator) error {
+func (k *KafkaConsumer) Gather(_ context.Context, _ cua.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/kafka_consumer_legacy/kafka_consumer_legacy.go
+++ b/plugins/inputs/kafka_consumer_legacy/kafka_consumer_legacy.go
@@ -1,6 +1,7 @@
 package kafkaconsumerlegacy
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync"
@@ -174,7 +175,7 @@ func (k *Kafka) Stop() {
 	}
 }
 
-func (k *Kafka) Gather(acc cua.Accumulator) error {
+func (k *Kafka) Gather(_ context.Context, _ cua.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/kapacitor/kapacitor.go
+++ b/plugins/inputs/kapacitor/kapacitor.go
@@ -1,6 +1,7 @@
 package kapacitor
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -49,7 +50,7 @@ func (*Kapacitor) SampleConfig() string {
 `
 }
 
-func (k *Kapacitor) Gather(acc cua.Accumulator) error {
+func (k *Kapacitor) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if k.client == nil {
 		client, err := k.createHTTPClient()
 		if err != nil {

--- a/plugins/inputs/kapacitor/kapacitor_test.go
+++ b/plugins/inputs/kapacitor/kapacitor_test.go
@@ -1,6 +1,7 @@
 package kapacitor_test
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -25,7 +26,7 @@ func TestKapacitor(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	require.NoError(t, plugin.Gather(&acc))
+	require.NoError(t, plugin.Gather(context.Background(), &acc))
 
 	require.Len(t, acc.Metrics, 63)
 
@@ -83,7 +84,7 @@ func TestMissingStats(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	_ = plugin.Gather(&acc)
+	_ = plugin.Gather(context.Background(), &acc)
 
 	require.False(t, acc.HasField("kapacitor_memstats", "alloc_bytes"))
 	require.True(t, acc.HasField("kapacitor", "num_tasks"))
@@ -104,7 +105,7 @@ func TestErrorHandling(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	_ = plugin.Gather(&acc)
+	_ = plugin.Gather(context.Background(), &acc)
 	acc.WaitError(1)
 	require.Equal(t, uint64(0), acc.NMetrics())
 }
@@ -120,7 +121,7 @@ func TestErrorHandling404(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	_ = plugin.Gather(&acc)
+	_ = plugin.Gather(context.Background(), &acc)
 	acc.WaitError(1)
 	require.Equal(t, uint64(0), acc.NMetrics())
 }

--- a/plugins/inputs/kernel/kernel.go
+++ b/plugins/inputs/kernel/kernel.go
@@ -33,7 +33,7 @@ func (k *Kernel) Description() string {
 
 func (k *Kernel) SampleConfig() string { return "" }
 
-func (k *Kernel) Gather(acc cua.Accumulator) error {
+func (k *Kernel) Gather(ctx context.Context, acc cua.Accumulator) error {
 
 	data, err := k.getProcStat()
 	if err != nil {

--- a/plugins/inputs/kernel/kernel.go
+++ b/plugins/inputs/kernel/kernel.go
@@ -4,6 +4,7 @@ package kernel
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"strconv"

--- a/plugins/inputs/kernel/kernel_notlinux.go
+++ b/plugins/inputs/kernel/kernel_notlinux.go
@@ -3,6 +3,8 @@
 package kernel
 
 import (
+	"context"
+
 	"github.com/circonus-labs/circonus-unified-agent/cua"
 	"github.com/circonus-labs/circonus-unified-agent/plugins/inputs"
 )
@@ -16,7 +18,7 @@ func (k *Kernel) Description() string {
 
 func (k *Kernel) SampleConfig() string { return "" }
 
-func (k *Kernel) Gather(acc cua.Accumulator) error {
+func (k *Kernel) Gather(_ context.Context, _ cua.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/kernel/kernel_test.go
+++ b/plugins/inputs/kernel/kernel_test.go
@@ -22,7 +22,7 @@ func TestFullProcFile(t *testing.T) {
 	}
 
 	acc := testutil.Accumulator{}
-	err := k.Gather(&acc)
+	err := k.Gather(context.Background(), &acc)
 	assert.NoError(t, err)
 
 	fields := map[string]interface{}{
@@ -49,7 +49,7 @@ func TestPartialProcFile(t *testing.T) {
 	}
 
 	acc := testutil.Accumulator{}
-	err := k.Gather(&acc)
+	err := k.Gather(context.Background(), &acc)
 	assert.NoError(t, err)
 
 	fields := map[string]interface{}{
@@ -75,7 +75,7 @@ func TestInvalidProcFile1(t *testing.T) {
 	}
 
 	acc := testutil.Accumulator{}
-	err := k.Gather(&acc)
+	err := k.Gather(context.Background(), &acc)
 	assert.Error(t, err)
 }
 
@@ -88,7 +88,7 @@ func TestInvalidProcFile2(t *testing.T) {
 	}
 
 	acc := testutil.Accumulator{}
-	err := k.Gather(&acc)
+	err := k.Gather(context.Background(), &acc)
 	assert.Error(t, err)
 }
 
@@ -101,7 +101,7 @@ func TestNoProcFile(t *testing.T) {
 	}
 
 	acc := testutil.Accumulator{}
-	err := k.Gather(&acc)
+	err := k.Gather(context.Background(), &acc)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "does not exist")
 }

--- a/plugins/inputs/kernel/kernel_test.go
+++ b/plugins/inputs/kernel/kernel_test.go
@@ -3,6 +3,7 @@
 package kernel
 
 import (
+	"context"
 	"os"
 	"testing"
 

--- a/plugins/inputs/kernel_vmstat/kernel_vmstat.go
+++ b/plugins/inputs/kernel_vmstat/kernel_vmstat.go
@@ -4,6 +4,7 @@ package kernelvmstat
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"strconv"

--- a/plugins/inputs/kernel_vmstat/kernel_vmstat.go
+++ b/plugins/inputs/kernel_vmstat/kernel_vmstat.go
@@ -24,7 +24,7 @@ func (k *KernelVmstat) SampleConfig() string {
 	return ""
 }
 
-func (k *KernelVmstat) Gather(acc cua.Accumulator) error {
+func (k *KernelVmstat) Gather(ctx context.Context, acc cua.Accumulator) error {
 	data, err := k.getProcVmstat()
 	if err != nil {
 		return err

--- a/plugins/inputs/kernel_vmstat/kernel_vmstat_test.go
+++ b/plugins/inputs/kernel_vmstat/kernel_vmstat_test.go
@@ -19,7 +19,7 @@ func TestFullVmStatProcFile(t *testing.T) {
 	}
 
 	acc := testutil.Accumulator{}
-	err := k.Gather(&acc)
+	err := k.Gather(context.Background(), &acc)
 	assert.NoError(t, err)
 
 	fields := map[string]interface{}{
@@ -127,7 +127,7 @@ func TestPartialVmStatProcFile(t *testing.T) {
 	}
 
 	acc := testutil.Accumulator{}
-	err := k.Gather(&acc)
+	err := k.Gather(context.Background(), &acc)
 	assert.NoError(t, err)
 
 	fields := map[string]interface{}{
@@ -157,7 +157,7 @@ func TestInvalidVmStatProcFile1(t *testing.T) {
 	}
 
 	acc := testutil.Accumulator{}
-	err := k.Gather(&acc)
+	err := k.Gather(context.Background(), &acc)
 	assert.Error(t, err)
 }
 
@@ -170,7 +170,7 @@ func TestNoVmStatProcFile(t *testing.T) {
 	}
 
 	acc := testutil.Accumulator{}
-	err := k.Gather(&acc)
+	err := k.Gather(context.Background(), &acc)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "does not exist")
 }

--- a/plugins/inputs/kernel_vmstat/kernel_vmstat_test.go
+++ b/plugins/inputs/kernel_vmstat/kernel_vmstat_test.go
@@ -3,6 +3,7 @@
 package kernelvmstat
 
 import (
+	"context"
 	"os"
 	"testing"
 

--- a/plugins/inputs/kibana/kibana.go
+++ b/plugins/inputs/kibana/kibana.go
@@ -1,6 +1,7 @@
 package kibana
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -138,7 +139,7 @@ func (k *Kibana) Description() string {
 	return "Read status information from one or more Kibana servers"
 }
 
-func (k *Kibana) Gather(acc cua.Accumulator) error {
+func (k *Kibana) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if k.client == nil {
 		client, err := k.createHTTPClient()
 

--- a/plugins/inputs/kinesis_consumer/kinesis_consumer.go
+++ b/plugins/inputs/kinesis_consumer/kinesis_consumer.go
@@ -314,7 +314,7 @@ func (k *KinesisConsumer) Stop() {
 	k.wg.Wait()
 }
 
-func (k *KinesisConsumer) Gather(acc cua.Accumulator) error {
+func (k *KinesisConsumer) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if k.cons == nil {
 		return k.connect(acc)
 	}

--- a/plugins/inputs/kube_inventory/kube_state.go
+++ b/plugins/inputs/kube_inventory/kube_state.go
@@ -118,7 +118,7 @@ func (ki *KubernetesInventory) Init() error {
 }
 
 // Gather collects kubernetes metrics from a given URL.
-func (ki *KubernetesInventory) Gather(acc cua.Accumulator) (err error) {
+func (ki *KubernetesInventory) Gather(ctx context.Context, acc cua.Accumulator) (err error) {
 	resourceFilter, err := filter.NewIncludeExcludeFilter(ki.ResourceInclude, ki.ResourceExclude)
 	if err != nil {
 		return fmt.Errorf("resource filters: %w", err)
@@ -130,7 +130,6 @@ func (ki *KubernetesInventory) Gather(acc cua.Accumulator) (err error) {
 	}
 
 	wg := sync.WaitGroup{}
-	ctx := context.Background()
 
 	for collector, f := range availableCollectors {
 		if resourceFilter.Match(collector) {

--- a/plugins/inputs/kubernetes/kubernetes.go
+++ b/plugins/inputs/kubernetes/kubernetes.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -112,7 +113,7 @@ func (k *Kubernetes) Init() error {
 }
 
 // Gather collects kubernetes metrics from a given URL
-func (k *Kubernetes) Gather(acc cua.Accumulator) error {
+func (k *Kubernetes) Gather(ctx context.Context, acc cua.Accumulator) error {
 	acc.AddError(k.gatherSummary(k.URL, acc))
 	return nil
 }

--- a/plugins/inputs/lanz/lanz.go
+++ b/plugins/inputs/lanz/lanz.go
@@ -1,6 +1,7 @@
 package lanz
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -44,7 +45,7 @@ func (l *Lanz) Description() string {
 	return "Read metrics off Arista LANZ, via socket"
 }
 
-func (l *Lanz) Gather(acc cua.Accumulator) error {
+func (l *Lanz) Gather(_ context.Context, _ cua.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/leofs/leofs.go
+++ b/plugins/inputs/leofs/leofs.go
@@ -2,6 +2,7 @@ package leofs
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os/exec"
 	"strconv"
@@ -160,7 +161,7 @@ func (l *LeoFS) Description() string {
 	return "Read metrics from a LeoFS Server via SNMP"
 }
 
-func (l *LeoFS) Gather(acc cua.Accumulator) error {
+func (l *LeoFS) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if len(l.Servers) == 0 {
 		_ = l.gatherServer(defaultEndpoint, ServerTypeManagerMaster, acc)
 		return nil

--- a/plugins/inputs/linux_sysctl_fs/linux_sysctl_fs.go
+++ b/plugins/inputs/linux_sysctl_fs/linux_sysctl_fs.go
@@ -2,6 +2,7 @@ package linuxsysctlfs
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"path"
@@ -66,7 +67,7 @@ func (sfs *SysctlFS) gatherOne(name string, fields map[string]interface{}) error
 	return nil
 }
 
-func (sfs *SysctlFS) Gather(acc cua.Accumulator) error {
+func (sfs *SysctlFS) Gather(ctx context.Context, acc cua.Accumulator) error {
 	fields := map[string]interface{}{}
 
 	for _, n := range []string{"aio-nr", "aio-max-nr", "dquot-nr", "dquot-max", "super-nr", "super-max"} {

--- a/plugins/inputs/linux_sysctl_fs/linux_sysctl_fs_test.go
+++ b/plugins/inputs/linux_sysctl_fs/linux_sysctl_fs_test.go
@@ -1,6 +1,7 @@
 package linuxsysctlfs
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -24,7 +25,7 @@ func TestSysctlFSGather(t *testing.T) {
 		path: td,
 	}
 	var acc testutil.Accumulator
-	require.NoError(t, sfs.Gather(&acc))
+	require.NoError(t, sfs.Gather(context.Background(), &acc))
 
 	acc.AssertContainsFields(t, "linux_sysctl_fs", map[string]interface{}{
 		"aio-nr":             uint64(100),

--- a/plugins/inputs/logstash/logstash.go
+++ b/plugins/inputs/logstash/logstash.go
@@ -1,6 +1,7 @@
 package logstash
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -419,7 +420,7 @@ func (logstash *Logstash) gatherPipelinesStats(url string, accumulator cua.Accum
 }
 
 // Gather ask this plugin to start gathering metrics
-func (logstash *Logstash) Gather(accumulator cua.Accumulator) error {
+func (logstash *Logstash) Gather(ctx context.Context, accumulator cua.Accumulator) error {
 	if logstash.client == nil {
 		client, err := logstash.createHTTPClient()
 

--- a/plugins/inputs/lustre2/lustre2.go
+++ b/plugins/inputs/lustre2/lustre2.go
@@ -11,6 +11,7 @@ for HPC environments. It stores statistics about its activity in
 package lustre2
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -443,7 +444,7 @@ func (l *Lustre2) Description() string {
 }
 
 // Gather reads stats from all lustre targets
-func (l *Lustre2) Gather(acc cua.Accumulator) error {
+func (l *Lustre2) Gather(ctx context.Context, acc cua.Accumulator) error {
 	// l.allFields = make(map[string]map[string]interface{})
 	l.allFields = make(map[tags]map[string]interface{})
 

--- a/plugins/inputs/lustre2/lustre2_test.go
+++ b/plugins/inputs/lustre2/lustre2_test.go
@@ -3,6 +3,7 @@
 package lustre2
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -165,7 +166,7 @@ func TestLustre2GeneratesMetrics(t *testing.T) {
 
 	var acc testutil.Accumulator
 
-	err = m.Gather(&acc)
+	err = m.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	tags := map[string]string{
@@ -232,7 +233,7 @@ func TestLustre2GeneratesJobstatsMetrics(t *testing.T) {
 
 	var acc testutil.Accumulator
 
-	err = m.Gather(&acc)
+	err = m.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	// make this two tags

--- a/plugins/inputs/mailchimp/mailchimp.go
+++ b/plugins/inputs/mailchimp/mailchimp.go
@@ -1,6 +1,7 @@
 package mailchimp
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -35,7 +36,7 @@ func (m *MailChimp) Description() string {
 	return "Gathers metrics from the /3.0/reports MailChimp API"
 }
 
-func (m *MailChimp) Gather(acc cua.Accumulator) error {
+func (m *MailChimp) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if m.api == nil {
 		m.api = NewChimpAPI(m.APIKey)
 	}

--- a/plugins/inputs/mailchimp/mailchimp_test.go
+++ b/plugins/inputs/mailchimp/mailchimp_test.go
@@ -1,6 +1,7 @@
 package mailchimp
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -33,7 +34,7 @@ func TestMailChimpGatherReports(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	err = m.Gather(&acc)
+	err = m.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	tags := make(map[string]string)
@@ -97,7 +98,7 @@ func TestMailChimpGatherReport(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	err = m.Gather(&acc)
+	err = m.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	tags := make(map[string]string)
@@ -162,7 +163,7 @@ func TestMailChimpGatherError(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	err = m.Gather(&acc)
+	err = m.Gather(context.Background(), &acc)
 	require.Error(t, err)
 }
 

--- a/plugins/inputs/marklogic/marklogic.go
+++ b/plugins/inputs/marklogic/marklogic.go
@@ -1,6 +1,7 @@
 package marklogic
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -135,7 +136,7 @@ func (c *Marklogic) SampleConfig() string {
 }
 
 // Gather metrics from HTTP Server.
-func (c *Marklogic) Gather(accumulator cua.Accumulator) error {
+func (c *Marklogic) Gather(ctx context.Context, accumulator cua.Accumulator) error {
 	var wg sync.WaitGroup
 
 	if c.client == nil {

--- a/plugins/inputs/marklogic/marklogic_test.go
+++ b/plugins/inputs/marklogic/marklogic_test.go
@@ -1,6 +1,7 @@
 package marklogic
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -39,7 +40,7 @@ func TestMarklogic(t *testing.T) {
 	require.NoError(t, err)
 
 	// Gather data from the test server
-	err = ml.Gather(acc)
+	err = ml.Gather(context.Background(), acc)
 	require.NoError(t, err)
 
 	// Expect the correct values for all known keys

--- a/plugins/inputs/mcrouter/mcrouter.go
+++ b/plugins/inputs/mcrouter/mcrouter.go
@@ -124,8 +124,7 @@ func (m *Mcrouter) Description() string {
 }
 
 // Gather reads stats from all configured servers accumulates stats
-func (m *Mcrouter) Gather(acc cua.Accumulator) error {
-	ctx := context.Background()
+func (m *Mcrouter) Gather(ctx context.Context, acc cua.Accumulator) error {
 
 	if m.Timeout.Duration < 1*time.Second {
 		m.Timeout.Duration = defaultTimeout

--- a/plugins/inputs/mem/memory.go
+++ b/plugins/inputs/mem/memory.go
@@ -1,6 +1,7 @@
 package mem
 
 import (
+	"context"
 	"fmt"
 	"runtime"
 
@@ -25,7 +26,7 @@ func (s *Stats) Init() error {
 	return nil
 }
 
-func (s *Stats) Gather(acc cua.Accumulator) error {
+func (s *Stats) Gather(ctx context.Context, acc cua.Accumulator) error {
 	vm, err := s.ps.VMStat()
 	if err != nil {
 		return fmt.Errorf("error getting virtual memory info: %w", err)

--- a/plugins/inputs/mem/memory_test.go
+++ b/plugins/inputs/mem/memory_test.go
@@ -1,6 +1,7 @@
 package mem
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -63,7 +64,7 @@ func TestMemStats(t *testing.T) {
 	plugin.platform = "linux"
 
 	require.NoError(t, err)
-	err = plugin.Gather(&acc)
+	err = plugin.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expected := []cua.Metric{

--- a/plugins/inputs/memcached/memcached.go
+++ b/plugins/inputs/memcached/memcached.go
@@ -3,6 +3,7 @@ package memcached
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"net"
 	"strconv"
@@ -122,7 +123,7 @@ func (m *Memcached) Description() string {
 }
 
 // Gather reads stats from all configured servers accumulates stats
-func (m *Memcached) Gather(acc cua.Accumulator) error {
+func (m *Memcached) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if len(m.Servers) == 0 && len(m.UnixSockets) == 0 {
 		return m.gatherServer(":11211", false, acc)
 	}

--- a/plugins/inputs/mesos/mesos.go
+++ b/plugins/inputs/mesos/mesos.go
@@ -1,6 +1,7 @@
 package mesos
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -170,7 +171,7 @@ func (m *Mesos) initialize() error {
 }
 
 // Gather() metrics from given list of Mesos Masters
-func (m *Mesos) Gather(acc cua.Accumulator) error {
+func (m *Mesos) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if !m.initialized {
 		err := m.initialize()
 		if err != nil {

--- a/plugins/inputs/minecraft/minecraft.go
+++ b/plugins/inputs/minecraft/minecraft.go
@@ -1,6 +1,7 @@
 package minecraft
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/circonus-labs/circonus-unified-agent/cua"
@@ -50,7 +51,7 @@ func (s *Minecraft) SampleConfig() string {
 	return sampleConfig
 }
 
-func (s *Minecraft) Gather(acc cua.Accumulator) error {
+func (s *Minecraft) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if s.client == nil {
 		connector := newConnector(s.Server, s.Port, s.Password)
 		client := newClient(connector)

--- a/plugins/inputs/minecraft/minecraft_test.go
+++ b/plugins/inputs/minecraft/minecraft_test.go
@@ -1,6 +1,7 @@
 package minecraft
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -116,7 +117,7 @@ func TestGather(t *testing.T) {
 			var acc testutil.Accumulator
 			acc.TimeFunc = func() time.Time { return now }
 
-			err := plugin.Gather(&acc)
+			err := plugin.Gather(context.Background(), &acc)
 
 			require.Equal(t, tt.err, err)
 			testutil.RequireMetricsEqual(t, tt.metrics, acc.GetCUAMetrics())

--- a/plugins/inputs/modbus/modbus.go
+++ b/plugins/inputs/modbus/modbus.go
@@ -1,6 +1,7 @@
 package modbus
 
 import (
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -682,7 +683,7 @@ func scaleInt64(s float64, v int64) int64 {
 }
 
 // Gather implements the plugin interface method for data accumulation
-func (m *Modbus) Gather(acc cua.Accumulator) error {
+func (m *Modbus) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if !m.isConnected {
 		err := connect(m)
 		if err != nil {

--- a/plugins/inputs/modbus/modbus_test.go
+++ b/plugins/inputs/modbus/modbus_test.go
@@ -1,6 +1,7 @@
 package modbus
 
 import (
+	"context"
 	"testing"
 
 	m "github.com/goburrow/modbus"
@@ -108,7 +109,7 @@ func TestCoils(t *testing.T) {
 			err = modbus.Init()
 			assert.NoError(t, err)
 			var acc testutil.Accumulator
-			err = modbus.Gather(&acc)
+			err = modbus.Gather(context.Background(), &acc)
 			assert.NoError(t, err)
 			assert.NotEmpty(t, modbus.registers)
 
@@ -647,7 +648,7 @@ func TestHoldingRegisters(t *testing.T) {
 			err = modbus.Init()
 			assert.NoError(t, err)
 			var acc testutil.Accumulator
-			_ = modbus.Gather(&acc)
+			_ = modbus.Gather(context.Background(), &acc)
 			assert.NotEmpty(t, modbus.registers)
 
 			for _, coil := range modbus.registers {
@@ -701,7 +702,7 @@ func TestRetrySuccessful(t *testing.T) {
 		err = modbus.Init()
 		assert.NoError(t, err)
 		var acc testutil.Accumulator
-		err = modbus.Gather(&acc)
+		err = modbus.Gather(context.Background(), &acc)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, modbus.registers)
 
@@ -746,7 +747,7 @@ func TestRetryFail(t *testing.T) {
 		err = modbus.Init()
 		assert.NoError(t, err)
 		var acc testutil.Accumulator
-		err = modbus.Gather(&acc)
+		err = modbus.Gather(context.Background(), &acc)
 		assert.Error(t, err)
 	})
 
@@ -779,7 +780,7 @@ func TestRetryFail(t *testing.T) {
 		err = modbus.Init()
 		assert.NoError(t, err)
 		var acc testutil.Accumulator
-		err = modbus.Gather(&acc)
+		err = modbus.Gather(context.Background(), &acc)
 		assert.Error(t, err)
 		assert.Equal(t, counter, 1)
 	})

--- a/plugins/inputs/mongodb/mongodb.go
+++ b/plugins/inputs/mongodb/mongodb.go
@@ -1,6 +1,7 @@
 package mongodb
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -77,7 +78,7 @@ var localhost = &url.URL{Host: "mongodb://127.0.0.1:27017"}
 
 // Reads stats from all configured servers accumulates stats.
 // Returns one of the errors encountered while gather stats (if any).
-func (m *MongoDB) Gather(acc cua.Accumulator) error {
+func (m *MongoDB) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if len(m.Servers) == 0 {
 		_ = m.gatherServer(m.getMongoServer(localhost), acc)
 		return nil

--- a/plugins/inputs/monit/monit.go
+++ b/plugins/inputs/monit/monit.go
@@ -1,6 +1,7 @@
 package monit
 
 import (
+	"context"
 	"encoding/xml"
 	"fmt"
 	"net/http"
@@ -229,7 +230,7 @@ func (m *Monit) Init() error {
 	return nil
 }
 
-func (m *Monit) Gather(acc cua.Accumulator) error {
+func (m *Monit) Gather(ctx context.Context, acc cua.Accumulator) error {
 
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s/_status?format=xml", m.Address), nil)
 	if err != nil {

--- a/plugins/inputs/monit/monit_test.go
+++ b/plugins/inputs/monit/monit_test.go
@@ -1,6 +1,7 @@
 package monit
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -341,7 +342,7 @@ func TestServiceType(t *testing.T) {
 			_ = plugin.Init()
 
 			var acc testutil.Accumulator
-			err := plugin.Gather(&acc)
+			err := plugin.Gather(context.Background(), &acc)
 			require.NoError(t, err)
 
 			testutil.RequireMetricsEqual(t, tt.expected, acc.GetCUAMetrics(),
@@ -541,7 +542,7 @@ func TestMonitFailure(t *testing.T) {
 			_ = plugin.Init()
 
 			var acc testutil.Accumulator
-			err := plugin.Gather(&acc)
+			err := plugin.Gather(context.Background(), &acc)
 			require.NoError(t, err)
 
 			testutil.RequireMetricsEqual(t, tt.expected, acc.GetCUAMetrics(),
@@ -570,7 +571,7 @@ func TestAllowHosts(t *testing.T) {
 
 	r.client.Transport = &transportMock{}
 
-	err := r.Gather(&acc)
+	err := r.Gather(context.Background(), &acc)
 
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "read: connection reset by peer")
@@ -587,7 +588,7 @@ func TestConnection(t *testing.T) {
 	_ = r.Init()
 
 	var acc testutil.Accumulator
-	err := r.Gather(&acc)
+	err := r.Gather(context.Background(), &acc)
 
 	var uerr *url.Error
 	if !errors.As(err, &uerr) {
@@ -624,7 +625,7 @@ func TestInvalidUsernameOrPassword(t *testing.T) {
 
 	_ = r.Init()
 
-	err := r.Gather(&acc)
+	err := r.Gather(context.Background(), &acc)
 
 	assert.EqualError(t, err, "received status code 401 (Unauthorized), expected 200")
 }
@@ -656,7 +657,7 @@ func TestNoUsernameOrPasswordConfiguration(t *testing.T) {
 
 	_ = r.Init()
 
-	err := r.Gather(&acc)
+	err := r.Gather(context.Background(), &acc)
 
 	assert.EqualError(t, err, "received status code 401 (Unauthorized), expected 200")
 }
@@ -700,7 +701,7 @@ func TestInvalidXMLAndInvalidTypes(t *testing.T) {
 			_ = plugin.Init()
 
 			var acc testutil.Accumulator
-			err := plugin.Gather(&acc)
+			err := plugin.Gather(context.Background(), &acc)
 
 			if assert.Error(t, err) {
 				assert.Contains(t, err.Error(), "error parsing input:")

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer.go
@@ -300,7 +300,7 @@ func (m *MQTTConsumer) Stop() {
 	m.cancel()
 }
 
-func (m *MQTTConsumer) Gather(acc cua.Accumulator) error {
+func (m *MQTTConsumer) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if m.state == Disconnected {
 		m.state = Connecting
 		m.Log.Debugf("Connecting %v", m.Servers)

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
@@ -1,6 +1,7 @@
 package mqttconsumer
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -114,7 +115,7 @@ func TestLifecycleSanity(t *testing.T) {
 	err = plugin.Start(&acc)
 	require.NoError(t, err)
 
-	err = plugin.Gather(&acc)
+	err = plugin.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	plugin.Stop()

--- a/plugins/inputs/multifile/multifile.go
+++ b/plugins/inputs/multifile/multifile.go
@@ -2,6 +2,7 @@ package multifile
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"math"
 	"os"
@@ -77,7 +78,7 @@ func (m *MultiFile) init() {
 	m.initialized = true
 }
 
-func (m *MultiFile) Gather(acc cua.Accumulator) error {
+func (m *MultiFile) Gather(ctx context.Context, acc cua.Accumulator) error {
 	m.init()
 	now := time.Now()
 	fields := make(map[string]interface{})

--- a/plugins/inputs/multifile/multifile_test.go
+++ b/plugins/inputs/multifile/multifile_test.go
@@ -1,6 +1,7 @@
 package multifile
 
 import (
+	"context"
 	"os"
 	"path"
 	"testing"
@@ -29,7 +30,7 @@ func TestFileTypes(t *testing.T) {
 
 	var acc testutil.Accumulator
 
-	err := m.Gather(&acc)
+	err := m.Gather(context.Background(), &acc)
 
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"exampletag": "test"}, acc.Metrics[0].Tags)
@@ -57,7 +58,7 @@ func FailEarly(failEarly bool, t *testing.T) error {
 
 	var acc testutil.Accumulator
 
-	err := m.Gather(&acc)
+	err := m.Gather(context.Background(), &acc)
 
 	if err == nil {
 		assert.Equal(t, map[string]interface{}{

--- a/plugins/inputs/mysql/mysql.go
+++ b/plugins/inputs/mysql/mysql.go
@@ -2,6 +2,7 @@ package mysql
 
 import (
 	"bytes"
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -160,7 +161,7 @@ func (m *Mysql) InitMysql() {
 	m.initDone = true
 }
 
-func (m *Mysql) Gather(acc cua.Accumulator) error {
+func (m *Mysql) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if len(m.Servers) == 0 {
 		// default to localhost if nothing specified.
 		return m.gatherServer(localhost, acc)

--- a/plugins/inputs/mysql/mysql_test.go
+++ b/plugins/inputs/mysql/mysql_test.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"testing"
@@ -20,7 +21,7 @@ func TestMysqlDefaultsToLocal(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	err := m.Gather(&acc)
+	err := m.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	assert.True(t, acc.HasMeasurement("mysql"))
@@ -39,7 +40,7 @@ func TestMysqlMultipleInstances(t *testing.T) {
 	}
 
 	var acc, acc2 testutil.Accumulator
-	err := m.Gather(&acc)
+	err := m.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 	assert.True(t, acc.HasMeasurement("mysql"))
 	// acc should have global variables
@@ -48,7 +49,7 @@ func TestMysqlMultipleInstances(t *testing.T) {
 	m2 := &Mysql{
 		Servers: []string{testServer},
 	}
-	err = m2.Gather(&acc2)
+	err = m2.Gather(context.Background(), &acc2)
 	require.NoError(t, err)
 	assert.True(t, acc2.HasMeasurement("mysql"))
 	// acc2 should not have global variables

--- a/plugins/inputs/nats/nats.go
+++ b/plugins/inputs/nats/nats.go
@@ -3,6 +3,7 @@
 package nats
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -40,7 +41,7 @@ func (n *Nats) Description() string {
 	return "Provides metrics about the state of a NATS server"
 }
 
-func (n *Nats) Gather(acc cua.Accumulator) error {
+func (n *Nats) Gather(ctx context.Context, acc cua.Accumulator) error {
 	rurl, err := url.Parse(n.Server)
 	if err != nil {
 		return fmt.Errorf("url parse (%s): %w", n.Server, err)

--- a/plugins/inputs/nats/nats_test.go
+++ b/plugins/inputs/nats/nats_test.go
@@ -3,6 +3,7 @@
 package nats
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -73,7 +74,7 @@ func TestMetricsCorrect(t *testing.T) {
 	defer srv.Close()
 
 	n := &Nats{Server: srv.URL}
-	err := n.Gather(&acc)
+	err := n.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	fields := map[string]interface{}{

--- a/plugins/inputs/nats_consumer/nats_consumer.go
+++ b/plugins/inputs/nats_consumer/nats_consumer.go
@@ -261,7 +261,7 @@ func (n *natsConsumer) Stop() {
 	n.clean()
 }
 
-func (n *natsConsumer) Gather(acc cua.Accumulator) error {
+func (n *natsConsumer) Gather(_ context.Context, _ cua.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/neptune_apex/neptune_apex.go
+++ b/plugins/inputs/neptune_apex/neptune_apex.go
@@ -3,6 +3,7 @@
 package neptuneapex
 
 import (
+	"context"
 	"encoding/xml"
 	"fmt"
 	"io"
@@ -78,7 +79,7 @@ func (*NeptuneApex) SampleConfig() string {
 }
 
 // Gather implements Input.Gather
-func (n *NeptuneApex) Gather(acc cua.Accumulator) error {
+func (n *NeptuneApex) Gather(ctx context.Context, acc cua.Accumulator) error {
 	var wg sync.WaitGroup
 	for _, server := range n.Servers {
 		wg.Add(1)

--- a/plugins/inputs/neptune_apex/neptune_apex_test.go
+++ b/plugins/inputs/neptune_apex/neptune_apex_test.go
@@ -46,7 +46,7 @@ func TestGather(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			var acc testutil.Accumulator
 			n.Servers = test.servers
-			_ = n.Gather(&acc)
+			_ = n.Gather(context.Background(), &acc)
 			if len(acc.Errors) != len(test.servers) {
 				t.Errorf("Number of servers mismatch. got=%d, want=%d",
 					len(acc.Errors), len(test.servers))

--- a/plugins/inputs/net/net.go
+++ b/plugins/inputs/net/net.go
@@ -1,6 +1,7 @@
 package net
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strings"
@@ -42,7 +43,7 @@ func (*IOStats) SampleConfig() string {
 	return netSampleConfig
 }
 
-func (s *IOStats) Gather(acc cua.Accumulator) error {
+func (s *IOStats) Gather(ctx context.Context, acc cua.Accumulator) error {
 	netio, err := s.ps.NetIO()
 	if err != nil {
 		return fmt.Errorf("error getting net io info: %w", err)

--- a/plugins/inputs/net/net_test.go
+++ b/plugins/inputs/net/net_test.go
@@ -1,6 +1,7 @@
 package net
 
 import (
+	"context"
 	"syscall"
 	"testing"
 
@@ -58,7 +59,7 @@ func TestNetStats(t *testing.T) {
 
 	mps.On("NetConnections").Return(netstats, nil)
 
-	err = (&IOStats{ps: &mps, skipChecks: true}).Gather(&acc)
+	err = (&IOStats{ps: &mps, skipChecks: true}).Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	ntags := map[string]string{
@@ -88,7 +89,7 @@ func TestNetStats(t *testing.T) {
 
 	acc.Metrics = nil
 
-	err = (&Stats{&mps}).Gather(&acc)
+	err = (&Stats{&mps}).Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	fields3 := map[string]interface{}{
@@ -109,7 +110,7 @@ func TestNetStats(t *testing.T) {
 	acc.AssertContainsTaggedFields(t, "netstat", fields3, make(map[string]string))
 
 	acc.Metrics = nil
-	err = (&IOStats{ps: &mps, IgnoreProtocolStats: true}).Gather(&acc)
+	err = (&IOStats{ps: &mps, IgnoreProtocolStats: true}).Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	acc.AssertDoesNotContainsTaggedFields(t, "netstat", fields3, make(map[string]string))

--- a/plugins/inputs/net/netstat.go
+++ b/plugins/inputs/net/netstat.go
@@ -1,6 +1,7 @@
 package net
 
 import (
+	"context"
 	"fmt"
 	"syscall"
 
@@ -23,7 +24,7 @@ func (*Stats) SampleConfig() string {
 	return tcpstatSampleConfig
 }
 
-func (s *Stats) Gather(acc cua.Accumulator) error {
+func (s *Stats) Gather(ctx context.Context, acc cua.Accumulator) error {
 	netconns, err := s.ps.NetConnections()
 	if err != nil {
 		return fmt.Errorf("error getting net connections info: %w", err)

--- a/plugins/inputs/net_response/net_response.go
+++ b/plugins/inputs/net_response/net_response.go
@@ -2,6 +2,7 @@ package netresponse
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -190,7 +191,7 @@ func (n *NetResponse) UDPGather() (tags map[string]string, fields map[string]int
 // Gather is called by agent when the plugin is executed on its interval.
 // It will call either UDPGather or TCPGather based on the configuration and
 // also fill an Accumulator that is supplied.
-func (n *NetResponse) Gather(acc cua.Accumulator) error {
+func (n *NetResponse) Gather(ctx context.Context, acc cua.Accumulator) error {
 	const (
 		udp = "udp"
 		tcp = "tcp"

--- a/plugins/inputs/net_response/net_response_test.go
+++ b/plugins/inputs/net_response/net_response_test.go
@@ -1,6 +1,7 @@
 package netresponse
 
 import (
+	"context"
 	"net"
 	"sync"
 	"testing"
@@ -35,7 +36,7 @@ func TestBadProtocol(t *testing.T) {
 		Address:  ":9999",
 	}
 	// Error
-	err1 := c.Gather(&acc)
+	err1 := c.Gather(context.Background(), &acc)
 	require.Error(t, err1)
 	assert.Equal(t, "Bad protocol", err1.Error())
 }
@@ -46,7 +47,7 @@ func TestNoPort(t *testing.T) {
 		Protocol: "tcp",
 		Address:  ":",
 	}
-	err1 := c.Gather(&acc)
+	err1 := c.Gather(context.Background(), &acc)
 	require.Error(t, err1)
 	assert.Equal(t, "Bad port", err1.Error())
 }
@@ -57,7 +58,7 @@ func TestAddressOnly(t *testing.T) {
 		Protocol: "tcp",
 		Address:  "127.0.0.1",
 	}
-	err1 := c.Gather(&acc)
+	err1 := c.Gather(context.Background(), &acc)
 	require.Error(t, err1)
 	assert.Equal(t, "address 127.0.0.1: missing port in address", err1.Error())
 }
@@ -76,10 +77,10 @@ func TestSendExpectStrings(t *testing.T) {
 		Send:     "toast",
 		Expect:   "",
 	}
-	err1 := tc.Gather(&acc)
+	err1 := tc.Gather(context.Background(), &acc)
 	require.Error(t, err1)
 	assert.Equal(t, "Send string cannot be empty", err1.Error())
-	err2 := uc.Gather(&acc)
+	err2 := uc.Gather(context.Background(), &acc)
 	require.Error(t, err2)
 	assert.Equal(t, "Expected string cannot be empty", err2.Error())
 }
@@ -93,7 +94,7 @@ func TestTCPError(t *testing.T) {
 		Timeout:  internal.Duration{Duration: time.Second * 30},
 	}
 	// Error
-	err1 := c.Gather(&acc)
+	err1 := c.Gather(context.Background(), &acc)
 	require.NoError(t, err1)
 	acc.AssertContainsTaggedFields(t,
 		"net_response",
@@ -128,7 +129,7 @@ func TestTCPOK1(t *testing.T) {
 	wg.Wait()
 	// Connect
 	wg.Add(1)
-	err1 := c.Gather(&acc)
+	err1 := c.Gather(context.Background(), &acc)
 	wg.Wait()
 	// Override response time
 	for _, p := range acc.Metrics {
@@ -172,7 +173,7 @@ func TestTCPOK2(t *testing.T) {
 	wg.Wait()
 	// Connect
 	wg.Add(1)
-	err1 := c.Gather(&acc)
+	err1 := c.Gather(context.Background(), &acc)
 	wg.Wait()
 	// Override response time
 	for _, p := range acc.Metrics {
@@ -208,7 +209,7 @@ func TestUDPError(t *testing.T) {
 		Protocol: "udp",
 	}
 	// Gather
-	err1 := c.Gather(&acc)
+	err1 := c.Gather(context.Background(), &acc)
 	// Override response time
 	for _, p := range acc.Metrics {
 		p.Fields["response_time"] = 1.0
@@ -250,7 +251,7 @@ func TestUDPOK1(t *testing.T) {
 	wg.Wait()
 	// Connect
 	wg.Add(1)
-	err1 := c.Gather(&acc)
+	err1 := c.Gather(context.Background(), &acc)
 	wg.Wait()
 	// Override response time
 	for _, p := range acc.Metrics {

--- a/plugins/inputs/nginx/nginx.go
+++ b/plugins/inputs/nginx/nginx.go
@@ -2,6 +2,7 @@ package nginx
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -49,7 +50,7 @@ func (n *Nginx) Description() string {
 	return "Read Nginx's basic status information (ngx_http_stub_status_module)"
 }
 
-func (n *Nginx) Gather(acc cua.Accumulator) error {
+func (n *Nginx) Gather(ctx context.Context, acc cua.Accumulator) error {
 	var wg sync.WaitGroup
 
 	// Create an HTTP client that is re-used for each

--- a/plugins/inputs/nginx_plus/nginx_plus.go
+++ b/plugins/inputs/nginx_plus/nginx_plus.go
@@ -2,6 +2,7 @@ package nginxplus
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -50,7 +51,7 @@ func (n *NginxPlus) Description() string {
 	return "Read Nginx Plus' full status information (ngx_http_status_module)"
 }
 
-func (n *NginxPlus) Gather(acc cua.Accumulator) error {
+func (n *NginxPlus) Gather(ctx context.Context, acc cua.Accumulator) error {
 	var wg sync.WaitGroup
 
 	// Create an HTTP client that is re-used for each

--- a/plugins/inputs/nginx_plus/nginx_plus_test.go
+++ b/plugins/inputs/nginx_plus/nginx_plus_test.go
@@ -1,6 +1,7 @@
 package nginxplus
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -269,7 +270,7 @@ func TestNginxPlusGeneratesMetrics(t *testing.T) {
 
 	var acc testutil.Accumulator
 
-	errNginx := n.Gather(&acc)
+	errNginx := n.Gather(context.Background(), &acc)
 
 	require.NoError(t, errNginx)
 

--- a/plugins/inputs/nginx_plus_api/nginx_plus_api.go
+++ b/plugins/inputs/nginx_plus_api/nginx_plus_api.go
@@ -1,6 +1,7 @@
 package nginxplusapi
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -69,7 +70,7 @@ func (n *NginxPlusAPI) Description() string {
 	return "Read Nginx Plus Api documentation"
 }
 
-func (n *NginxPlusAPI) Gather(acc cua.Accumulator) error {
+func (n *NginxPlusAPI) Gather(ctx context.Context, acc cua.Accumulator) error {
 	var wg sync.WaitGroup
 
 	// Create an HTTP client that is re-used for each

--- a/plugins/inputs/nginx_sts/nginx_sts.go
+++ b/plugins/inputs/nginx_sts/nginx_sts.go
@@ -2,6 +2,7 @@ package nginxsts
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -49,7 +50,7 @@ func (*STS) Description() string {
 	return "Read Nginx virtual host traffic status module information (nginx-module-sts)"
 }
 
-func (n *STS) Gather(acc cua.Accumulator) error {
+func (n *STS) Gather(ctx context.Context, acc cua.Accumulator) error {
 	var wg sync.WaitGroup
 
 	// Create an HTTP client that is re-used for each

--- a/plugins/inputs/nginx_sts/nginx_sts_test.go
+++ b/plugins/inputs/nginx_sts/nginx_sts_test.go
@@ -1,6 +1,7 @@
 package nginxsts
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -183,7 +184,7 @@ func TestNginxPlusGeneratesMetrics(t *testing.T) {
 
 	var acc testutil.Accumulator
 
-	err := n.Gather(&acc)
+	err := n.Gather(context.Background(), &acc)
 
 	require.NoError(t, err)
 

--- a/plugins/inputs/nginx_upstream_check/nginx_upstream_check.go
+++ b/plugins/inputs/nginx_upstream_check/nginx_upstream_check.go
@@ -1,6 +1,7 @@
 package nginxupstreamcheck
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -165,7 +166,7 @@ func (check *UpstreamCheck) gatherJSONData(rurl string, value interface{}) error
 	return nil
 }
 
-func (check *UpstreamCheck) Gather(accumulator cua.Accumulator) error {
+func (check *UpstreamCheck) Gather(ctx context.Context, accumulator cua.Accumulator) error {
 	if check.client == nil {
 		client, err := check.createHTTPClient()
 

--- a/plugins/inputs/nginx_upstream_check/nginx_upstream_check_test.go
+++ b/plugins/inputs/nginx_upstream_check/nginx_upstream_check_test.go
@@ -1,6 +1,7 @@
 package nginxupstreamcheck
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -61,7 +62,7 @@ func TestNginxUpstreamCheckData(test *testing.T) {
 
 	var accumulator testutil.Accumulator
 
-	checkError := check.Gather(&accumulator)
+	checkError := check.Gather(context.Background(), &accumulator)
 	require.NoError(test, checkError)
 
 	accumulator.AssertContainsTaggedFields(
@@ -130,6 +131,6 @@ func TestNginxUpstreamCheckRequest(test *testing.T) {
 
 	var accumulator testutil.Accumulator
 
-	checkError := check.Gather(&accumulator)
+	checkError := check.Gather(context.Background(), &accumulator)
 	require.NoError(test, checkError)
 }

--- a/plugins/inputs/nginx_vts/nginx_vts.go
+++ b/plugins/inputs/nginx_vts/nginx_vts.go
@@ -2,6 +2,7 @@ package nginxvts
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -49,7 +50,7 @@ func (n *NginxVTS) Description() string {
 	return "Read Nginx virtual host traffic status module information (nginx-module-vts)"
 }
 
-func (n *NginxVTS) Gather(acc cua.Accumulator) error {
+func (n *NginxVTS) Gather(ctx context.Context, acc cua.Accumulator) error {
 	var wg sync.WaitGroup
 
 	// Create an HTTP client that is re-used for each

--- a/plugins/inputs/nginx_vts/nginx_vts_test.go
+++ b/plugins/inputs/nginx_vts/nginx_vts_test.go
@@ -1,6 +1,7 @@
 package nginxvts
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -220,7 +221,7 @@ func TestNginxPlusGeneratesMetrics(t *testing.T) {
 
 	var acc testutil.Accumulator
 
-	err := n.Gather(&acc)
+	err := n.Gather(context.Background(), &acc)
 
 	require.NoError(t, err)
 

--- a/plugins/inputs/nsd/nsd.go
+++ b/plugins/inputs/nsd/nsd.go
@@ -3,6 +3,7 @@ package nsd
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"net"
 	"os/exec"
@@ -95,7 +96,7 @@ func nsdRunner(cmdName string, timeout internal.Duration, useSudo bool, server s
 }
 
 // Gather collects stats from nsd-control and adds them to the Accumulator
-func (s *NSD) Gather(acc cua.Accumulator) error {
+func (s *NSD) Gather(ctx context.Context, acc cua.Accumulator) error {
 	out, err := s.run(s.Binary, s.Timeout, s.UseSudo, s.Server, s.ConfigFile)
 	if err != nil {
 		return fmt.Errorf("error gathering metrics: %w", err)

--- a/plugins/inputs/nsd/nsd_test.go
+++ b/plugins/inputs/nsd/nsd_test.go
@@ -2,6 +2,7 @@ package nsd
 
 import (
 	"bytes"
+	"context"
 	"testing"
 	"time"
 
@@ -23,7 +24,7 @@ func TestParseFullOutput(t *testing.T) {
 	v := &NSD{
 		run: NSDControl(fullOutput, TestTimeout, true, "", ""),
 	}
-	err := v.Gather(acc)
+	err := v.Gather(context.Background(), acc)
 
 	assert.NoError(t, err)
 

--- a/plugins/inputs/nsq/nsq.go
+++ b/plugins/inputs/nsq/nsq.go
@@ -23,6 +23,7 @@
 package nsq
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -78,7 +79,7 @@ func (n *NSQ) Description() string {
 	return "Read NSQ topic and channel statistics."
 }
 
-func (n *NSQ) Gather(acc cua.Accumulator) error {
+func (n *NSQ) Gather(ctx context.Context, acc cua.Accumulator) error {
 	var err error
 
 	if n.httpClient == nil {

--- a/plugins/inputs/nsq_consumer/nsq_consumer.go
+++ b/plugins/inputs/nsq_consumer/nsq_consumer.go
@@ -180,7 +180,7 @@ func (n *NSQConsumer) Stop() {
 }
 
 // Gather is a noop
-func (n *NSQConsumer) Gather(acc cua.Accumulator) error {
+func (n *NSQConsumer) Gather(ctx context.Context, acc cua.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/nstat/nstat.go
+++ b/plugins/inputs/nstat/nstat.go
@@ -2,6 +2,7 @@ package nstat
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"strconv"
@@ -58,7 +59,7 @@ func (ns *Nstat) SampleConfig() string {
 	return sampleConfig
 }
 
-func (ns *Nstat) Gather(acc cua.Accumulator) error {
+func (ns *Nstat) Gather(ctx context.Context, acc cua.Accumulator) error {
 	// load paths, get from env if config values are empty
 	ns.loadPaths()
 

--- a/plugins/inputs/ntpq/ntpq.go
+++ b/plugins/inputs/ntpq/ntpq.go
@@ -3,6 +3,7 @@ package ntpq
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"os/exec"
 	"regexp"
@@ -41,7 +42,7 @@ func (n *NTPQ) SampleConfig() string {
 `
 }
 
-func (n *NTPQ) Gather(acc cua.Accumulator) error {
+func (n *NTPQ) Gather(ctx context.Context, acc cua.Accumulator) error {
 	out, err := n.runQ()
 	if err != nil {
 		return err

--- a/plugins/inputs/nvidia_smi/nvidia_smi.go
+++ b/plugins/inputs/nvidia_smi/nvidia_smi.go
@@ -1,6 +1,7 @@
 package nvidiasmi
 
 import (
+	"context"
 	"encoding/xml"
 	"fmt"
 	"os"
@@ -39,7 +40,7 @@ func (smi *NvidiaSMI) SampleConfig() string {
 }
 
 // Gather implements the Input interface
-func (smi *NvidiaSMI) Gather(acc cua.Accumulator) error {
+func (smi *NvidiaSMI) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if _, err := os.Stat(smi.BinPath); os.IsNotExist(err) {
 		return fmt.Errorf("nvidia-smi binary not at path %s, cannot gather GPU data", smi.BinPath)
 	}

--- a/plugins/inputs/opcua/opcua_client.go
+++ b/plugins/inputs/opcua/opcua_client.go
@@ -376,7 +376,7 @@ func disconnect(o *OpcUA) error {
 }
 
 // Gather defines what data the plugin will gather.
-func (o *OpcUA) Gather(acc cua.Accumulator) error {
+func (o *OpcUA) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if o.state == Disconnected {
 		o.state = Connecting
 		err := Connect(o)

--- a/plugins/inputs/openldap/openldap.go
+++ b/plugins/inputs/openldap/openldap.go
@@ -1,6 +1,7 @@
 package openldap
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -89,7 +90,7 @@ func NewOpenldap() *Openldap {
 }
 
 // gather metrics
-func (o *Openldap) Gather(acc cua.Accumulator) error {
+func (o *Openldap) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if o.TLS == "" {
 		o.TLS = o.SSL
 	}

--- a/plugins/inputs/openldap/openldap_test.go
+++ b/plugins/inputs/openldap/openldap_test.go
@@ -1,6 +1,7 @@
 package openldap
 
 import (
+	"context"
 	"strconv"
 	"testing"
 
@@ -44,7 +45,7 @@ func TestOpenldapNoConnection(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	err := o.Gather(&acc)
+	err := o.Gather(context.Background(), &acc)
 	require.NoError(t, err)        // test that we didn't return an error
 	assert.Zero(t, acc.NFields())  // test that we didn't return any fields
 	assert.NotEmpty(t, acc.Errors) // test that we set an error
@@ -61,7 +62,7 @@ func TestOpenldapGeneratesMetrics(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	err := o.Gather(&acc)
+	err := o.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 	commonTests(t, o, &acc)
 }
@@ -79,7 +80,7 @@ func TestOpenldapStartTLS(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	err := o.Gather(&acc)
+	err := o.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 	commonTests(t, o, &acc)
 }
@@ -97,7 +98,7 @@ func TestOpenldapLDAPS(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	err := o.Gather(&acc)
+	err := o.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 	commonTests(t, o, &acc)
 }
@@ -115,7 +116,7 @@ func TestOpenldapInvalidSSL(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	err := o.Gather(&acc)
+	err := o.Gather(context.Background(), &acc)
 	require.NoError(t, err)        // test that we didn't return an error
 	assert.Zero(t, acc.NFields())  // test that we didn't return any fields
 	assert.NotEmpty(t, acc.Errors) // test that we set an error
@@ -136,7 +137,7 @@ func TestOpenldapBind(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	err := o.Gather(&acc)
+	err := o.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 	commonTests(t, o, &acc)
 }
@@ -165,7 +166,7 @@ func TestOpenldapReverseMetrics(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	err := o.Gather(&acc)
+	err := o.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 	assert.True(t, acc.HasInt64Field("openldap", "connections_total"), "Has an integer field called connections_total")
 }

--- a/plugins/inputs/openntpd/openntpd.go
+++ b/plugins/inputs/openntpd/openntpd.go
@@ -3,6 +3,7 @@ package openntpd
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"os/exec"
 	"strconv"
@@ -92,7 +93,7 @@ func openntpdRunner(cmdName string, timeout internal.Duration, useSudo bool) (*b
 	return &out, nil
 }
 
-func (n *Openntpd) Gather(acc cua.Accumulator) error {
+func (n *Openntpd) Gather(ctx context.Context, acc cua.Accumulator) error {
 	out, err := n.run(n.Binary, n.Timeout, n.UseSudo)
 	if err != nil {
 		return fmt.Errorf("error gathering metrics: %w", err)

--- a/plugins/inputs/openntpd/openntpd_test.go
+++ b/plugins/inputs/openntpd/openntpd_test.go
@@ -2,6 +2,7 @@ package openntpd
 
 import (
 	"bytes"
+	"context"
 	"testing"
 	"time"
 
@@ -23,7 +24,7 @@ func TestParseSimpleOutput(t *testing.T) {
 	v := &Openntpd{
 		run: OpenntpdCTL(simpleOutput, TestTimeout, false),
 	}
-	err := v.Gather(acc)
+	err := v.Gather(context.Background(), acc)
 
 	assert.NoError(t, err)
 	assert.True(t, acc.HasMeasurement("openntpd"))
@@ -54,7 +55,7 @@ func TestParseSimpleOutputwithStatePrefix(t *testing.T) {
 	v := &Openntpd{
 		run: OpenntpdCTL(simpleOutputwithStatePrefix, TestTimeout, false),
 	}
-	err := v.Gather(acc)
+	err := v.Gather(context.Background(), acc)
 
 	assert.NoError(t, err)
 	assert.True(t, acc.HasMeasurement("openntpd"))
@@ -86,7 +87,7 @@ func TestParseSimpleOutputInvalidPeer(t *testing.T) {
 	v := &Openntpd{
 		run: OpenntpdCTL(simpleOutputInvalidPeer, TestTimeout, false),
 	}
-	err := v.Gather(acc)
+	err := v.Gather(context.Background(), acc)
 
 	assert.NoError(t, err)
 	assert.True(t, acc.HasMeasurement("openntpd"))
@@ -114,7 +115,7 @@ func TestParseSimpleOutputServersDNSError(t *testing.T) {
 	v := &Openntpd{
 		run: OpenntpdCTL(simpleOutputServersDNSError, TestTimeout, false),
 	}
-	err := v.Gather(acc)
+	err := v.Gather(context.Background(), acc)
 
 	assert.NoError(t, err)
 	assert.True(t, acc.HasMeasurement("openntpd"))
@@ -156,7 +157,7 @@ func TestParseSimpleOutputServerDNSError(t *testing.T) {
 	v := &Openntpd{
 		run: OpenntpdCTL(simpleOutputServerDNSError, TestTimeout, false),
 	}
-	err := v.Gather(acc)
+	err := v.Gather(context.Background(), acc)
 
 	assert.NoError(t, err)
 	assert.True(t, acc.HasMeasurement("openntpd"))
@@ -184,7 +185,7 @@ func TestParseFullOutput(t *testing.T) {
 	v := &Openntpd{
 		run: OpenntpdCTL(fullOutput, TestTimeout, false),
 	}
-	err := v.Gather(acc)
+	err := v.Gather(context.Background(), acc)
 
 	assert.NoError(t, err)
 	assert.True(t, acc.HasMeasurement("openntpd"))

--- a/plugins/inputs/opensmtpd/opensmtpd.go
+++ b/plugins/inputs/opensmtpd/opensmtpd.go
@@ -3,6 +3,7 @@ package opensmtpd
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"os/exec"
 	"strconv"
@@ -75,7 +76,7 @@ func opensmtpdRunner(cmdName string, timeout internal.Duration, useSudo bool) (*
 // Accumulator
 //
 // All the dots in stat name will replaced by underscores. Histogram statistics will not be collected.
-func (s *Opensmtpd) Gather(acc cua.Accumulator) error {
+func (s *Opensmtpd) Gather(ctx context.Context, acc cua.Accumulator) error {
 	// Always exclude uptime.human statistics
 	statExcluded := []string{"uptime.human"}
 	filterExcluded, err := filter.Compile(statExcluded)

--- a/plugins/inputs/opensmtpd/opensmtpd_test.go
+++ b/plugins/inputs/opensmtpd/opensmtpd_test.go
@@ -2,6 +2,7 @@ package opensmtpd
 
 import (
 	"bytes"
+	"context"
 	"testing"
 	"time"
 
@@ -23,7 +24,7 @@ func TestFilterSomeStats(t *testing.T) {
 	v := &Opensmtpd{
 		run: SMTPCtl(fullOutput, TestTimeout, false),
 	}
-	err := v.Gather(acc)
+	err := v.Gather(context.Background(), acc)
 
 	assert.NoError(t, err)
 	assert.True(t, acc.HasMeasurement("opensmtpd"))

--- a/plugins/inputs/openweathermap/openweathermap.go
+++ b/plugins/inputs/openweathermap/openweathermap.go
@@ -1,6 +1,7 @@
 package openweathermap
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -81,7 +82,7 @@ func (n *OpenWeatherMap) Description() string {
 	return "Read current weather and forecasts data from openweathermap.org"
 }
 
-func (n *OpenWeatherMap) Gather(acc cua.Accumulator) error {
+func (n *OpenWeatherMap) Gather(ctx context.Context, acc cua.Accumulator) error {
 	var wg sync.WaitGroup
 	var strs []string
 

--- a/plugins/inputs/openweathermap/openweathermap_test.go
+++ b/plugins/inputs/openweathermap/openweathermap_test.go
@@ -1,6 +1,7 @@
 package openweathermap
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -427,7 +428,7 @@ func TestForecastGeneratesMetrics(t *testing.T) {
 
 	var acc testutil.Accumulator
 
-	err := n.Gather(&acc)
+	err := n.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expected := []cua.Metric{
@@ -512,7 +513,7 @@ func TestWeatherGeneratesMetrics(t *testing.T) {
 
 	var acc testutil.Accumulator
 
-	err := n.Gather(&acc)
+	err := n.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expected := []cua.Metric{
@@ -572,7 +573,7 @@ func TestRainMetrics(t *testing.T) {
 
 	var acc testutil.Accumulator
 
-	err := n.Gather(&acc)
+	err := n.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expected := []cua.Metric{
@@ -716,7 +717,7 @@ func TestBatchWeatherGeneratesMetrics(t *testing.T) {
 
 	var acc testutil.Accumulator
 
-	err := n.Gather(&acc)
+	err := n.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expected := []cua.Metric{

--- a/plugins/inputs/passenger/passenger.go
+++ b/plugins/inputs/passenger/passenger.go
@@ -2,6 +2,7 @@ package passenger
 
 import (
 	"bytes"
+	"context"
 	"encoding/xml"
 	"fmt"
 	"os/exec"
@@ -145,7 +146,7 @@ func (*passenger) Description() string {
 	return "Read metrics of passenger using passenger-status"
 }
 
-func (p *passenger) Gather(acc cua.Accumulator) error {
+func (p *passenger) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if p.Command == "" {
 		p.Command = "passenger-status -v --show=xml"
 	}

--- a/plugins/inputs/passenger/passenger_test.go
+++ b/plugins/inputs/passenger/passenger_test.go
@@ -1,6 +1,7 @@
 package passenger
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -44,7 +45,7 @@ func Test_Invalid_Passenger_Status_Cli(t *testing.T) {
 
 	var acc testutil.Accumulator
 
-	err := r.Gather(&acc)
+	err := r.Gather(context.Background(), &acc)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `exec: "an-invalid-command": executable file not found in `)
 }
@@ -59,7 +60,7 @@ func Test_Invalid_Xml(t *testing.T) {
 
 	var acc testutil.Accumulator
 
-	err := r.Gather(&acc)
+	err := r.Gather(context.Background(), &acc)
 	require.Error(t, err)
 	assert.Equal(t, "Cannot parse input with error: EOF", err.Error())
 }
@@ -73,7 +74,7 @@ func Test_Default_Config_Load_Default_Command(t *testing.T) {
 
 	var acc testutil.Accumulator
 
-	err := r.Gather(&acc)
+	err := r.Gather(context.Background(), &acc)
 	require.Error(t, err)
 	assert.Equal(t, err.Error(), "exec: \"passenger-status\": executable file not found in $PATH")
 }
@@ -89,7 +90,7 @@ func TestPassengerGenerateMetric(t *testing.T) {
 
 	var acc testutil.Accumulator
 
-	err := r.Gather(&acc)
+	err := r.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	tags := map[string]string{

--- a/plugins/inputs/pf/pf.go
+++ b/plugins/inputs/pf/pf.go
@@ -2,6 +2,7 @@ package pf
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"fmt"
 	"os/exec"
@@ -39,7 +40,7 @@ func (pf *PF) SampleConfig() string {
 }
 
 // Gather is the entrypoint for the plugin.
-func (pf *PF) Gather(acc cua.Accumulator) error {
+func (pf *PF) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if pf.PfctlCommand == "" {
 		var err error
 		if pf.PfctlCommand, pf.PfctlArgs, err = pf.buildPfctlCmd(); err != nil {

--- a/plugins/inputs/pgbouncer/pgbouncer.go
+++ b/plugins/inputs/pgbouncer/pgbouncer.go
@@ -2,6 +2,7 @@ package pgbouncer
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"strconv"
 
@@ -40,7 +41,7 @@ func (p *PgBouncer) Description() string {
 	return "Read metrics from one or many pgbouncer servers"
 }
 
-func (p *PgBouncer) Gather(acc cua.Accumulator) error {
+func (p *PgBouncer) Gather(ctx context.Context, acc cua.Accumulator) error {
 	var (
 		err     error
 		query   string

--- a/plugins/inputs/pgbouncer/pgbouncer_test.go
+++ b/plugins/inputs/pgbouncer/pgbouncer_test.go
@@ -1,6 +1,7 @@
 package pgbouncer
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -27,7 +28,7 @@ func TestPgBouncerGeneratesMetrics(t *testing.T) {
 
 	var acc testutil.Accumulator
 	require.NoError(t, p.Start(&acc))
-	require.NoError(t, p.Gather(&acc))
+	require.NoError(t, p.Gather(context.Background(), &acc))
 
 	intMetrics := []string{
 		"total_requests",

--- a/plugins/inputs/phpfpm/phpfpm.go
+++ b/plugins/inputs/phpfpm/phpfpm.go
@@ -3,6 +3,7 @@ package phpfpm
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -103,7 +104,7 @@ func (p *phpfpm) Init() error {
 
 // Reads stats from all configured servers accumulates stats.
 // Returns one of the errors encountered while gather stats (if any).
-func (p *phpfpm) Gather(acc cua.Accumulator) error {
+func (p *phpfpm) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if len(p.Urls) == 0 {
 		return p.gatherServer("http://127.0.0.1/status", acc)
 	}

--- a/plugins/inputs/ping/ping.go
+++ b/plugins/inputs/ping/ping.go
@@ -125,7 +125,7 @@ func (*Ping) SampleConfig() string {
 	return sampleConfig
 }
 
-func (p *Ping) Gather(acc cua.Accumulator) error {
+func (p *Ping) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if p.Interface != "" && p.listenAddr == "" {
 		p.listenAddr = getAddr(p.Interface)
 	}

--- a/plugins/inputs/postfix/postfix.go
+++ b/plugins/inputs/postfix/postfix.go
@@ -5,6 +5,7 @@
 package postfix
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -73,7 +74,7 @@ type Postfix struct {
 	QueueDirectory string
 }
 
-func (p *Postfix) Gather(acc cua.Accumulator) error {
+func (p *Postfix) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if p.QueueDirectory == "" {
 		var err error
 		p.QueueDirectory, err = getQueueDirectory()

--- a/plugins/inputs/postfix/postfix_test.go
+++ b/plugins/inputs/postfix/postfix_test.go
@@ -3,6 +3,7 @@
 package postfix
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -33,7 +34,7 @@ func TestGather(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	require.NoError(t, p.Gather(&acc))
+	require.NoError(t, p.Gather(context.Background(), &acc))
 
 	metrics := map[string]*testutil.Metric{}
 	for _, m := range acc.Metrics {

--- a/plugins/inputs/postgresql/postgresql.go
+++ b/plugins/inputs/postgresql/postgresql.go
@@ -2,6 +2,7 @@ package postgresql
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"strings"
 
@@ -66,7 +67,7 @@ func (p *Postgresql) IgnoredColumns() map[string]bool {
 	return ignoredColumns
 }
 
-func (p *Postgresql) Gather(acc cua.Accumulator) error {
+func (p *Postgresql) Gather(ctx context.Context, acc cua.Accumulator) error {
 	var (
 		err     error
 		query   string

--- a/plugins/inputs/postgresql/postgresql_test.go
+++ b/plugins/inputs/postgresql/postgresql_test.go
@@ -1,6 +1,7 @@
 package postgresql
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -27,7 +28,7 @@ func TestPostgresqlGeneratesMetrics(t *testing.T) {
 
 	var acc testutil.Accumulator
 	require.NoError(t, p.Start(&acc))
-	require.NoError(t, p.Gather(&acc))
+	require.NoError(t, p.Gather(context.Background(), &acc))
 
 	intMetrics := []string{
 		"xact_commit",
@@ -112,7 +113,7 @@ func TestPostgresqlTagsMetricsWithDatabaseName(t *testing.T) {
 	var acc testutil.Accumulator
 
 	require.NoError(t, p.Start(&acc))
-	require.NoError(t, p.Gather(&acc))
+	require.NoError(t, p.Gather(context.Background(), &acc))
 
 	point, ok := acc.Get("postgresql")
 	require.True(t, ok)
@@ -137,7 +138,7 @@ func TestPostgresqlDefaultsToAllDatabases(t *testing.T) {
 	var acc testutil.Accumulator
 
 	require.NoError(t, p.Start(&acc))
-	require.NoError(t, p.Gather(&acc))
+	require.NoError(t, p.Gather(context.Background(), &acc))
 
 	var found bool
 
@@ -169,7 +170,7 @@ func TestPostgresqlIgnoresUnwantedColumns(t *testing.T) {
 
 	var acc testutil.Accumulator
 	require.NoError(t, p.Start(&acc))
-	require.NoError(t, p.Gather(&acc))
+	require.NoError(t, p.Gather(context.Background(), &acc))
 
 	for col := range p.IgnoredColumns() {
 		assert.False(t, acc.HasMeasurement(col))
@@ -194,7 +195,7 @@ func TestPostgresqlDatabaseWhitelistTest(t *testing.T) {
 	var acc testutil.Accumulator
 
 	require.NoError(t, p.Start(&acc))
-	require.NoError(t, p.Gather(&acc))
+	require.NoError(t, p.Gather(context.Background(), &acc))
 
 	var foundTemplate0 = false
 	var foundTemplate1 = false
@@ -233,7 +234,7 @@ func TestPostgresqlDatabaseBlacklistTest(t *testing.T) {
 
 	var acc testutil.Accumulator
 	require.NoError(t, p.Start(&acc))
-	require.NoError(t, p.Gather(&acc))
+	require.NoError(t, p.Gather(context.Background(), &acc))
 
 	var foundTemplate0 = false
 	var foundTemplate1 = false

--- a/plugins/inputs/postgresql_extensible/postgresql_extensible.go
+++ b/plugins/inputs/postgresql_extensible/postgresql_extensible.go
@@ -2,6 +2,7 @@ package postgresqlextensible
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -140,7 +141,7 @@ func ReadQueryFromFile(filePath string) (string, error) {
 	return string(query), nil
 }
 
-func (p *Postgresql) Gather(acc cua.Accumulator) error {
+func (p *Postgresql) Gather(ctx context.Context, acc cua.Accumulator) error {
 	var (
 		err        error
 		sqlQuery   string

--- a/plugins/inputs/powerdns/powerdns.go
+++ b/plugins/inputs/powerdns/powerdns.go
@@ -2,6 +2,7 @@ package powerdns
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -35,7 +36,7 @@ func (p *Powerdns) Description() string {
 	return "Read metrics from one or many PowerDNS servers"
 }
 
-func (p *Powerdns) Gather(acc cua.Accumulator) error {
+func (p *Powerdns) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if len(p.UnixSockets) == 0 {
 		return p.gatherServer("/var/run/pdns.controlsocket", acc)
 	}

--- a/plugins/inputs/powerdns_recursor/powerdns_recursor.go
+++ b/plugins/inputs/powerdns_recursor/powerdns_recursor.go
@@ -2,6 +2,7 @@ package powerdnsrecursor
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -58,7 +59,7 @@ func (p *PowerdnsRecursor) Init() error {
 	return nil
 }
 
-func (p *PowerdnsRecursor) Gather(acc cua.Accumulator) error {
+func (p *PowerdnsRecursor) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if len(p.UnixSockets) == 0 {
 		return p.gatherServer("/var/run/pdns_recursor.controlsocket", acc)
 	}

--- a/plugins/inputs/processes/processes_notwindows.go
+++ b/plugins/inputs/processes/processes_notwindows.go
@@ -4,6 +4,7 @@ package processes
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -28,7 +29,7 @@ type Processes struct {
 	forceProc bool
 }
 
-func (p *Processes) Gather(acc cua.Accumulator) error {
+func (p *Processes) Gather(ctx context.Context, acc cua.Accumulator) error {
 	// Get an empty map of metric fields
 	fields := getEmptyFields()
 

--- a/plugins/inputs/processes/processes_test.go
+++ b/plugins/inputs/processes/processes_test.go
@@ -3,6 +3,7 @@
 package processes
 
 import (
+	"context"
 	"fmt"
 	"runtime"
 	"testing"
@@ -23,7 +24,7 @@ func TestProcesses(t *testing.T) {
 	}
 	var acc testutil.Accumulator
 
-	err := processes.Gather(&acc)
+	err := processes.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	assert.True(t, acc.HasInt64Field("processes", "running"))
@@ -43,7 +44,7 @@ func TestFromPS(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	err := processes.Gather(&acc)
+	err := processes.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	fields := getEmptyFields()
@@ -65,7 +66,7 @@ func TestFromPSError(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	err := processes.Gather(&acc)
+	err := processes.Gather(context.Background(), &acc)
 	require.Error(t, err)
 }
 
@@ -81,7 +82,7 @@ func TestFromProcFiles(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	err := processes.Gather(&acc)
+	err := processes.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	fields := getEmptyFields()
@@ -104,7 +105,7 @@ func TestFromProcFilesWithSpaceInCmd(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	err := processes.Gather(&acc)
+	err := processes.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	fields := getEmptyFields()
@@ -137,7 +138,7 @@ func TestParkedProcess(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	err := plugin.Gather(&acc)
+	err := plugin.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expected := []cua.Metric{

--- a/plugins/inputs/processes/processes_windows.go
+++ b/plugins/inputs/processes/processes_windows.go
@@ -16,7 +16,7 @@ func (e *Processes) Init() error {
 	return nil
 }
 
-func (e *Processes) Gather(acc cua.Accumulator) error {
+func (e *Processes) Gather(_ context.Context, _ cua.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/processes/processes_windows.go
+++ b/plugins/inputs/processes/processes_windows.go
@@ -3,6 +3,8 @@
 package processes
 
 import (
+	"context"
+
 	"github.com/circonus-labs/circonus-unified-agent/cua"
 	"github.com/circonus-labs/circonus-unified-agent/plugins/inputs"
 )

--- a/plugins/inputs/procstat/procstat.go
+++ b/plugins/inputs/procstat/procstat.go
@@ -2,6 +2,7 @@ package procstat
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -92,7 +93,7 @@ func (*Procstat) Description() string {
 	return "Monitor process cpu and memory usage"
 }
 
-func (p *Procstat) Gather(acc cua.Accumulator) error {
+func (p *Procstat) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if p.createPIDFinder == nil {
 		switch p.PidFinder {
 		case "native":

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -211,7 +211,7 @@ func (p *Prometheus) GetAllURLs() (map[string]URLAndAddress, error) {
 
 // Reads stats from all configured servers accumulates stats.
 // Returns one of the errors encountered while gather stats (if any).
-func (p *Prometheus) Gather(acc cua.Accumulator) error {
+func (p *Prometheus) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if p.client == nil {
 		client, err := p.createHTTPClient()
 		if err != nil {

--- a/plugins/inputs/prometheus/prometheus_test.go
+++ b/plugins/inputs/prometheus/prometheus_test.go
@@ -1,6 +1,7 @@
 package prometheus
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"net/http"
@@ -171,7 +172,7 @@ go_gc_duration_seconds_count 42
 
 	var acc testutil.Accumulator
 
-	err := p.Gather(&acc)
+	err := p.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expected := []cua.Metric{

--- a/plugins/inputs/proxmox/proxmox.go
+++ b/plugins/inputs/proxmox/proxmox.go
@@ -1,6 +1,7 @@
 package proxmox
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -39,7 +40,7 @@ func (px *Proxmox) Description() string {
 	return "Provides metrics from Proxmox nodes (Proxmox Virtual Environment > 6.2)."
 }
 
-func (px *Proxmox) Gather(acc cua.Accumulator) error {
+func (px *Proxmox) Gather(ctx context.Context, acc cua.Accumulator) error {
 	err := getNodeSearchDomain(px)
 	if err != nil {
 		return err

--- a/plugins/inputs/proxmox/proxmox_test.go
+++ b/plugins/inputs/proxmox/proxmox_test.go
@@ -1,6 +1,7 @@
 package proxmox
 
 import (
+	"context"
 	"net/url"
 	"strings"
 	"testing"
@@ -137,7 +138,7 @@ func TestGather(t *testing.T) {
 	px.nodeSearchDomain = "test.example.com"
 
 	acc := &testutil.Accumulator{}
-	err := px.Gather(acc)
+	err := px.Gather(context.Background(), acc)
 	require.NoError(t, err)
 
 	// Results from both tests above

--- a/plugins/inputs/puppetagent/puppetagent.go
+++ b/plugins/inputs/puppetagent/puppetagent.go
@@ -1,6 +1,7 @@
 package puppetagent
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"reflect"
@@ -82,7 +83,7 @@ func (pa *PuppetAgent) Description() string {
 }
 
 // Gather reads stats from all configured servers accumulates stats
-func (pa *PuppetAgent) Gather(acc cua.Accumulator) error {
+func (pa *PuppetAgent) Gather(ctx context.Context, acc cua.Accumulator) error {
 
 	if len(pa.Location) == 0 {
 		pa.Location = "/var/lib/puppet/state/last_run_summary.yaml"

--- a/plugins/inputs/puppetagent/puppetagent_test.go
+++ b/plugins/inputs/puppetagent/puppetagent_test.go
@@ -1,6 +1,7 @@
 package puppetagent
 
 import (
+	"context"
 	"testing"
 
 	"github.com/circonus-labs/circonus-unified-agent/testutil"
@@ -12,7 +13,7 @@ func TestGather(t *testing.T) {
 	pa := PuppetAgent{
 		Location: "last_run_summary.yaml",
 	}
-	_ = pa.Gather(&acc)
+	_ = pa.Gather(context.Background(), &acc)
 
 	tags := map[string]string{"location": "last_run_summary.yaml"}
 	fields := map[string]interface{}{

--- a/plugins/inputs/rabbitmq/rabbitmq.go
+++ b/plugins/inputs/rabbitmq/rabbitmq.go
@@ -1,6 +1,7 @@
 package rabbitmq
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -335,7 +336,7 @@ func (r *RabbitMQ) Description() string {
 }
 
 // Gather ...
-func (r *RabbitMQ) Gather(acc cua.Accumulator) error {
+func (r *RabbitMQ) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if r.Client == nil {
 		tlsCfg, err := r.ClientConfig.TLSConfig()
 		if err != nil {

--- a/plugins/inputs/raindrops/raindrops.go
+++ b/plugins/inputs/raindrops/raindrops.go
@@ -2,6 +2,7 @@ package raindrops
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -33,7 +34,7 @@ func (r *Raindrops) Description() string {
 	return "Read raindrops stats (raindrops - real-time stats for preforking Rack servers)"
 }
 
-func (r *Raindrops) Gather(acc cua.Accumulator) error {
+func (r *Raindrops) Gather(ctx context.Context, acc cua.Accumulator) error {
 	var wg sync.WaitGroup
 
 	for _, u := range r.URLs {

--- a/plugins/inputs/ras/ras.go
+++ b/plugins/inputs/ras/ras.go
@@ -4,6 +4,7 @@
 package ras
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"os"

--- a/plugins/inputs/ras/ras.go
+++ b/plugins/inputs/ras/ras.go
@@ -107,7 +107,7 @@ func (r *Ras) Stop() {
 }
 
 // Gather reads the stats provided by RASDaemon and writes it to the Accumulator.
-func (r *Ras) Gather(acc cua.Accumulator) error {
+func (r *Ras) Gather(ctx context.Context, acc cua.Accumulator) error {
 	rows, err := r.db.Query(mceQuery, r.latestTimestamp)
 	if err != nil {
 		return fmt.Errorf("ras db query: %w", err)

--- a/plugins/inputs/redfish/redfish.go
+++ b/plugins/inputs/redfish/redfish.go
@@ -1,6 +1,7 @@
 package redfish
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -247,7 +248,7 @@ func (r *Redfish) getThermal(ref string) (*Thermal, error) {
 	return thermal, nil
 }
 
-func (r *Redfish) Gather(acc cua.Accumulator) error {
+func (r *Redfish) Gather(ctx context.Context, acc cua.Accumulator) error {
 	address, _, err := net.SplitHostPort(r.baseURL.Host)
 	if err != nil {
 		address = r.baseURL.Host

--- a/plugins/inputs/redfish/redfish_test.go
+++ b/plugins/inputs/redfish/redfish_test.go
@@ -1,6 +1,7 @@
 package redfish
 
 import (
+	"context"
 	"errors"
 	"net"
 	"net/http"
@@ -473,7 +474,7 @@ func TestDellApis(t *testing.T) {
 	_ = plugin.Init()
 	var acc testutil.Accumulator
 
-	err = plugin.Gather(&acc)
+	err = plugin.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 	require.True(t, acc.HasMeasurement("redfish_thermal_temperatures"))
 	testutil.RequireMetricsEqual(t, expectedMetrics, acc.GetCUAMetrics(),
@@ -628,7 +629,7 @@ func TestHPApis(t *testing.T) {
 	_ = hpPlugin.Init()
 	var hpAcc testutil.Accumulator
 
-	err = hpPlugin.Gather(&hpAcc)
+	err = hpPlugin.Gather(context.Background(), &hpAcc)
 	require.NoError(t, err)
 	require.True(t, hpAcc.HasMeasurement("redfish_thermal_temperatures"))
 	testutil.RequireMetricsEqual(t, expectedMetricsHp, hpAcc.GetCUAMetrics(),
@@ -654,7 +655,7 @@ func TestConnection(t *testing.T) {
 
 	var acc testutil.Accumulator
 	_ = r.Init()
-	err := r.Gather(&acc)
+	err := r.Gather(context.Background(), &acc)
 
 	var uerr *url.Error
 	if !errors.As(err, &uerr) {
@@ -689,7 +690,7 @@ func TestInvalidUsernameorPassword(t *testing.T) {
 
 	var acc testutil.Accumulator
 	_ = r.Init()
-	err := r.Gather(&acc)
+	err := r.Gather(context.Background(), &acc)
 	require.Error(t, err)
 	require.EqualError(t, err, "received status code 401 (Unauthorized), expected 200")
 }
@@ -793,7 +794,7 @@ func TestInvalidDellJSON(t *testing.T) {
 		_ = plugin.Init()
 
 		var acc testutil.Accumulator
-		err := plugin.Gather(&acc)
+		err := plugin.Gather(context.Background(), &acc)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "error parsing input:")
 	}
@@ -865,7 +866,7 @@ func TestInvalidHPJSON(t *testing.T) {
 			_ = plugin.Init()
 
 			var acc testutil.Accumulator
-			err := plugin.Gather(&acc)
+			err := plugin.Gather(context.Background(), &acc)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "error parsing input:")
 		})

--- a/plugins/inputs/redis/redis.go
+++ b/plugins/inputs/redis/redis.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"net/url"
@@ -193,7 +194,7 @@ func (r *Redis) init(acc cua.Accumulator) error {
 
 // Reads stats from all configured servers accumulates stats.
 // Returns one of the errors encountered while gather stats (if any).
-func (r *Redis) Gather(acc cua.Accumulator) error {
+func (r *Redis) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if !r.initialized {
 		err := r.init(acc)
 		if err != nil {

--- a/plugins/inputs/rethinkdb/rethinkdb.go
+++ b/plugins/inputs/rethinkdb/rethinkdb.go
@@ -1,6 +1,7 @@
 package rethinkdb
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"sync"
@@ -43,7 +44,7 @@ var localhost = &Server{URL: &url.URL{Host: "127.0.0.1:28015"}}
 
 // Reads stats from all configured servers accumulates stats.
 // Returns one of the errors encountered while gather stats (if any).
-func (r *RethinkDB) Gather(acc cua.Accumulator) error {
+func (r *RethinkDB) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if len(r.Servers) == 0 {
 		_ = r.gatherServer(localhost, acc)
 		return nil

--- a/plugins/inputs/riak/riak.go
+++ b/plugins/inputs/riak/riak.go
@@ -1,6 +1,7 @@
 package riak
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -96,7 +97,7 @@ func (r *Riak) Description() string {
 }
 
 // Reads stats from all configured servers.
-func (r *Riak) Gather(acc cua.Accumulator) error {
+func (r *Riak) Gather(ctx context.Context, acc cua.Accumulator) error {
 	// Default to a single server at localhost (default port) if none specified
 	if len(r.Servers) == 0 {
 		r.Servers = []string{"http://127.0.0.1:8098"}

--- a/plugins/inputs/riak/riak_test.go
+++ b/plugins/inputs/riak/riak_test.go
@@ -1,6 +1,7 @@
 package riak
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -31,7 +32,7 @@ func TestRiak(t *testing.T) {
 	acc := &testutil.Accumulator{}
 
 	// Gather data from the test server
-	err = riak.Gather(acc)
+	err = riak.Gather(context.Background(), acc)
 	require.NoError(t, err)
 
 	// Expect the correct values for all known keys

--- a/plugins/inputs/riemann_listener/riemann_listener.go
+++ b/plugins/inputs/riemann_listener/riemann_listener.go
@@ -307,7 +307,7 @@ func (rsl *RiemannSocketListener) SampleConfig() string {
 `
 }
 
-func (rsl *RiemannSocketListener) Gather(_ cua.Accumulator) error {
+func (rsl *RiemannSocketListener) Gather(_ context.Context, _ cua.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/salesforce/salesforce.go
+++ b/plugins/inputs/salesforce/salesforce.go
@@ -1,6 +1,7 @@
 package salesforce
 
 import (
+	"context"
 	"encoding/json"
 	"encoding/xml"
 	"errors"
@@ -82,7 +83,7 @@ func (s *Salesforce) Description() string {
 }
 
 // Reads limits values from Salesforce API
-func (s *Salesforce) Gather(acc cua.Accumulator) error {
+func (s *Salesforce) Gather(ctx context.Context, acc cua.Accumulator) error {
 	limits, err := s.fetchLimits()
 	if err != nil {
 		return err

--- a/plugins/inputs/sensors/sensors.go
+++ b/plugins/inputs/sensors/sensors.go
@@ -44,7 +44,7 @@ func (*Sensors) SampleConfig() string {
 
 }
 
-func (s *Sensors) Gather(acc cua.Accumulator) error {
+func (s *Sensors) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if len(s.path) == 0 {
 		return errors.New("sensors not found: verify that lm-sensors package is installed and that sensors is in your PATH")
 	}

--- a/plugins/inputs/sensors/sensors.go
+++ b/plugins/inputs/sensors/sensors.go
@@ -3,6 +3,7 @@
 package sensors
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os/exec"

--- a/plugins/inputs/sensors/sensors_test.go
+++ b/plugins/inputs/sensors/sensors_test.go
@@ -3,6 +3,7 @@
 package sensors
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"

--- a/plugins/inputs/sensors/sensors_test.go
+++ b/plugins/inputs/sensors/sensors_test.go
@@ -22,7 +22,7 @@ func TestGatherDefault(t *testing.T) {
 	defer func() { execCommand = exec.Command }()
 	var acc testutil.Accumulator
 
-	err := s.Gather(&acc)
+	err := s.Gather(context.Background(), &acc)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -163,7 +163,7 @@ func TestGatherNotRemoveNumbers(t *testing.T) {
 	defer func() { execCommand = exec.Command }()
 	var acc testutil.Accumulator
 
-	err := s.Gather(&acc)
+	err := s.Gather(context.Background(), &acc)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/inputs/sflow/sflow.go
+++ b/plugins/inputs/sflow/sflow.go
@@ -2,6 +2,7 @@ package sflow
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -100,7 +101,7 @@ func (s *SFlow) Start(acc cua.Accumulator) error {
 }
 
 // Gather is a NOOP for sFlow as it receives, asynchronously, sFlow network packets
-func (s *SFlow) Gather(_ cua.Accumulator) error {
+func (s *SFlow) Gather(_ context.Context, _ cua.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/smart/smart.go
+++ b/plugins/inputs/smart/smart.go
@@ -2,6 +2,7 @@ package smart
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -382,7 +383,7 @@ func (m *Smart) Init() error {
 }
 
 // Gather takes in an accumulator and adds the metrics that the SMART tools gather.
-func (m *Smart) Gather(acc cua.Accumulator) error {
+func (m *Smart) Gather(ctx context.Context, acc cua.Accumulator) error {
 	var err error
 	var scannedNVMeDevices []string
 	var scannedNonNVMeDevices []string

--- a/plugins/inputs/smart/smart_test.go
+++ b/plugins/inputs/smart/smart_test.go
@@ -1,6 +1,7 @@
 package smart
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"testing"
@@ -50,7 +51,7 @@ func TestGatherAttributes(t *testing.T) {
 			s.Devices = []string{"/dev/ada0"}
 			var acc testutil.Accumulator
 
-			err := s.Gather(&acc)
+			err := s.Gather(context.Background(), &acc)
 
 			require.NoError(t, err)
 			assert.Equal(t, 65, acc.NFields(), "Wrong number of fields gathered")
@@ -67,7 +68,7 @@ func TestGatherAttributes(t *testing.T) {
 			s.Devices = []string{"/dev/nvme0"}
 			var acc testutil.Accumulator
 
-			err := s.Gather(&acc)
+			err := s.Gather(context.Background(), &acc)
 
 			require.NoError(t, err)
 			assert.Equal(t, 32, acc.NFields(), "Wrong number of fields gathered")
@@ -104,7 +105,7 @@ func TestGatherNoAttributes(t *testing.T) {
 		var acc testutil.Accumulator
 		s.PathSmartctl = "smartctl"
 
-		err := s.Gather(&acc)
+		err := s.Gather(context.Background(), &acc)
 
 		require.NoError(t, err)
 		assert.Equal(t, 8, acc.NFields(), "Wrong number of fields gathered")

--- a/plugins/inputs/snmp/snmp.go
+++ b/plugins/inputs/snmp/snmp.go
@@ -3,6 +3,7 @@ package snmp
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -337,7 +338,7 @@ func (s *Snmp) Description() string {
 // Gather retrieves all the configured fields and tables.
 // Any error encountered does not halt the process. The errors are accumulated
 // and returned at the end.
-func (s *Snmp) Gather(acc cua.Accumulator) error {
+func (s *Snmp) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if err := s.init(); err != nil {
 		return err
 	}

--- a/plugins/inputs/snmp/snmp_test.go
+++ b/plugins/inputs/snmp/snmp_test.go
@@ -2,6 +2,7 @@
 package snmp
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os/exec"
@@ -641,7 +642,7 @@ func TestGather(t *testing.T) {
 	acc := &testutil.Accumulator{}
 
 	tstart := time.Now()
-	_ = s.Gather(acc)
+	_ = s.Gather(context.Background(), acc)
 	tstop := time.Now()
 
 	require.Len(t, acc.Metrics, 2)
@@ -688,7 +689,7 @@ func TestGather_host(t *testing.T) {
 
 	acc := &testutil.Accumulator{}
 
-	_ = s.Gather(acc)
+	_ = s.Gather(context.Background(), acc)
 
 	require.Len(t, acc.Metrics, 1)
 	m := acc.Metrics[0]

--- a/plugins/inputs/snmp_dm/snmp.go
+++ b/plugins/inputs/snmp_dm/snmp.go
@@ -18,8 +18,8 @@ import (
 	"github.com/circonus-labs/circonus-unified-agent/internal"
 	"github.com/circonus-labs/circonus-unified-agent/internal/snmp"
 	"github.com/circonus-labs/circonus-unified-agent/plugins/inputs"
+	"github.com/gosnmp/gosnmp"
 	"github.com/influxdata/wlog"
-	"github.com/soniah/gosnmp"
 )
 
 const description = `Retrieves SNMP values from remote agents`

--- a/plugins/inputs/snmp_dm/snmp.go
+++ b/plugins/inputs/snmp_dm/snmp.go
@@ -129,7 +129,11 @@ func (s *Snmp) init() error {
 		return nil
 	}
 
-	dest, err := circmgr.NewMetricDestination("snmp_dm", "snmp_dm", s.InstanceID, "", s.Log)
+	id := "snmp_dm"
+	if s.InstanceID != "" {
+		id += ":" + s.InstanceID
+	}
+	dest, err := circmgr.NewMetricDestination(id, "snmp_dm "+s.InstanceID, s.InstanceID, "", s.Log)
 	if err != nil {
 		return fmt.Errorf("new metric destination: %w", err)
 	}

--- a/plugins/inputs/snmp_dm/snmp_test.go
+++ b/plugins/inputs/snmp_dm/snmp_test.go
@@ -2,6 +2,7 @@
 package snmp
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os/exec"
@@ -641,7 +642,7 @@ func TestGather(t *testing.T) {
 	acc := &testutil.Accumulator{}
 
 	tstart := time.Now()
-	_ = s.Gather(acc)
+	_ = s.Gather(context.Background(), acc)
 	tstop := time.Now()
 
 	require.Len(t, acc.Metrics, 2)
@@ -688,7 +689,7 @@ func TestGather_host(t *testing.T) {
 
 	acc := &testutil.Accumulator{}
 
-	_ = s.Gather(acc)
+	_ = s.Gather(context.Background(), acc)
 
 	require.Len(t, acc.Metrics, 1)
 	m := acc.Metrics[0]

--- a/plugins/inputs/snmp_dm/snmp_test.go
+++ b/plugins/inputs/snmp_dm/snmp_test.go
@@ -14,8 +14,8 @@ import (
 	config "github.com/circonus-labs/circonus-unified-agent/internal/snmp"
 	"github.com/circonus-labs/circonus-unified-agent/plugins/inputs"
 	"github.com/circonus-labs/circonus-unified-agent/testutil"
+	"github.com/gosnmp/gosnmp"
 	"github.com/influxdata/toml"
-	"github.com/soniah/gosnmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/plugins/inputs/snmp_trap/snmp_trap.go
+++ b/plugins/inputs/snmp_trap/snmp_trap.go
@@ -3,6 +3,7 @@ package snmptrap
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"net"
 	"os/exec"
@@ -94,7 +95,7 @@ func (s *SnmpTrap) Description() string {
 	return "Receive SNMP traps"
 }
 
-func (s *SnmpTrap) Gather(_ cua.Accumulator) error {
+func (s *SnmpTrap) Gather(_ context.Context, _ cua.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/socket_listener/socket_listener.go
+++ b/plugins/inputs/socket_listener/socket_listener.go
@@ -2,6 +2,7 @@ package socketlistener
 
 import (
 	"bufio"
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -268,7 +269,7 @@ func (sl *SocketListener) SampleConfig() string {
 `
 }
 
-func (sl *SocketListener) Gather(_ cua.Accumulator) error {
+func (sl *SocketListener) Gather(_ context.Context, _ cua.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/solr/solr.go
+++ b/plugins/inputs/solr/solr.go
@@ -1,6 +1,7 @@
 package solr
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -141,7 +142,7 @@ func (s *Solr) Description() string {
 
 // Gather reads the stats from Solr and writes it to the
 // Accumulator.
-func (s *Solr) Gather(acc cua.Accumulator) error {
+func (s *Solr) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if s.client == nil {
 		client := s.createHTTPClient()
 		s.client = client

--- a/plugins/inputs/solr/solr_test.go
+++ b/plugins/inputs/solr/solr_test.go
@@ -1,6 +1,7 @@
 package solr
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -16,7 +17,7 @@ func TestGatherStats(t *testing.T) {
 	solr := NewSolr()
 	solr.Servers = []string{ts.URL}
 	var acc testutil.Accumulator
-	require.NoError(t, solr.Gather(&acc))
+	require.NoError(t, solr.Gather(context.Background(), &acc))
 
 	acc.AssertContainsTaggedFields(t, "solr_admin",
 		solrAdminMainCoreStatusExpected,
@@ -48,7 +49,7 @@ func TestSolr7MbeansStats(t *testing.T) {
 	solr := NewSolr()
 	solr.Servers = []string{ts.URL}
 	var acc testutil.Accumulator
-	require.NoError(t, solr.Gather(&acc))
+	require.NoError(t, solr.Gather(context.Background(), &acc))
 	acc.AssertContainsTaggedFields(t, "solr_cache",
 		solr7CacheExpected,
 		map[string]string{"core": "main", "handler": "documentCache"})
@@ -59,7 +60,7 @@ func TestSolr3GatherStats(t *testing.T) {
 	solr := NewSolr()
 	solr.Servers = []string{ts.URL}
 	var acc testutil.Accumulator
-	require.NoError(t, solr.Gather(&acc))
+	require.NoError(t, solr.Gather(context.Background(), &acc))
 
 	acc.AssertContainsTaggedFields(t, "solr_admin",
 		solrAdminMainCoreStatusExpected,
@@ -90,7 +91,7 @@ func TestNoCoreDataHandling(t *testing.T) {
 	solr := NewSolr()
 	solr.Servers = []string{ts.URL}
 	var acc testutil.Accumulator
-	require.NoError(t, solr.Gather(&acc))
+	require.NoError(t, solr.Gather(context.Background(), &acc))
 
 	acc.AssertContainsTaggedFields(t, "solr_admin",
 		solrAdminMainCoreStatusExpected,

--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -1,6 +1,7 @@
 package sqlserver
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"log"
@@ -216,7 +217,7 @@ func initQueries(s *SQLServer) error {
 }
 
 // Gather collect data from SQL Server
-func (s *SQLServer) Gather(acc cua.Accumulator) error {
+func (s *SQLServer) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if !s.isInitialized {
 		if err := initQueries(s); err != nil {
 			acc.AddError(err)

--- a/plugins/inputs/sqlserver/sqlserver_test.go
+++ b/plugins/inputs/sqlserver/sqlserver_test.go
@@ -1,6 +1,7 @@
 package sqlserver
 
 import (
+	"context"
 	"strconv"
 	"strings"
 	"testing"
@@ -129,12 +130,12 @@ func TestSqlServer_MultipleInstance(t *testing.T) {
 	}
 
 	var acc, acc2 testutil.Accumulator
-	err := s.Gather(&acc)
+	err := s.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 	assert.Equal(t, s.isInitialized, true)
 	assert.Equal(t, s2.isInitialized, false)
 
-	err = s2.Gather(&acc2)
+	err = s2.Gather(context.Background(), &acc2)
 	require.NoError(t, err)
 	assert.Equal(t, s.isInitialized, true)
 	assert.Equal(t, s2.isInitialized, true)

--- a/plugins/inputs/stackdriver/stackdriver.go
+++ b/plugins/inputs/stackdriver/stackdriver.go
@@ -274,9 +274,7 @@ func (s *Stackdriver) SampleConfig() string {
 }
 
 // Gather implements cua.Input interface
-func (s *Stackdriver) Gather(acc cua.Accumulator) error {
-	ctx := context.Background()
-
+func (s *Stackdriver) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if s.RateLimit == 0 {
 		s.RateLimit = defaultRateLimit
 	}

--- a/plugins/inputs/stackdriver/stackdriver_test.go
+++ b/plugins/inputs/stackdriver/stackdriver_test.go
@@ -672,7 +672,7 @@ func TestGather(t *testing.T) {
 				},
 			}
 
-			err := s.Gather(&acc)
+			err := s.Gather(context.Background(), &acc)
 			require.NoError(t, err)
 
 			actual := []cua.Metric{}
@@ -797,7 +797,7 @@ func TestGatherAlign(t *testing.T) {
 				client: client,
 			}
 
-			err := s.Gather(&acc)
+			err := s.Gather(context.Background(), &acc)
 			require.NoError(t, err)
 
 			actual := []cua.Metric{}
@@ -1109,7 +1109,7 @@ func TestListMetricDescriptorFilter(t *testing.T) {
 			s := tt.stackdriver
 			s.client = client
 
-			err := s.Gather(&acc)
+			err := s.Gather(context.Background(), &acc)
 			require.NoError(t, err)
 
 			require.Equal(t, len(client.calls), len(tt.calls))

--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -3,6 +3,7 @@ package statsd
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -249,7 +250,7 @@ func (*Statsd) SampleConfig() string {
 	return sampleConfig
 }
 
-func (s *Statsd) Gather(acc cua.Accumulator) error {
+func (s *Statsd) Gather(ctx context.Context, acc cua.Accumulator) error {
 	s.Lock()
 	defer s.Unlock()
 	now := time.Now()

--- a/plugins/inputs/statsd/statsd_test.go
+++ b/plugins/inputs/statsd/statsd_test.go
@@ -1,6 +1,7 @@
 package statsd
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -446,7 +447,7 @@ func TestParse_Timings(t *testing.T) {
 		}
 	}
 
-	_ = s.Gather(acc)
+	_ = s.Gather(context.Background(), acc)
 
 	valid := map[string]interface{}{
 		"90_percentile": float64(11),
@@ -990,7 +991,7 @@ func TestParse_DataDogTags(t *testing.T) {
 
 			err := s.parseStatsdLine(tt.line)
 			require.NoError(t, err)
-			err = s.Gather(&acc)
+			err = s.Gather(context.Background(), &acc)
 			require.NoError(t, err)
 
 			testutil.RequireMetricsEqual(t, tt.expected, acc.GetCUAMetrics(),
@@ -1237,7 +1238,7 @@ func TestParse_TimingsMultipleFieldsWithTemplate(t *testing.T) {
 			t.Errorf("Parsing line %s should not have resulted in an error\n", line)
 		}
 	}
-	_ = s.Gather(acc)
+	_ = s.Gather(context.Background(), acc)
 
 	valid := map[string]interface{}{
 		"success_90_percentile": float64(11),
@@ -1288,7 +1289,7 @@ func TestParse_TimingsMultipleFieldsWithoutTemplate(t *testing.T) {
 			t.Errorf("Parsing line %s should not have resulted in an error\n", line)
 		}
 	}
-	_ = s.Gather(acc)
+	_ = s.Gather(context.Background(), acc)
 
 	expectedSuccess := map[string]interface{}{
 		"90_percentile": float64(11),
@@ -1459,7 +1460,7 @@ func TestParse_Timings_Delete(t *testing.T) {
 		t.Errorf("Should be 1 timing, found %d", len(s.timings))
 	}
 
-	_ = s.Gather(fakeacc)
+	_ = s.Gather(context.Background(), fakeacc)
 
 	if len(s.timings) != 0 {
 		t.Errorf("All timings should have been deleted, found %d", len(s.timings))
@@ -1484,7 +1485,7 @@ func TestParse_Gauges_Delete(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	_ = s.Gather(fakeacc)
+	_ = s.Gather(context.Background(), fakeacc)
 
 	err = testValidateGauge("current_users", 100, s.gauges)
 	if err == nil {
@@ -1510,7 +1511,7 @@ func TestParse_Sets_Delete(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	_ = s.Gather(fakeacc)
+	_ = s.Gather(context.Background(), fakeacc)
 
 	err = testValidateSet("unique_user_ids", 1, s.sets)
 	if err == nil {
@@ -1536,7 +1537,7 @@ func TestParse_Counters_Delete(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	_ = s.Gather(fakeacc)
+	_ = s.Gather(context.Background(), fakeacc)
 
 	err = testValidateCounter("total_users", 100, s.counters)
 	if err == nil {
@@ -1677,7 +1678,7 @@ func TestTCP(t *testing.T) {
 	require.NoError(t, err)
 
 	for {
-		err = statsd.Gather(&acc)
+		err = statsd.Gather(context.Background(), &acc)
 		require.NoError(t, err)
 
 		if len(acc.Metrics) > 0 {
@@ -1722,7 +1723,7 @@ func TestUdp(t *testing.T) {
 	require.NoError(t, err)
 
 	for {
-		err = statsd.Gather(&acc)
+		err = statsd.Gather(context.Background(), &acc)
 		require.NoError(t, err)
 
 		if len(acc.Metrics) > 0 {

--- a/plugins/inputs/suricata/suricata.go
+++ b/plugins/inputs/suricata/suricata.go
@@ -216,7 +216,7 @@ func (s *Suricata) parse(acc cua.Accumulator, sjson []byte) {
 
 // Gather measures and submits one full set of telemetry.
 // Not used here, submission is completely input-driven.
-func (s *Suricata) Gather(acc cua.Accumulator) error {
+func (s *Suricata) Gather(_ context.Context, _ cua.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/swap/swap.go
+++ b/plugins/inputs/swap/swap.go
@@ -1,6 +1,7 @@
 package swap
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/circonus-labs/circonus-unified-agent/cua"
@@ -18,7 +19,7 @@ func (*Stats) Description() string {
 
 func (*Stats) SampleConfig() string { return "" }
 
-func (s *Stats) Gather(acc cua.Accumulator) error {
+func (s *Stats) Gather(ctx context.Context, acc cua.Accumulator) error {
 	swap, err := s.ps.SwapStat()
 	if err != nil {
 		return fmt.Errorf("error getting swap memory info: %w", err)

--- a/plugins/inputs/swap/swap_test.go
+++ b/plugins/inputs/swap/swap_test.go
@@ -1,6 +1,7 @@
 package swap
 
 import (
+	"context"
 	"testing"
 
 	"github.com/circonus-labs/circonus-unified-agent/plugins/inputs/system"
@@ -26,7 +27,7 @@ func TestSwapStats(t *testing.T) {
 
 	mps.On("SwapStat").Return(sms, nil)
 
-	err = (&Stats{&mps}).Gather(&acc)
+	err = (&Stats{&mps}).Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	swapfields := map[string]interface{}{

--- a/plugins/inputs/synproxy/synproxy_linux.go
+++ b/plugins/inputs/synproxy/synproxy_linux.go
@@ -4,6 +4,7 @@ package synproxy
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os"
 	"strconv"

--- a/plugins/inputs/synproxy/synproxy_linux.go
+++ b/plugins/inputs/synproxy/synproxy_linux.go
@@ -12,7 +12,7 @@ import (
 	"github.com/circonus-labs/circonus-unified-agent/cua"
 )
 
-func (k *Synproxy) Gather(acc cua.Accumulator) error {
+func (k *Synproxy) Gather(ctx context.Context, acc cua.Accumulator) error {
 	data, err := k.getSynproxyStat()
 	if err != nil {
 		return err

--- a/plugins/inputs/synproxy/synproxy_notlinux.go
+++ b/plugins/inputs/synproxy/synproxy_notlinux.go
@@ -3,6 +3,8 @@
 package synproxy
 
 import (
+	"context"
+
 	"github.com/circonus-labs/circonus-unified-agent/cua"
 	"github.com/circonus-labs/circonus-unified-agent/plugins/inputs"
 )
@@ -12,7 +14,7 @@ func (k *Synproxy) Init() error {
 	return nil
 }
 
-func (k *Synproxy) Gather(acc cua.Accumulator) error {
+func (k *Synproxy) Gather(_ context.Context, _ cua.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/synproxy/synproxy_test.go
+++ b/plugins/inputs/synproxy/synproxy_test.go
@@ -3,6 +3,7 @@
 package synproxy
 
 import (
+	"context"
 	"os"
 	"testing"
 

--- a/plugins/inputs/synproxy/synproxy_test.go
+++ b/plugins/inputs/synproxy/synproxy_test.go
@@ -35,7 +35,7 @@ func TestSynproxyFileHeaderMismatch(t *testing.T) {
 	}
 
 	acc := testutil.Accumulator{}
-	err := k.Gather(&acc)
+	err := k.Gather(context.Background(), &acc)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid number of columns in data")
 }
@@ -49,7 +49,7 @@ func TestSynproxyFileInvalidHex(t *testing.T) {
 	}
 
 	acc := testutil.Accumulator{}
-	err := k.Gather(&acc)
+	err := k.Gather(context.Background(), &acc)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid value")
 }
@@ -64,7 +64,7 @@ func TestNoSynproxyFile(t *testing.T) {
 	}
 
 	acc := testutil.Accumulator{}
-	err := k.Gather(&acc)
+	err := k.Gather(context.Background(), &acc)
 	assert.Error(t, err)
 }
 
@@ -144,7 +144,7 @@ func testSynproxyFileData(t *testing.T, fileData string, cuaData map[string]inte
 	}
 
 	acc := testutil.Accumulator{}
-	err := k.Gather(&acc)
+	err := k.Gather(context.Background(), &acc)
 	assert.NoError(t, err)
 
 	acc.AssertContainsFields(t, "synproxy", cuaData)

--- a/plugins/inputs/syslog/syslog.go
+++ b/plugins/inputs/syslog/syslog.go
@@ -1,6 +1,7 @@
 package syslog
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"io"
@@ -123,7 +124,7 @@ func (s *Syslog) Description() string {
 }
 
 // Gather ...
-func (s *Syslog) Gather(_ cua.Accumulator) error {
+func (s *Syslog) Gather(_ context.Context, _ cua.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/sysstat/sysstat.go
+++ b/plugins/inputs/sysstat/sysstat.go
@@ -135,7 +135,7 @@ func (*Sysstat) SampleConfig() string {
 	return sampleConfig
 }
 
-func (s *Sysstat) Gather(acc cua.Accumulator) error {
+func (s *Sysstat) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if s.SadcInterval.Duration != 0 {
 		// Collect interval is calculated as interval - parseInterval
 		s.interval = int(s.SadcInterval.Duration.Seconds()) + parseInterval

--- a/plugins/inputs/sysstat/sysstat.go
+++ b/plugins/inputs/sysstat/sysstat.go
@@ -4,6 +4,7 @@ package sysstat
 
 import (
 	"bufio"
+	"context"
 	"encoding/csv"
 	"errors"
 	"fmt"

--- a/plugins/inputs/system/system.go
+++ b/plugins/inputs/system/system.go
@@ -3,6 +3,7 @@ package system
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -30,7 +31,7 @@ func (*Stats) SampleConfig() string {
 `
 }
 
-func (s *Stats) Gather(acc cua.Accumulator) error {
+func (s *Stats) Gather(ctx context.Context, acc cua.Accumulator) error {
 	loadavg, err := load.Avg()
 	if err != nil && !strings.Contains(err.Error(), "not implemented") {
 		return fmt.Errorf("load avg: %w", err)

--- a/plugins/inputs/systemd_units/systemd_units_linux.go
+++ b/plugins/inputs/systemd_units/systemd_units_linux.go
@@ -3,6 +3,7 @@ package systemdunits
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -135,7 +136,7 @@ func (s *SystemdUnits) SampleConfig() string {
 }
 
 // Gather parses systemctl outputs and adds counters to the Accumulator
-func (s *SystemdUnits) Gather(acc cua.Accumulator) error {
+func (s *SystemdUnits) Gather(ctx context.Context, acc cua.Accumulator) error {
 	out, err := s.systemctl(s.Timeout, s.UnitType)
 	if err != nil {
 		return err

--- a/plugins/inputs/tail/tail.go
+++ b/plugins/inputs/tail/tail.go
@@ -160,7 +160,7 @@ func (t *Tail) Init() error {
 	return fmt.Errorf("new decoder: %w", err)
 }
 
-func (t *Tail) Gather(acc cua.Accumulator) error {
+func (t *Tail) Gather(ctx context.Context, acc cua.Accumulator) error {
 	return t.tailNewFiles(true)
 }
 

--- a/plugins/inputs/tail/tail_test.go
+++ b/plugins/inputs/tail/tail_test.go
@@ -2,6 +2,7 @@ package tail
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -293,7 +294,7 @@ cpu,42
 	err = plugin.Start(&acc)
 	require.NoError(t, err)
 	defer plugin.Stop()
-	err = plugin.Gather(&acc)
+	err = plugin.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 	acc.Wait(2)
 	plugin.Stop()
@@ -349,7 +350,7 @@ func TestMultipleMetricsOnFirstLine(t *testing.T) {
 	err = plugin.Start(&acc)
 	require.NoError(t, err)
 	defer plugin.Stop()
-	err = plugin.Gather(&acc)
+	err = plugin.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 	acc.Wait(2)
 	plugin.Stop()

--- a/plugins/inputs/teamspeak/teamspeak.go
+++ b/plugins/inputs/teamspeak/teamspeak.go
@@ -1,6 +1,7 @@
 package teamspeak
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 
@@ -38,7 +39,7 @@ func (ts *Teamspeak) SampleConfig() string {
 	return sampleConfig
 }
 
-func (ts *Teamspeak) Gather(acc cua.Accumulator) error {
+func (ts *Teamspeak) Gather(ctx context.Context, acc cua.Accumulator) error {
 	var err error
 
 	if !ts.connected {

--- a/plugins/inputs/teamspeak/teamspeak_test.go
+++ b/plugins/inputs/teamspeak/teamspeak_test.go
@@ -2,6 +2,7 @@ package teamspeak
 
 import (
 	"bufio"
+	"context"
 	"net"
 	"strings"
 	"testing"
@@ -38,7 +39,7 @@ func TestGather(t *testing.T) {
 		Password:       "test",
 		VirtualServers: []int{1},
 	}
-	err = testConfig.Gather(&acc)
+	err = testConfig.Gather(context.Background(), &acc)
 
 	if err != nil {
 		t.Fatalf("Gather returned error. Error: %s\n", err)

--- a/plugins/inputs/temp/temp.go
+++ b/plugins/inputs/temp/temp.go
@@ -1,6 +1,7 @@
 package temp
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -23,7 +24,7 @@ func (t *Temperature) SampleConfig() string {
 	return sampleConfig
 }
 
-func (t *Temperature) Gather(acc cua.Accumulator) error {
+func (t *Temperature) Gather(ctx context.Context, acc cua.Accumulator) error {
 	temps, err := t.ps.Temperature()
 	if err != nil {
 		if strings.Contains(err.Error(), "not implemented yet") {

--- a/plugins/inputs/temp/temp_test.go
+++ b/plugins/inputs/temp/temp_test.go
@@ -1,6 +1,7 @@
 package temp
 
 import (
+	"context"
 	"testing"
 
 	"github.com/circonus-labs/circonus-unified-agent/plugins/inputs/system"
@@ -22,7 +23,7 @@ func TestTemperature(t *testing.T) {
 
 	mps.On("Temperature").Return([]host.TemperatureStat{ts}, nil)
 
-	err = (&Temperature{ps: &mps}).Gather(&acc)
+	err = (&Temperature{ps: &mps}).Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	expectedFields := map[string]interface{}{

--- a/plugins/inputs/tengine/tengine.go
+++ b/plugins/inputs/tengine/tengine.go
@@ -2,6 +2,7 @@ package tengine
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -50,7 +51,7 @@ func (n *Tengine) Description() string {
 	return "Read Tengine's basic status information (ngx_http_reqstat_module)"
 }
 
-func (n *Tengine) Gather(acc cua.Accumulator) error {
+func (n *Tengine) Gather(ctx context.Context, acc cua.Accumulator) error {
 	var wg sync.WaitGroup
 
 	// Create an HTTP client that is re-used for each

--- a/plugins/inputs/tomcat/tomcat.go
+++ b/plugins/inputs/tomcat/tomcat.go
@@ -1,6 +1,7 @@
 package tomcat
 
 import (
+	"context"
 	"encoding/xml"
 	"fmt"
 	"net/http"
@@ -97,7 +98,7 @@ func (s *Tomcat) SampleConfig() string {
 	return sampleconfig
 }
 
-func (s *Tomcat) Gather(acc cua.Accumulator) error {
+func (s *Tomcat) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if s.client == nil {
 		client, err := s.createHTTPClient()
 		if err != nil {

--- a/plugins/inputs/tomcat/tomcat_test.go
+++ b/plugins/inputs/tomcat/tomcat_test.go
@@ -1,6 +1,7 @@
 package tomcat
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -50,7 +51,7 @@ func TestHTTPTomcat8(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	err := tc.Gather(&acc)
+	err := tc.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	// tomcat_jvm_memory
@@ -122,7 +123,7 @@ func TestHTTPTomcat6(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	err := tc.Gather(&acc)
+	err := tc.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	// tomcat_jvm_memory

--- a/plugins/inputs/trig/trig.go
+++ b/plugins/inputs/trig/trig.go
@@ -1,6 +1,7 @@
 package trig
 
 import (
+	"context"
 	"math"
 
 	"github.com/circonus-labs/circonus-unified-agent/cua"
@@ -25,7 +26,7 @@ func (s *Trig) Description() string {
 	return "Inserts sine and cosine waves for demonstration purposes"
 }
 
-func (s *Trig) Gather(acc cua.Accumulator) error {
+func (s *Trig) Gather(ctx context.Context, acc cua.Accumulator) error {
 	sinner := math.Sin((s.x*math.Pi)/5.0) * s.Amplitude
 	cosinner := math.Cos((s.x*math.Pi)/5.0) * s.Amplitude
 

--- a/plugins/inputs/trig/trig_test.go
+++ b/plugins/inputs/trig/trig_test.go
@@ -1,6 +1,7 @@
 package trig
 
 import (
+	"context"
 	"math"
 	"testing"
 
@@ -19,7 +20,7 @@ func TestTrig(t *testing.T) {
 		sine := math.Sin((i*math.Pi)/5.0) * s.Amplitude
 		cosine := math.Cos((i*math.Pi)/5.0) * s.Amplitude
 
-		_ = s.Gather(&acc)
+		_ = s.Gather(context.Background(), &acc)
 
 		fields := make(map[string]interface{})
 		fields["sine"] = sine

--- a/plugins/inputs/twemproxy/twemproxy.go
+++ b/plugins/inputs/twemproxy/twemproxy.go
@@ -1,6 +1,7 @@
 package twemproxy
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -32,7 +33,7 @@ func (t *Twemproxy) Description() string {
 }
 
 // Gather data from all Twemproxy instances
-func (t *Twemproxy) Gather(acc cua.Accumulator) error {
+func (t *Twemproxy) Gather(ctx context.Context, acc cua.Accumulator) error {
 	conn, err := net.DialTimeout("tcp", t.Addr, 1*time.Second)
 	if err != nil {
 		return fmt.Errorf("dial (%s): %w", t.Addr, err)

--- a/plugins/inputs/twemproxy/twemproxy_test.go
+++ b/plugins/inputs/twemproxy/twemproxy_test.go
@@ -1,6 +1,7 @@
 package twemproxy
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -91,7 +92,7 @@ func TestGather(t *testing.T) {
 
 	var acc testutil.Accumulator
 	acc.SetDebug(true)
-	err = twemproxy.Gather(&acc)
+	err = twemproxy.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	var sourceData map[string]interface{}

--- a/plugins/inputs/unbound/unbound.go
+++ b/plugins/inputs/unbound/unbound.go
@@ -125,7 +125,7 @@ func unboundRunner(cmdName string, timeout internal.Duration, useSudo bool, serv
 // Gather collects stats from unbound-control and adds them to the Accumulator
 //
 // All the dots in stat name will replaced by underscores. Histogram statistics will not be collected.
-func (s *Unbound) Gather(acc cua.Accumulator) error {
+func (s *Unbound) Gather(ctx context.Context, acc cua.Accumulator) error {
 
 	// Always exclude histogram statistics
 	statExcluded := []string{"histogram.*"}

--- a/plugins/inputs/unbound/unbound_test.go
+++ b/plugins/inputs/unbound/unbound_test.go
@@ -2,6 +2,7 @@ package unbound
 
 import (
 	"bytes"
+	"context"
 	"testing"
 	"time"
 
@@ -23,7 +24,7 @@ func TestParseFullOutput(t *testing.T) {
 	v := &Unbound{
 		run: UnboundControl(fullOutput, TestTimeout, true, "", false, ""),
 	}
-	err := v.Gather(acc)
+	err := v.Gather(context.Background(), acc)
 
 	assert.NoError(t, err)
 
@@ -41,7 +42,7 @@ func TestParseFullOutputThreadAsTag(t *testing.T) {
 		run:         UnboundControl(fullOutput, TestTimeout, true, "", true, ""),
 		ThreadAsTag: true,
 	}
-	err := v.Gather(acc)
+	err := v.Gather(context.Background(), acc)
 
 	assert.NoError(t, err)
 

--- a/plugins/inputs/uwsgi/uwsgi.go
+++ b/plugins/inputs/uwsgi/uwsgi.go
@@ -3,6 +3,7 @@
 package uwsgi
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -48,7 +49,7 @@ func (u *Uwsgi) SampleConfig() string {
 }
 
 // Gather collect data from uWSGI Server
-func (u *Uwsgi) Gather(acc cua.Accumulator) error {
+func (u *Uwsgi) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if u.client == nil {
 		u.client = &http.Client{
 			Timeout: u.Timeout.Duration,

--- a/plugins/inputs/uwsgi/uwsgi_test.go
+++ b/plugins/inputs/uwsgi/uwsgi_test.go
@@ -1,6 +1,7 @@
 package uwsgi_test
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -122,7 +123,7 @@ func TestBasic(t *testing.T) {
 		Servers: []string{fakeServer.URL + "/"},
 	}
 	var acc testutil.Accumulator
-	_ = plugin.Gather(&acc)
+	_ = plugin.Gather(context.Background(), &acc)
 	require.Equal(t, 0, len(acc.Errors))
 }
 
@@ -153,7 +154,7 @@ func TestInvalidJSON(t *testing.T) {
 		Servers: []string{fakeServer.URL + "/"},
 	}
 	var acc testutil.Accumulator
-	_ = plugin.Gather(&acc)
+	_ = plugin.Gather(context.Background(), &acc)
 	require.Equal(t, 1, len(acc.Errors))
 }
 
@@ -162,7 +163,7 @@ func TestHttpError(t *testing.T) {
 		Servers: []string{"http://novalidurladress/"},
 	}
 	var acc testutil.Accumulator
-	_ = plugin.Gather(&acc)
+	_ = plugin.Gather(context.Background(), &acc)
 	require.Equal(t, 1, len(acc.Errors))
 }
 
@@ -171,7 +172,7 @@ func TestTcpError(t *testing.T) {
 		Servers: []string{"tcp://novalidtcpadress/"},
 	}
 	var acc testutil.Accumulator
-	_ = plugin.Gather(&acc)
+	_ = plugin.Gather(context.Background(), &acc)
 	require.Equal(t, 1, len(acc.Errors))
 }
 
@@ -180,6 +181,6 @@ func TestUnixSocketError(t *testing.T) {
 		Servers: []string{"unix:///novalidunixsocket"},
 	}
 	var acc testutil.Accumulator
-	_ = plugin.Gather(&acc)
+	_ = plugin.Gather(context.Background(), &acc)
 	require.Equal(t, 1, len(acc.Errors))
 }

--- a/plugins/inputs/varnish/varnish.go
+++ b/plugins/inputs/varnish/varnish.go
@@ -5,6 +5,7 @@ package varnish
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"os/exec"
 	"strconv"
@@ -98,7 +99,7 @@ func varnishRunner(cmdName string, useSudo bool, instanceName string, timeout in
 // The prefix of each stat (eg MAIN, MEMPOOL, LCK, etc) will be used as a
 // 'section' tag and all stats that share that prefix will be reported as fields
 // with that tag
-func (s *Varnish) Gather(acc cua.Accumulator) error {
+func (s *Varnish) Gather(ctx context.Context, acc cua.Accumulator) error {
 	if s.filter == nil {
 		var err error
 		if len(s.Stats) == 0 {

--- a/plugins/inputs/varnish/varnish_test.go
+++ b/plugins/inputs/varnish/varnish_test.go
@@ -4,6 +4,7 @@ package varnish
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -26,7 +27,7 @@ func TestGather(t *testing.T) {
 		run:   fakeVarnishStat(smOutput, false, "", internal.Duration{Duration: time.Second}),
 		Stats: []string{"*"},
 	}
-	_ = v.Gather(acc)
+	_ = v.Gather(context.Background(), acc)
 
 	acc.HasMeasurement("varnish")
 	for tag, fields := range parsedSmOutput {
@@ -42,7 +43,7 @@ func TestParseFullOutput(t *testing.T) {
 		run:   fakeVarnishStat(fullOutput, true, "", internal.Duration{Duration: time.Second}),
 		Stats: []string{"*"},
 	}
-	err := v.Gather(acc)
+	err := v.Gather(context.Background(), acc)
 
 	assert.NoError(t, err)
 	acc.HasMeasurement("varnish")
@@ -57,7 +58,7 @@ func TestFilterSomeStats(t *testing.T) {
 		run:   fakeVarnishStat(fullOutput, false, "", internal.Duration{Duration: time.Second}),
 		Stats: []string{"MGT.*", "VBE.*"},
 	}
-	err := v.Gather(acc)
+	err := v.Gather(context.Background(), acc)
 
 	assert.NoError(t, err)
 	acc.HasMeasurement("varnish")
@@ -80,7 +81,7 @@ func TestFieldConfig(t *testing.T) {
 			run:   fakeVarnishStat(fullOutput, true, "", internal.Duration{Duration: time.Second}),
 			Stats: strings.Split(fieldCfg, ","),
 		}
-		err := v.Gather(acc)
+		err := v.Gather(context.Background(), acc)
 
 		assert.NoError(t, err)
 		acc.HasMeasurement("varnish")

--- a/plugins/inputs/vsphere/vsphere.go
+++ b/plugins/inputs/vsphere/vsphere.go
@@ -308,7 +308,7 @@ func (v *VSphere) Stop() {
 
 // Gather is the main data collection function called by the agent core. It performs all
 // the data collection and writes all metrics into the Accumulator passed as an argument.
-func (v *VSphere) Gather(acc cua.Accumulator) error {
+func (v *VSphere) Gather(ctx context.Context, acc cua.Accumulator) error {
 	var wg sync.WaitGroup
 	for _, ep := range v.endpoints {
 		wg.Add(1)

--- a/plugins/inputs/vsphere/vsphere_test.go
+++ b/plugins/inputs/vsphere/vsphere_test.go
@@ -495,7 +495,7 @@ func testCollection(t *testing.T, excludeClusters bool) {
 
 	require.NoError(t, v.Start(&acc))
 	defer v.Stop()
-	require.NoError(t, v.Gather(&acc))
+	require.NoError(t, v.Gather(context.Background(), &acc))
 	require.Equal(t, 0, len(acc.Errors), fmt.Sprintf("Errors found: %s", acc.Errors))
 	require.True(t, len(acc.Metrics) > 0, "No metrics were collected")
 	cache := make(map[string]string)

--- a/plugins/inputs/webhooks/webhooks.go
+++ b/plugins/inputs/webhooks/webhooks.go
@@ -1,6 +1,7 @@
 package webhooks
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -74,7 +75,7 @@ func (*Webhooks) Description() string {
 	return "A Webhooks Event collector"
 }
 
-func (*Webhooks) Gather(_ cua.Accumulator) error {
+func (*Webhooks) Gather(_ context.Context, _ cua.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/win_eventlog/win_eventlog.go
+++ b/plugins/inputs/win_eventlog/win_eventlog.go
@@ -133,7 +133,7 @@ func (w *WinEventLog) SampleConfig() string {
 }
 
 // Gather Windows Event Log entries
-func (w *WinEventLog) Gather(acc cua.Accumulator) error {
+func (w *WinEventLog) Gather(ctx context.Context, acc cua.Accumulator) error {
 
 	var err error
 	if w.subscription == 0 {

--- a/plugins/inputs/win_eventlog/win_eventlog.go
+++ b/plugins/inputs/win_eventlog/win_eventlog.go
@@ -7,6 +7,7 @@ package wineventlog
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/xml"
 	"errors"
 	"fmt"

--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -3,6 +3,7 @@
 package winperfcounters
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"

--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -339,7 +339,7 @@ func (m *WinPerfCounters) ParseConfig() error {
 	return err
 }
 
-func (m *WinPerfCounters) Gather(acc cua.Accumulator) error {
+func (m *WinPerfCounters) Gather(ctx context.Context, acc cua.Accumulator) error {
 	// Parse the config once
 	var err error
 

--- a/plugins/inputs/win_perf_counters/win_perf_counters_integration_test.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters_integration_test.go
@@ -3,6 +3,7 @@
 package winperfcounters
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -476,7 +477,7 @@ func TestWinPerfcountersConfigError2(t *testing.T) {
 
 	_ = m.ParseConfig()
 	var acc testutil.Accumulator
-	err := m.Gather(&acc)
+	err := m.Gather(context.Background(), &acc)
 	require.Error(t, err)
 }
 
@@ -544,11 +545,11 @@ func TestWinPerfcountersCollect1(t *testing.T) {
 
 	m := WinPerfCounters{PrintValid: false, Object: perfobjects, query: &PerformanceQueryImpl{}}
 	var acc testutil.Accumulator
-	err := m.Gather(&acc)
+	err := m.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	time.Sleep(2000 * time.Millisecond)
-	err = m.Gather(&acc)
+	err = m.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 	assert.Len(t, acc.Metrics, 2)
 
@@ -590,11 +591,11 @@ func TestWinPerfcountersCollect2(t *testing.T) {
 
 	m := WinPerfCounters{PrintValid: false, UsePerfCounterTime: true, Object: perfobjects, query: &PerformanceQueryImpl{}, UseWildcardsExpansion: true}
 	var acc testutil.Accumulator
-	err := m.Gather(&acc)
+	err := m.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	time.Sleep(2000 * time.Millisecond)
-	err = m.Gather(&acc)
+	err = m.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	assert.Len(t, acc.Metrics, 4)

--- a/plugins/inputs/win_perf_counters/win_perf_counters_test.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters_test.go
@@ -524,7 +524,7 @@ func TestSimpleGather(t *testing.T) {
 			vistaAndNewer: false,
 		}}
 	var acc1 testutil.Accumulator
-	err = m.Gather(&acc1)
+	err = m.Gather(context.Background(), &acc1)
 	require.NoError(t, err)
 
 	fields1 := map[string]interface{}{
@@ -542,7 +542,7 @@ func TestSimpleGather(t *testing.T) {
 
 	var acc2 testutil.Accumulator
 
-	err = m.Gather(&acc2)
+	err = m.Gather(context.Background(), &acc2)
 	require.NoError(t, err)
 	acc1.AssertContainsTaggedFields(t, measurement, fields1, tags1)
 }
@@ -567,7 +567,7 @@ func TestSimpleGatherNoData(t *testing.T) {
 			vistaAndNewer: false,
 		}}
 	var acc1 testutil.Accumulator
-	err = m.Gather(&acc1)
+	err = m.Gather(context.Background(), &acc1)
 	// this "PDH_NO_DATA" error should not be returned to caller, but checked, and handled
 	require.NoError(t, err)
 
@@ -588,7 +588,7 @@ func TestSimpleGatherNoData(t *testing.T) {
 
 	var acc2 testutil.Accumulator
 
-	err = m.Gather(&acc2)
+	err = m.Gather(context.Background(), &acc2)
 	require.NoError(t, err)
 	acc1.AssertDoesNotContainsTaggedFields(t, measurement, fields1, tags1)
 }
@@ -614,7 +614,7 @@ func TestSimpleGatherWithTimestamp(t *testing.T) {
 			vistaAndNewer: true,
 		}}
 	var acc1 testutil.Accumulator
-	err = m.Gather(&acc1)
+	err = m.Gather(context.Background(), &acc1)
 	require.NoError(t, err)
 
 	fields1 := map[string]interface{}{
@@ -649,7 +649,7 @@ func TestGatherError(t *testing.T) {
 			vistaAndNewer: false,
 		}}
 	var acc1 testutil.Accumulator
-	err = m.Gather(&acc1)
+	err = m.Gather(context.Background(), &acc1)
 	require.Error(t, err)
 	require.Equal(t, expectedError, err.Error())
 
@@ -659,7 +659,7 @@ func TestGatherError(t *testing.T) {
 
 	var acc2 testutil.Accumulator
 
-	err = m.Gather(&acc2)
+	err = m.Gather(context.Background(), &acc2)
 	require.Error(t, err)
 	require.Equal(t, expectedError, err.Error())
 }
@@ -686,7 +686,7 @@ func TestGatherInvalidDataIgnore(t *testing.T) {
 			vistaAndNewer: false,
 		}}
 	var acc1 testutil.Accumulator
-	err = m.Gather(&acc1)
+	err = m.Gather(context.Background(), &acc1)
 	require.NoError(t, err)
 
 	fields1 := map[string]interface{}{
@@ -704,7 +704,7 @@ func TestGatherInvalidDataIgnore(t *testing.T) {
 	m.lastRefreshed = time.Time{}
 
 	var acc2 testutil.Accumulator
-	err = m.Gather(&acc2)
+	err = m.Gather(context.Background(), &acc2)
 	require.NoError(t, err)
 	acc1.AssertContainsTaggedFields(t, measurement, fields1, tags1)
 }
@@ -734,7 +734,7 @@ func TestGatherRefreshingWithExpansion(t *testing.T) {
 		CountersRefreshInterval: internal.Duration{Duration: time.Second * 10},
 	}
 	var acc1 testutil.Accumulator
-	err = m.Gather(&acc1)
+	err = m.Gather(context.Background(), &acc1)
 	assert.Len(t, m.counters, 4)
 	require.NoError(t, err)
 	assert.Len(t, acc1.Metrics, 2)
@@ -780,7 +780,7 @@ func TestGatherRefreshingWithExpansion(t *testing.T) {
 	}
 
 	// test before elapsing CounterRefreshRate counters are not refreshed
-	err = m.Gather(&acc2)
+	err = m.Gather(context.Background(), &acc2)
 	require.NoError(t, err)
 	assert.Len(t, m.counters, 4)
 	assert.Len(t, acc2.Metrics, 2)
@@ -791,7 +791,7 @@ func TestGatherRefreshingWithExpansion(t *testing.T) {
 	time.Sleep(m.CountersRefreshInterval.Duration)
 
 	var acc3 testutil.Accumulator
-	err = m.Gather(&acc3)
+	err = m.Gather(context.Background(), &acc3)
 	require.NoError(t, err)
 	assert.Len(t, acc3.Metrics, 3)
 
@@ -826,7 +826,7 @@ func TestGatherRefreshingWithoutExpansion(t *testing.T) {
 		query:                   fpm,
 		CountersRefreshInterval: internal.Duration{Duration: time.Second * 10}}
 	var acc1 testutil.Accumulator
-	err = m.Gather(&acc1)
+	err = m.Gather(context.Background(), &acc1)
 	assert.Len(t, m.counters, 2)
 	require.NoError(t, err)
 	assert.Len(t, acc1.Metrics, 2)
@@ -874,7 +874,7 @@ func TestGatherRefreshingWithoutExpansion(t *testing.T) {
 	}
 
 	// test before elapsing CounterRefreshRate counters are not refreshed
-	err = m.Gather(&acc2)
+	err = m.Gather(context.Background(), &acc2)
 	require.NoError(t, err)
 	assert.Len(t, m.counters, 2)
 	assert.Len(t, acc2.Metrics, 3)
@@ -902,7 +902,7 @@ func TestGatherRefreshingWithoutExpansion(t *testing.T) {
 	time.Sleep(m.CountersRefreshInterval.Duration)
 
 	var acc3 testutil.Accumulator
-	err = m.Gather(&acc3)
+	err = m.Gather(context.Background(), &acc3)
 	require.NoError(t, err)
 	assert.Len(t, acc3.Metrics, 2)
 	fields4 := map[string]interface{}{
@@ -948,7 +948,7 @@ func TestGatherTotalNoExpansion(t *testing.T) {
 			vistaAndNewer: true,
 		}}
 	var acc1 testutil.Accumulator
-	err = m.Gather(&acc1)
+	err = m.Gather(context.Background(), &acc1)
 	require.NoError(t, err)
 	assert.Len(t, m.counters, 2)
 	assert.Len(t, acc1.Metrics, 2)
@@ -978,7 +978,7 @@ func TestGatherTotalNoExpansion(t *testing.T) {
 	m.lastRefreshed = time.Time{}
 
 	var acc2 testutil.Accumulator
-	err = m.Gather(&acc2)
+	err = m.Gather(context.Background(), &acc2)
 	require.NoError(t, err)
 	assert.Len(t, m.counters, 2)
 	assert.Len(t, acc2.Metrics, 1)

--- a/plugins/inputs/win_perf_counters/win_perf_counters_test.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters_test.go
@@ -3,6 +3,7 @@
 package winperfcounters
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"

--- a/plugins/inputs/win_services/win_services.go
+++ b/plugins/inputs/win_services/win_services.go
@@ -3,6 +3,7 @@
 package winservices
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"

--- a/plugins/inputs/win_services/win_services.go
+++ b/plugins/inputs/win_services/win_services.go
@@ -111,7 +111,7 @@ func (m *WinServices) SampleConfig() string {
 	return sampleConfig
 }
 
-func (m *WinServices) Gather(acc cua.Accumulator) error {
+func (m *WinServices) Gather(ctx context.Context, acc cua.Accumulator) error {
 	scmgr, err := m.mgrProvider.Connect()
 	if err != nil {
 		return fmt.Errorf("could not open service manager: %w", err)

--- a/plugins/inputs/win_services/win_services_integration_test.go
+++ b/plugins/inputs/win_services/win_services_integration_test.go
@@ -4,6 +4,7 @@
 package winservices
 
 import (
+	"context"
 	"testing"
 
 	"github.com/circonus-labs/circonus-unified-agent/testutil"
@@ -54,6 +55,6 @@ func TestGatherErrors(t *testing.T) {
 	}
 	require.Len(t, ws.ServiceNames, 3, "Different number of services")
 	var acc testutil.Accumulator
-	require.NoError(t, ws.Gather(&acc))
+	require.NoError(t, ws.Gather(context.Background(), &acc))
 	require.Len(t, acc.Errors, 3, "There should be 3 errors after gather")
 }

--- a/plugins/inputs/win_services/win_services_test.go
+++ b/plugins/inputs/win_services/win_services_test.go
@@ -134,14 +134,14 @@ func TestMgrErrors(t *testing.T) {
 	// mgr.connect error
 	winServices := &WinServices{testutil.Logger{}, nil, &FakeMgProvider{testErrors[0]}}
 	var acc1 testutil.Accumulator
-	err := winServices.Gather(&acc1)
+	err := winServices.Gather(context.Background(), &acc1)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), testErrors[0].mgrConnectError.Error())
 
 	// mgr.listServices error
 	winServices = &WinServices{testutil.Logger{}, nil, &FakeMgProvider{testErrors[1]}}
 	var acc2 testutil.Accumulator
-	err = winServices.Gather(&acc2)
+	err = winServices.Gather(context.Background(), &acc2)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), testErrors[1].mgrListServicesError.Error())
 
@@ -151,7 +151,7 @@ func TestMgrErrors(t *testing.T) {
 
 	buf := &bytes.Buffer{}
 	log.SetOutput(buf)
-	require.NoError(t, winServices.Gather(&acc3))
+	require.NoError(t, winServices.Gather(context.Background(), &acc3))
 
 	require.Contains(t, buf.String(), testErrors[2].services[0].serviceOpenError.Error())
 }
@@ -162,7 +162,7 @@ func TestServiceErrors(t *testing.T) {
 
 	buf := &bytes.Buffer{}
 	log.SetOutput(buf)
-	require.NoError(t, winServices.Gather(&acc1))
+	require.NoError(t, winServices.Gather(context.Background(), &acc1))
 
 	// open service error
 	require.Contains(t, buf.String(), testErrors[2].services[0].serviceOpenError.Error())
@@ -182,7 +182,7 @@ var testSimpleData = []testData{
 func TestGather2(t *testing.T) {
 	winServices := &WinServices{testutil.Logger{}, nil, &FakeMgProvider{testSimpleData[0]}}
 	var acc1 testutil.Accumulator
-	require.NoError(t, winServices.Gather(&acc1))
+	require.NoError(t, winServices.Gather(context.Background(), &acc1))
 	assert.Len(t, acc1.Errors, 0, "There should be no errors after gather")
 
 	for _, s := range testSimpleData[0].services {

--- a/plugins/inputs/win_services/win_services_test.go
+++ b/plugins/inputs/win_services/win_services_test.go
@@ -4,6 +4,7 @@ package winservices
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"log"

--- a/plugins/inputs/wireguard/wireguard.go
+++ b/plugins/inputs/wireguard/wireguard.go
@@ -1,6 +1,7 @@
 package wireguard
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -54,7 +55,7 @@ func (wg *Wireguard) Init() error {
 	return nil
 }
 
-func (wg *Wireguard) Gather(acc cua.Accumulator) error {
+func (wg *Wireguard) Gather(ctx context.Context, acc cua.Accumulator) error {
 	devices, err := wg.enumerateDevices()
 	if err != nil {
 		return fmt.Errorf("error enumerating Wireguard devices: %w", err)

--- a/plugins/inputs/wireless/wireless_linux.go
+++ b/plugins/inputs/wireless/wireless_linux.go
@@ -4,6 +4,7 @@ package wireless
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"log"
 	"os"

--- a/plugins/inputs/wireless/wireless_linux.go
+++ b/plugins/inputs/wireless/wireless_linux.go
@@ -41,7 +41,7 @@ type wirelessInterface struct {
 }
 
 // Gather collects the wireless information.
-func (w *Wireless) Gather(acc cua.Accumulator) error {
+func (w *Wireless) Gather(ctx context.Context, acc cua.Accumulator) error {
 	// load proc path, get default value if config value and env variable are empty
 	w.loadPath()
 

--- a/plugins/inputs/wireless/wireless_notlinux.go
+++ b/plugins/inputs/wireless/wireless_notlinux.go
@@ -3,6 +3,8 @@
 package wireless
 
 import (
+	"context"
+
 	"github.com/circonus-labs/circonus-unified-agent/cua"
 	"github.com/circonus-labs/circonus-unified-agent/plugins/inputs"
 )
@@ -12,7 +14,7 @@ func (w *Wireless) Init() error {
 	return nil
 }
 
-func (w *Wireless) Gather(acc cua.Accumulator) error {
+func (w *Wireless) Gather(_ context.Context, _ cua.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/x509_cert/x509_cert.go
+++ b/plugins/inputs/x509_cert/x509_cert.go
@@ -3,6 +3,7 @@ package x509cert
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
@@ -192,7 +193,7 @@ func getTags(cert *x509.Certificate, location string) map[string]string {
 }
 
 // Gather adds metrics into the accumulator.
-func (c *X509Cert) Gather(acc cua.Accumulator) error {
+func (c *X509Cert) Gather(ctx context.Context, acc cua.Accumulator) error {
 	now := time.Now()
 
 	for _, location := range c.Sources {

--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -1,6 +1,7 @@
 package x509cert
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/base64"
 	"fmt"
@@ -118,7 +119,7 @@ func TestGatherRemote(t *testing.T) {
 			testErr := false
 
 			acc := testutil.Accumulator{}
-			err = sc.Gather(&acc)
+			err = sc.Gather(context.Background(), &acc)
 			if len(acc.Errors) > 0 {
 				testErr = true
 			}
@@ -190,7 +191,7 @@ func TestGatherLocal(t *testing.T) {
 			error := false
 
 			acc := testutil.Accumulator{}
-			err = sc.Gather(&acc)
+			err = sc.Gather(context.Background(), &acc)
 			if len(acc.Errors) > 0 {
 				error = true
 			}
@@ -228,7 +229,7 @@ func TestTags(t *testing.T) {
 	_ = sc.Init()
 
 	acc := testutil.Accumulator{}
-	err = sc.Gather(&acc)
+	err = sc.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	assert.True(t, acc.HasMeasurement("x509_cert"))
@@ -296,7 +297,7 @@ func TestGatherChain(t *testing.T) {
 			error := false
 
 			acc := testutil.Accumulator{}
-			err = sc.Gather(&acc)
+			err = sc.Gather(context.Background(), &acc)
 			if err != nil {
 				error = true
 			}
@@ -344,7 +345,7 @@ func TestGatherCert(t *testing.T) {
 	_ = m.Init()
 
 	var acc testutil.Accumulator
-	err := m.Gather(&acc)
+	err := m.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	assert.True(t, acc.HasMeasurement("x509_cert"))

--- a/plugins/inputs/zfs/zfs_freebsd.go
+++ b/plugins/inputs/zfs/zfs_freebsd.go
@@ -128,7 +128,7 @@ func (z *Zfs) gatherDatasetStats(acc cua.Accumulator) (string, error) {
 	return strings.Join(datasets, "::"), nil
 }
 
-func (z *Zfs) Gather(acc cua.Accumulator) error {
+func (z *Zfs) Gather(ctx context.Context, acc cua.Accumulator) error {
 	kstatMetrics := z.KstatMetrics
 	if len(kstatMetrics) == 0 {
 		kstatMetrics = []string{"arcstats", "zfetchstats", "vdev_cache_stats"}

--- a/plugins/inputs/zfs/zfs_freebsd.go
+++ b/plugins/inputs/zfs/zfs_freebsd.go
@@ -4,6 +4,8 @@ package zfs
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strconv"
@@ -45,19 +47,19 @@ func (z *Zfs) gatherPoolStats(acc cua.Accumulator) (string, error) {
 
 				size, err := strconv.ParseInt(col[2], 10, 64)
 				if err != nil {
-					return "", fmt.Errorf("Error parsing size: %s", err)
+					return "", fmt.Errorf("Error parsing size: %w", err)
 				}
 				fields["size"] = size
 
 				alloc, err := strconv.ParseInt(col[3], 10, 64)
 				if err != nil {
-					return "", fmt.Errorf("Error parsing allocation: %s", err)
+					return "", fmt.Errorf("Error parsing allocation: %w", err)
 				}
 				fields["allocated"] = alloc
 
 				free, err := strconv.ParseInt(col[4], 10, 64)
 				if err != nil {
-					return "", fmt.Errorf("Error parsing free: %s", err)
+					return "", fmt.Errorf("Error parsing free: %w", err)
 				}
 				fields["free"] = free
 
@@ -69,13 +71,13 @@ func (z *Zfs) gatherPoolStats(acc cua.Accumulator) (string, error) {
 
 				capval, err := strconv.ParseInt(col[6], 10, 0)
 				if err != nil {
-					return "", fmt.Errorf("Error parsing capacity: %s", err)
+					return "", fmt.Errorf("Error parsing capacity: %w", err)
 				}
 				fields["capacity"] = capval
 
 				dedup, err := strconv.ParseFloat(strings.TrimSuffix(col[7], "x"), 32)
 				if err != nil {
-					return "", fmt.Errorf("Error parsing dedupratio: %s", err)
+					return "", fmt.Errorf("Error parsing dedupratio: %w", err)
 				}
 				fields["dedupratio"] = dedup
 			}
@@ -116,7 +118,7 @@ func (z *Zfs) gatherDatasetStats(acc cua.Accumulator) (string, error) {
 			for i, key := range properties[1:] {
 				value, err := strconv.ParseInt(col[i+1], 10, 64)
 				if err != nil {
-					return "", fmt.Errorf("Error parsing %s %q: %s", key, col[i+1], err)
+					return "", fmt.Errorf("Error parsing %s %q: %w", key, col[i+1], err)
 				}
 				fields[key] = value
 			}
@@ -174,9 +176,13 @@ func run(command string, args ...string) ([]string, error) {
 	stdout := strings.TrimSpace(outbuf.String())
 	stderr := strings.TrimSpace(errbuf.String())
 
-	if _, ok := err.(*exec.ExitError); ok {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
 		return nil, fmt.Errorf("%s error: %s", command, stderr)
 	}
+	// if _, ok := err.(*exec.ExitError); ok {
+	// 	return nil, fmt.Errorf("%s error: %s", command, stderr)
+	// }
 	return strings.Split(stdout, "\n"), nil
 }
 

--- a/plugins/inputs/zfs/zfs_freebsd_test.go
+++ b/plugins/inputs/zfs/zfs_freebsd_test.go
@@ -3,6 +3,7 @@
 package zfs
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -11,60 +12,60 @@ import (
 )
 
 // $ zpool list -Hp -o name,health,size,alloc,free,fragmentation,capacity,dedupratio
-var zpool_output = []string{
+var zpoolOutput = []string{
 	"freenas-boot	ONLINE	30601641984	2022177280	28579464704	-	6	1.00x",
 	"red1	ONLINE	8933531975680	1126164848640	7807367127040	8%	12	1.83x",
 	"temp1	ONLINE	2989297238016	1626309320704	1362987917312	38%	54	1.28x",
 	"temp2	ONLINE	2989297238016	626958278656	2362338959360	12%	20	1.00x",
 }
 
-func mock_zpool() ([]string, error) {
-	return zpool_output, nil
+func mockZpool() ([]string, error) {
+	return zpoolOutput, nil
 }
 
 // $ zpool list -Hp -o name,health,size,alloc,free,fragmentation,capacity,dedupratio
-var zpool_output_unavail = []string{
+var zpoolOutputUnavail = []string{
 	"temp2	UNAVAIL	-	-	-	-	-	-",
 }
 
-func mock_zpool_unavail() ([]string, error) {
-	return zpool_output_unavail, nil
+func mockZpoolUnavail() ([]string, error) {
+	return zpoolOutputUnavail, nil
 }
 
 // $ zfs list -Hp -o name,avail,used,usedsnap,usedds
-var zdataset_output = []string{
+var zdatasetOutput = []string{
 	"zata    10741741326336  8564135526400   0       90112",
 	"zata/home       10741741326336  2498560 212992  2285568",
 	"zata/import     10741741326336  196608  81920   114688",
 	"zata/storage    10741741326336  8556084379648   3601138999296   4954945380352",
 }
 
-func mock_zdataset() ([]string, error) {
-	return zdataset_output, nil
+func mockZdataset(properties []string) ([]string, error) {
+	return zdatasetOutput, nil
 }
 
 // sysctl -q kstat.zfs.misc.arcstats
 
 // sysctl -q kstat.zfs.misc.vdev_cache_stats
-var kstat_vdev_cache_stats_output = []string{
+var kstatVdevCacheStatsOutput = []string{
 	"kstat.zfs.misc.vdev_cache_stats.misses: 87789",
 	"kstat.zfs.misc.vdev_cache_stats.hits: 465583",
 	"kstat.zfs.misc.vdev_cache_stats.delegations: 6952",
 }
 
 // sysctl -q kstat.zfs.misc.zfetchstats
-var kstat_zfetchstats_output = []string{
+var kstatZfetchstatsOutput = []string{
 	"kstat.zfs.misc.zfetchstats.max_streams: 0",
 	"kstat.zfs.misc.zfetchstats.misses: 0",
 	"kstat.zfs.misc.zfetchstats.hits: 0",
 }
 
-func mock_sysctl(metric string) ([]string, error) {
+func mockSysctl(metric string) ([]string, error) {
 	if metric == "vdev_cache_stats" {
-		return kstat_vdev_cache_stats_output, nil
+		return kstatVdevCacheStatsOutput, nil
 	}
 	if metric == "zfetchstats" {
-		return kstat_zfetchstats_output, nil
+		return kstatZfetchstatsOutput, nil
 	}
 	return []string{}, fmt.Errorf("Invalid arg")
 }
@@ -74,8 +75,8 @@ func TestZfsPoolMetrics(t *testing.T) {
 
 	z := &Zfs{
 		KstatMetrics: []string{"vdev_cache_stats"},
-		sysctl:       mock_sysctl,
-		zpool:        mock_zpool,
+		sysctl:       mockSysctl,
+		zpool:        mockZpool,
 	}
 	err := z.Gather(context.Background(), &acc)
 	require.NoError(t, err)
@@ -86,13 +87,13 @@ func TestZfsPoolMetrics(t *testing.T) {
 	z = &Zfs{
 		KstatMetrics: []string{"vdev_cache_stats"},
 		PoolMetrics:  true,
-		sysctl:       mock_sysctl,
-		zpool:        mock_zpool,
+		sysctl:       mockSysctl,
+		zpool:        mockZpool,
 	}
 	err = z.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
-	//one pool, all metrics
+	// one pool, all metrics
 	tags := map[string]string{
 		"pool":   "freenas-boot",
 		"health": "ONLINE",
@@ -109,8 +110,8 @@ func TestZfsPoolMetrics_unavail(t *testing.T) {
 
 	z := &Zfs{
 		KstatMetrics: []string{"vdev_cache_stats"},
-		sysctl:       mock_sysctl,
-		zpool:        mock_zpool_unavail,
+		sysctl:       mockSysctl,
+		zpool:        mockZpoolUnavail,
 	}
 	err := z.Gather(context.Background(), &acc)
 	require.NoError(t, err)
@@ -121,13 +122,13 @@ func TestZfsPoolMetrics_unavail(t *testing.T) {
 	z = &Zfs{
 		KstatMetrics: []string{"vdev_cache_stats"},
 		PoolMetrics:  true,
-		sysctl:       mock_sysctl,
-		zpool:        mock_zpool_unavail,
+		sysctl:       mockSysctl,
+		zpool:        mockZpoolUnavail,
 	}
 	err = z.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
-	//one pool, UNAVAIL
+	// one pool, UNAVAIL
 	tags := map[string]string{
 		"pool":   "temp2",
 		"health": "UNAVAIL",
@@ -143,8 +144,8 @@ func TestZfsDatasetMetrics(t *testing.T) {
 
 	z := &Zfs{
 		KstatMetrics: []string{"vdev_cache_stats"},
-		sysctl:       mock_sysctl,
-		zdataset:     mock_zdataset,
+		sysctl:       mockSysctl,
+		zdataset:     mockZdataset,
 	}
 	err := z.Gather(context.Background(), &acc)
 	require.NoError(t, err)
@@ -155,13 +156,13 @@ func TestZfsDatasetMetrics(t *testing.T) {
 	z = &Zfs{
 		KstatMetrics:   []string{"vdev_cache_stats"},
 		DatasetMetrics: true,
-		sysctl:         mock_sysctl,
-		zdataset:       mock_zdataset,
+		sysctl:         mockSysctl,
+		zdataset:       mockZdataset,
 	}
 	err = z.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
-	//one pool, all metrics
+	// one pool, all metrics
 	tags := map[string]string{
 		"dataset": "zata",
 	}
@@ -176,13 +177,13 @@ func TestZfsGeneratesMetrics(t *testing.T) {
 
 	z := &Zfs{
 		KstatMetrics: []string{"vdev_cache_stats"},
-		sysctl:       mock_sysctl,
-		zpool:        mock_zpool,
+		sysctl:       mockSysctl,
+		zpool:        mockZpool,
 	}
 	err := z.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
-	//four pool, vdev_cache_stats metrics
+	// four pool, vdev_cache_stats metrics
 	tags := map[string]string{
 		"pools": "freenas-boot::red1::temp1::temp2",
 	}
@@ -194,13 +195,13 @@ func TestZfsGeneratesMetrics(t *testing.T) {
 
 	z = &Zfs{
 		KstatMetrics: []string{"zfetchstats", "vdev_cache_stats"},
-		sysctl:       mock_sysctl,
-		zpool:        mock_zpool,
+		sysctl:       mockSysctl,
+		zpool:        mockZpool,
 	}
 	err = z.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
-	//four pool, vdev_cache_stats and zfetchstats metrics
+	// four pool, vdev_cache_stats and zfetchstats metrics
 	intMetrics = getKstatMetricsVdevAndZfetch()
 
 	acc.AssertContainsTaggedFields(t, "zfs", intMetrics, tags)

--- a/plugins/inputs/zfs/zfs_freebsd_test.go
+++ b/plugins/inputs/zfs/zfs_freebsd_test.go
@@ -77,7 +77,7 @@ func TestZfsPoolMetrics(t *testing.T) {
 		sysctl:       mock_sysctl,
 		zpool:        mock_zpool,
 	}
-	err := z.Gather(&acc)
+	err := z.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	require.False(t, acc.HasMeasurement("zfs_pool"))
@@ -89,7 +89,7 @@ func TestZfsPoolMetrics(t *testing.T) {
 		sysctl:       mock_sysctl,
 		zpool:        mock_zpool,
 	}
-	err = z.Gather(&acc)
+	err = z.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	//one pool, all metrics
@@ -112,7 +112,7 @@ func TestZfsPoolMetrics_unavail(t *testing.T) {
 		sysctl:       mock_sysctl,
 		zpool:        mock_zpool_unavail,
 	}
-	err := z.Gather(&acc)
+	err := z.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	require.False(t, acc.HasMeasurement("zfs_pool"))
@@ -124,7 +124,7 @@ func TestZfsPoolMetrics_unavail(t *testing.T) {
 		sysctl:       mock_sysctl,
 		zpool:        mock_zpool_unavail,
 	}
-	err = z.Gather(&acc)
+	err = z.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	//one pool, UNAVAIL
@@ -146,7 +146,7 @@ func TestZfsDatasetMetrics(t *testing.T) {
 		sysctl:       mock_sysctl,
 		zdataset:     mock_zdataset,
 	}
-	err := z.Gather(&acc)
+	err := z.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	require.False(t, acc.HasMeasurement("zfs_dataset"))
@@ -158,7 +158,7 @@ func TestZfsDatasetMetrics(t *testing.T) {
 		sysctl:         mock_sysctl,
 		zdataset:       mock_zdataset,
 	}
-	err = z.Gather(&acc)
+	err = z.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	//one pool, all metrics
@@ -179,7 +179,7 @@ func TestZfsGeneratesMetrics(t *testing.T) {
 		sysctl:       mock_sysctl,
 		zpool:        mock_zpool,
 	}
-	err := z.Gather(&acc)
+	err := z.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	//four pool, vdev_cache_stats metrics
@@ -197,7 +197,7 @@ func TestZfsGeneratesMetrics(t *testing.T) {
 		sysctl:       mock_sysctl,
 		zpool:        mock_zpool,
 	}
-	err = z.Gather(&acc)
+	err = z.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	//four pool, vdev_cache_stats and zfetchstats metrics

--- a/plugins/inputs/zfs/zfs_linux.go
+++ b/plugins/inputs/zfs/zfs_linux.go
@@ -3,6 +3,7 @@
 package zfs
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"strconv"

--- a/plugins/inputs/zfs/zfs_linux.go
+++ b/plugins/inputs/zfs/zfs_linux.go
@@ -77,7 +77,7 @@ func gatherPoolStats(pool poolInfo, acc cua.Accumulator) error {
 	return nil
 }
 
-func (z *Zfs) Gather(acc cua.Accumulator) error {
+func (z *Zfs) Gather(ctx context.Context, acc cua.Accumulator) error {
 	kstatMetrics := z.KstatMetrics
 	if len(kstatMetrics) == 0 {
 		// vdev_cache_stats is deprecated

--- a/plugins/inputs/zfs/zfs_linux_test.go
+++ b/plugins/inputs/zfs/zfs_linux_test.go
@@ -262,14 +262,14 @@ func TestZfsPoolMetrics(t *testing.T) {
 	var acc testutil.Accumulator
 
 	z := &Zfs{KstatPath: testKstatPath, KstatMetrics: []string{"arcstats"}}
-	err = z.Gather(&acc)
+	err = z.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	require.False(t, acc.HasMeasurement("zfs_pool"))
 	acc.Metrics = nil
 
 	z = &Zfs{KstatPath: testKstatPath, KstatMetrics: []string{"arcstats"}, PoolMetrics: true}
-	err = z.Gather(&acc)
+	err = z.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	// one pool, all metrics
@@ -321,7 +321,7 @@ func TestZfsGeneratesMetrics(t *testing.T) {
 	}
 
 	z := &Zfs{KstatPath: testKstatPath}
-	err = z.Gather(&acc)
+	err = z.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	acc.AssertContainsTaggedFields(t, "zfs", intMetrics, tags)
@@ -340,7 +340,7 @@ func TestZfsGeneratesMetrics(t *testing.T) {
 
 	z = &Zfs{KstatPath: testKstatPath}
 	acc2 := testutil.Accumulator{}
-	err = z.Gather(&acc2)
+	err = z.Gather(context.Background(), &acc2)
 	require.NoError(t, err)
 
 	acc2.AssertContainsTaggedFields(t, "zfs", intMetrics, tags)
@@ -351,7 +351,7 @@ func TestZfsGeneratesMetrics(t *testing.T) {
 	// two pools, one metric
 	z = &Zfs{KstatPath: testKstatPath, KstatMetrics: []string{"arcstats"}}
 	acc3 := testutil.Accumulator{}
-	err = z.Gather(&acc3)
+	err = z.Gather(context.Background(), &acc3)
 	require.NoError(t, err)
 
 	acc3.AssertContainsTaggedFields(t, "zfs", intMetrics, tags)

--- a/plugins/inputs/zfs/zfs_linux_test.go
+++ b/plugins/inputs/zfs/zfs_linux_test.go
@@ -3,6 +3,7 @@
 package zfs
 
 import (
+	"context"
 	"os"
 	"testing"
 

--- a/plugins/inputs/zfs/zfs_other.go
+++ b/plugins/inputs/zfs/zfs_other.go
@@ -3,11 +3,13 @@
 package zfs
 
 import (
+	"context"
+
 	"github.com/circonus-labs/circonus-unified-agent/cua"
 	"github.com/circonus-labs/circonus-unified-agent/plugins/inputs"
 )
 
-func (z *Zfs) Gather(acc cua.Accumulator) error {
+func (z *Zfs) Gather(_ context.Context, _ cua.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/zipkin/zipkin.go
+++ b/plugins/inputs/zipkin/zipkin.go
@@ -80,7 +80,7 @@ func (z Zipkin) SampleConfig() string {
 
 // Gather is empty for the zipkin plugin; all gathering is done through
 // the separate goroutine launched in (*Zipkin).Start()
-func (z *Zipkin) Gather(acc cua.Accumulator) error { return nil }
+func (z *Zipkin) Gather(_ context.Context, _ cua.Accumulator) error { return nil }
 
 // Start launches a separate goroutine for collecting zipkin client http requests,
 // passing in a cua.Accumulator such that data can be collected.

--- a/plugins/inputs/zookeeper/zookeeper.go
+++ b/plugins/inputs/zookeeper/zookeeper.go
@@ -77,8 +77,7 @@ func (z *Zookeeper) dial(ctx context.Context, addr string) (net.Conn, error) {
 }
 
 // Gather reads stats from all configured servers accumulates stats
-func (z *Zookeeper) Gather(acc cua.Accumulator) error {
-	ctx := context.Background()
+func (z *Zookeeper) Gather(ctx context.Context, acc cua.Accumulator) error {
 
 	if !z.initialized {
 		tlsConfig, err := z.ClientConfig.TLSConfig()

--- a/testutil/accumulator.go
+++ b/testutil/accumulator.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -303,8 +304,8 @@ func (a *Accumulator) TagValue(measurement string, key string) string {
 }
 
 // Calls the given Gather function and returns the first error found.
-func (a *Accumulator) GatherError(gf func(cua.Accumulator) error) error {
-	if err := gf(a); err != nil {
+func (a *Accumulator) GatherError(gf func(context.Context, cua.Accumulator) error) error {
+	if err := gf(context.Background(), a); err != nil {
 		return err
 	}
 	if len(a.Errors) > 0 {


### PR DESCRIPTION
snmp_dm will send metrics directly to Circonus (bypassing aggregators, parsers, processors, serializers, outputs, etc.)

The "direct metrics" plugins will just collection and send to Circonus directly.