### PR TITLE
Circ statsd CIRC-6596

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,6 +19,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.38
+          version: v1.40
           skip-go-installation: true
           args: --timeout=5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,7 +20,8 @@ linters:
     - ineffassign
     - deadcode
     - typecheck
-    - golint
+    # - revive
+    # - golint -- deprecated, owner archived repo, replaced by 'revive'
     - gosec
     # - interfacer -- deprecated, owner archived repo
     - misspell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# v0.0.26
+
+* upd: (snmp) one input to handle both dm and regular output
+* add: (snmp) text metric capability for syntax integer
+* add: (circmgr) same check name prefix handling as regular circ output
+* upd: (circmgr) use plugin and instance in cache file names
+* upd: (circmgr) reduce verbosity in new metric dest err msg
+* add: (circout) timestamp to agent metric
+* add: (statsd) new dm statsd input
+* add: (agent) context to input Start
+* add: (circmgr) global tags for dm inputs
+* upd: dependencies (go-trapcheck, go-trapmetrics)
+* fix: lint issues
+* upd: lint
+
 # v0.0.25
 
 * upd: enable default linux plugins for darwin and freebsd

--- a/cmd/circonus-unified-agent/circonus-unified-agent.go
+++ b/cmd/circonus-unified-agent/circonus-unified-agent.go
@@ -152,6 +152,9 @@ func runAgent(ctx context.Context,
 	if err := circonus.Initialize(c.GetGlobalCirconusConfig()); err != nil {
 		log.Printf("E! CMDM %s", err)
 	}
+	if len(c.Tags) > 0 {
+		circonus.AddGlobalTags(c.Tags)
+	}
 
 	if !*fTest && len(c.Outputs) == 0 {
 		return fmt.Errorf("Error: no outputs found, did you provide a valid config file?")

--- a/config/config.go
+++ b/config/config.go
@@ -1907,7 +1907,18 @@ ignore_fs = ["tmpfs", "devtmpfs", "devfs", "iso9660", "overlay", "aufs", "squash
 
 func getDefaultPluginList() *map[string]circonusPlugin {
 	switch runtime.GOOS {
-	case "linux", "darwin", "freebsd":
+	case "darwin":
+		// disable plugins which don't work on darwin
+		if cfg, ok := defaultPluginList["cpu"]; ok {
+			cfg.Enabled = false
+			defaultPluginList["cpu"] = cfg
+		}
+		if cfg, ok := defaultPluginList["diskio"]; ok {
+			cfg.Enabled = false
+			defaultPluginList["diskio"] = cfg
+		}
+		return &defaultPluginList
+	case "linux", "freebsd":
 		return &defaultPluginList
 	case "windows":
 		return &defaultWindowsPluginList

--- a/cua/input.go
+++ b/cua/input.go
@@ -15,7 +15,7 @@ type ServiceInput interface {
 
 	// Start the ServiceInput.  The Accumulator may be retained and used until
 	// Stop returns.
-	Start(Accumulator) error
+	Start(context.Context, Accumulator) error
 
 	// Stop stops the services and closes any necessary channels and connections.
 	// Metrics should not be written out to the accumulator once stop returns, so

--- a/go.mod
+++ b/go.mod
@@ -79,8 +79,8 @@ require (
 	github.com/kubernetes/apimachinery v0.0.0-20190119020841-d41becfba9ee
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lib/pq v1.3.0 // indirect
-	github.com/maier/go-trapcheck v0.0.6
-	github.com/maier/go-trapmetrics v0.0.5
+	github.com/maier/go-trapcheck v0.0.7
+	github.com/maier/go-trapmetrics v0.0.6
 	github.com/matttproud/golang_protobuf_extensions v1.0.1
 	github.com/mdlayher/apcupsd v0.0.0-20200608131503-2bf01da7bf1b
 	github.com/miekg/dns v1.0.14

--- a/go.sum
+++ b/go.sum
@@ -392,10 +392,10 @@ github.com/leodido/ragel-machinery v0.0.0-20181214104525-299bdde78165 h1:bCiVCRC
 github.com/leodido/ragel-machinery v0.0.0-20181214104525-299bdde78165/go.mod h1:WZxr2/6a/Ar9bMDc2rN/LJrE/hF6bXE4LPyDSIxwAfg=
 github.com/lib/pq v1.3.0 h1:/qkRGz8zljWiDcFvgpwUpwIAPu3r07TDvs3Rws+o/pU=
 github.com/lib/pq v1.3.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
-github.com/maier/go-trapcheck v0.0.6 h1:xul/pYWMv+nlUiampJDUyMVq89q3928zdyULlG6Nyyk=
-github.com/maier/go-trapcheck v0.0.6/go.mod h1:U26WvDi1hosmmPEwx59OGAURaXEI7QhZyEEDWZvVbr8=
-github.com/maier/go-trapmetrics v0.0.5 h1:n/cQEhiHvifNA90n6cGiMHHN8c37fIfD2TZu+iY4pgk=
-github.com/maier/go-trapmetrics v0.0.5/go.mod h1:/hmOLCy7iDGPQHJ2sQRzL0ajidMF1hHUhENXzTSUJ3A=
+github.com/maier/go-trapcheck v0.0.7 h1:QrKwPzUZkd2lR2iI5B1v7qDlivSByTb7YHp6p/xjr1w=
+github.com/maier/go-trapcheck v0.0.7/go.mod h1:U26WvDi1hosmmPEwx59OGAURaXEI7QhZyEEDWZvVbr8=
+github.com/maier/go-trapmetrics v0.0.6 h1:dzefSkxMvP1JS/MKvFWan+Kp/QN/6st7FE7JatzlgxQ=
+github.com/maier/go-trapmetrics v0.0.6/go.mod h1:nEdxuNc/E7I5AH8xrqdejQssor0x7IMxFdINLzdHwDw=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=

--- a/internal/circonus/config_cache.go
+++ b/internal/circonus/config_cache.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/circonus-labs/go-apiclient"
 	apiclicfg "github.com/circonus-labs/go-apiclient/config"
@@ -12,16 +13,16 @@ import (
 //
 // Check bundle config caching
 //
-func loadCheckConfig(instanceID string) *apiclient.CheckBundle {
+func loadCheckConfig(id string) *apiclient.CheckBundle {
 	if !ch.circCfg.CacheConfigs {
 		return nil
 	}
-	if instanceID == "" || ch.circCfg.CacheDir == "" {
+	if id == "" || ch.circCfg.CacheDir == "" {
 		return nil
 	}
 
 	path := ch.circCfg.CacheDir
-	checkConfigFile := filepath.Join(path, instanceID+".json")
+	checkConfigFile := filepath.Join(path, strings.ReplaceAll(id, ":", "_")+".json")
 
 	data, err := os.ReadFile(checkConfigFile)
 	if err != nil {
@@ -41,11 +42,11 @@ func loadCheckConfig(instanceID string) *apiclient.CheckBundle {
 	return &bundle
 }
 
-func saveCheckConfig(instanceID string, bundle *apiclient.CheckBundle) {
+func saveCheckConfig(id string, bundle *apiclient.CheckBundle) {
 	if !ch.circCfg.CacheConfigs {
 		return
 	}
-	if instanceID == "" || ch.circCfg.CacheDir == "" {
+	if id == "" || ch.circCfg.CacheDir == "" {
 		return
 	}
 	if bundle == nil {
@@ -53,7 +54,7 @@ func saveCheckConfig(instanceID string, bundle *apiclient.CheckBundle) {
 	}
 
 	path := ch.circCfg.CacheDir
-	checkConfigFile := filepath.Join(path, instanceID+".json")
+	checkConfigFile := filepath.Join(path, strings.ReplaceAll(id, ":", "_")+".json")
 
 	data, err := json.Marshal(bundle)
 	if err != nil {

--- a/models/running_output_test.go
+++ b/models/running_output_test.go
@@ -360,7 +360,7 @@ func TestRunningOutputWriteFailOrder(t *testing.T) {
 	// Verify that 10 metrics were written
 	assert.Len(t, m.Metrics(), 10)
 	// Verify that they are in order
-	expected := append(first5, next5...)
+	expected := append(first5, next5...) // nolint:gocritic
 	assert.Equal(t, expected, m.Metrics())
 }
 
@@ -421,7 +421,7 @@ func TestRunningOutputWriteFailOrder2(t *testing.T) {
 	// Verify that 20 metrics were written
 	assert.Len(t, m.Metrics(), 20)
 	// Verify that they are in order
-	expected := append(first5, next5...)
+	expected := append(first5, next5...) //nolint:gocritic
 	expected = append(expected, first5...)
 	expected = append(expected, next5...)
 	assert.Equal(t, expected, m.Metrics())

--- a/plugins/common/shim/example/cmd/main.go
+++ b/plugins/common/shim/example/cmd/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -53,7 +54,7 @@ func main() {
 	}
 
 	// run the input plugin(s) until stdin closes or we receive a termination signal
-	if err := shim.Run(*pollInterval); err != nil {
+	if err := shim.Run(context.Background(), *pollInterval); err != nil {
 		fmt.Fprintf(os.Stderr, "Err: %s\n", err)
 		os.Exit(1)
 	}

--- a/plugins/common/shim/goshim.go
+++ b/plugins/common/shim/goshim.go
@@ -73,10 +73,10 @@ func (s *Shim) watchForShutdown(cancel context.CancelFunc) {
 }
 
 // Run the input plugins..
-func (s *Shim) Run(pollInterval time.Duration) error {
+func (s *Shim) Run(ctx context.Context, pollInterval time.Duration) error {
 	switch {
 	case s.Input != nil:
-		err := s.RunInput(pollInterval)
+		err := s.RunInput(ctx, pollInterval)
 		if err != nil {
 			return fmt.Errorf("RunInput error: %w", err)
 		}

--- a/plugins/common/shim/goshim_test.go
+++ b/plugins/common/shim/goshim_test.go
@@ -49,7 +49,7 @@ func runErroringInputPlugin(t *testing.T, interval time.Duration, stdin io.Reade
 	}
 	_ = shim.AddInput(inp)
 	go func() {
-		err := shim.Run(interval)
+		err := shim.Run(context.Background(), interval)
 		require.NoError(t, err)
 		exited <- true
 	}()

--- a/plugins/common/shim/input.go
+++ b/plugins/common/shim/input.go
@@ -25,7 +25,7 @@ func (s *Shim) AddInput(input cua.Input) error {
 	return nil
 }
 
-func (s *Shim) RunInput(pollInterval time.Duration) error {
+func (s *Shim) RunInput(ctx context.Context, pollInterval time.Duration) error {
 	// context is used only to close the stdin reader. everything else cascades
 	// from that point and closes cleanly when it's done.
 	ctx, cancel := context.WithCancel(context.Background())
@@ -37,7 +37,7 @@ func (s *Shim) RunInput(pollInterval time.Duration) error {
 	acc.SetPrecision(time.Nanosecond)
 
 	if serviceInput, ok := s.Input.(cua.ServiceInput); ok {
-		if err := serviceInput.Start(acc); err != nil {
+		if err := serviceInput.Start(ctx, acc); err != nil {
 			return fmt.Errorf("failed to start input: %w", err)
 		}
 	}

--- a/plugins/common/shim/input_test.go
+++ b/plugins/common/shim/input_test.go
@@ -70,7 +70,7 @@ func runInputPlugin(t *testing.T, interval time.Duration, stdin io.Reader, stdou
 	}
 	_ = shim.AddInput(inp)
 	go func() {
-		err := shim.Run(interval)
+		err := shim.Run(context.Background(), interval)
 		require.NoError(t, err)
 		exited <- true
 	}()

--- a/plugins/inputs/clickhouse/clickhouse.go
+++ b/plugins/inputs/clickhouse/clickhouse.go
@@ -130,7 +130,7 @@ func (*ClickHouse) Description() string {
 }
 
 // Start ClickHouse input service
-func (ch *ClickHouse) Start(cua.Accumulator) error {
+func (ch *ClickHouse) Start(_ context.Context, _ cua.Accumulator) error {
 	timeout := defaultTimeout
 	if ch.Timeout.Duration != 0 {
 		timeout = ch.Timeout.Duration

--- a/plugins/inputs/docker_log/docker_log.go
+++ b/plugins/inputs/docker_log/docker_log.go
@@ -412,7 +412,7 @@ func tailMultiplexed(
 
 // Start is a noop which is required for a *DockerLogs to implement
 // the cua.ServiceInput interface
-func (d *DockerLogs) Start(cua.Accumulator) error {
+func (d *DockerLogs) Start(_ context.Context, _ cua.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/fail2ban/fail2ban.go
+++ b/plugins/inputs/fail2ban/fail2ban.go
@@ -61,7 +61,7 @@ func (f *Fail2ban) Gather(ctx context.Context, acc cua.Accumulator) error {
 		arg = append(arg, f.path)
 	}
 
-	args := append(arg, "status")
+	args := append(arg, "status") //nolint:gocritic
 
 	cmd := execCommand(name, args...)
 	out, err := cmd.Output()
@@ -83,7 +83,7 @@ func (f *Fail2ban) Gather(ctx context.Context, acc cua.Accumulator) error {
 
 	for _, jail := range jails {
 		fields := make(map[string]interface{})
-		args := append(arg, "status", jail)
+		args := append(arg, "status", jail) //nolint:gocritic
 		cmd := execCommand(name, args...)
 		out, err := cmd.Output()
 		if err != nil {

--- a/plugins/inputs/ping/ping_test.go
+++ b/plugins/inputs/ping/ping_test.go
@@ -211,7 +211,7 @@ func TestArgs6(t *testing.T) {
 
 func TestArguments(t *testing.T) {
 	arguments := []string{"-c", "3"}
-	expected := append(arguments, "www.google.com")
+	expected := append(arguments, "www.google.com") //nolint:gocritic
 	p := Ping{
 		Count:        2,
 		Interface:    "eth0",

--- a/plugins/inputs/statsd/datadog_test.go
+++ b/plugins/inputs/statsd/datadog_test.go
@@ -1,6 +1,7 @@
 package statsd
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -74,7 +75,7 @@ func TestEventGather(t *testing.T) {
 	}
 	acc := &testutil.Accumulator{}
 	s := NewTestStatsd()
-	require.NoError(t, s.Start(acc))
+	require.NoError(t, s.Start(context.Background(), acc))
 	defer s.Stop()
 
 	for i := range tests {
@@ -383,7 +384,7 @@ func TestEvents(t *testing.T) {
 	}
 	s := NewTestStatsd()
 	acc := &testutil.Accumulator{}
-	require.NoError(t, s.Start(acc))
+	require.NoError(t, s.Start(context.Background(), acc))
 	defer s.Stop()
 	for i := range tests {
 		i := i
@@ -412,7 +413,7 @@ func TestEventError(t *testing.T) {
 	now := time.Now()
 	s := NewTestStatsd()
 	acc := &testutil.Accumulator{}
-	require.NoError(t, s.Start(acc))
+	require.NoError(t, s.Start(context.Background(), acc))
 	defer s.Stop()
 
 	// missing length header

--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -6,8 +6,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"net"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -15,9 +15,11 @@ import (
 
 	"github.com/circonus-labs/circonus-unified-agent/cua"
 	"github.com/circonus-labs/circonus-unified-agent/internal"
+	circmgr "github.com/circonus-labs/circonus-unified-agent/internal/circonus"
 	"github.com/circonus-labs/circonus-unified-agent/plugins/inputs"
 	"github.com/circonus-labs/circonus-unified-agent/plugins/parsers/graphite"
 	"github.com/circonus-labs/circonus-unified-agent/selfstat"
+	"github.com/maier/go-trapmetrics"
 )
 
 const (
@@ -38,6 +40,8 @@ const (
 
 // Statsd allows the importing of statsd and dogstatsd data.
 type Statsd struct {
+	InstanceID string `toml:"instance_id"`
+
 	// Protocol used on listener - udp or tcp
 	Protocol string `toml:"protocol"`
 
@@ -48,22 +52,23 @@ type Statsd struct {
 	// fills up, packets will get dropped until the next Gather interval is ran.
 	AllowedPendingMessages int
 
-	// Percentiles specifies the percentiles that will be calculated for timing
-	// and histogram stats.
-	Percentiles     []internal.Number
-	PercentileLimit int
+	// // Percentiles specifies the percentiles that will be calculated for timing
+	// // and histogram stats.
+	// Percentiles     []internal.Number
+	// PercentileLimit int
 
-	DeleteGauges   bool
-	DeleteCounters bool
-	DeleteSets     bool
-	DeleteTimings  bool
-	ConvertNames   bool
+	// DeleteGauges   bool
+	// DeleteCounters bool
+	// DeleteSets     bool
+	// DeleteTimings  bool
+	// ConvertNames   bool
 
 	// MetricSeparator is the separator between parts of the metric name.
 	MetricSeparator string
-	// This flag enables parsing of tags in the dogstatsd extension to the
-	// statsd protocol (http://docs.datadoghq.com/guides/dogstatsd/)
-	ParseDataDogTags bool // depreciated in 1.10; use datadog_extensions
+
+	// // This flag enables parsing of tags in the dogstatsd extension to the
+	// // statsd protocol (http://docs.datadoghq.com/guides/dogstatsd/)
+	// ParseDataDogTags bool // depreciated in 1.10; use datadog_extensions
 
 	// Parses extensions to statsd in the datadog statsd format
 	// currently supports metrics and datadog tags.
@@ -95,13 +100,13 @@ type Statsd struct {
 	in   chan input
 	done chan struct{}
 
-	// Cache gauges, counters & sets so they can be aggregated as they arrive
-	// gauges and counters map measurement/tags hash -> field name -> metrics
-	// sets and timings map measurement/tags hash -> metrics
-	gauges   map[string]cachedgauge
-	counters map[string]cachedcounter
-	sets     map[string]cachedset
-	timings  map[string]cachedtimings
+	// // Cache gauges, counters & sets so they can be aggregated as they arrive
+	// // gauges and counters map measurement/tags hash -> field name -> metrics
+	// // sets and timings map measurement/tags hash -> metrics
+	// gauges   map[string]cachedgauge
+	// counters map[string]cachedcounter
+	// sets     map[string]cachedset
+	// timings  map[string]cachedtimings
 
 	// bucket -> influx templates
 	Templates []string
@@ -134,6 +139,9 @@ type Statsd struct {
 
 	Log cua.Logger
 
+	// circonus destination for the metrics from this input
+	metricDestination *trapmetrics.TrapMetrics
+
 	// A pool of byte slices to handle parsing
 	bufPool sync.Pool
 }
@@ -146,10 +154,10 @@ type input struct {
 
 // One statsd metric, form is <bucket>:<value>|<mtype>|@<samplerate>
 type metric struct {
-	name       string
-	field      string
-	bucket     string
-	hash       string
+	name   string
+	field  string
+	bucket string
+	// hash       string
 	intvalue   int64
 	floatvalue float64
 	strvalue   string
@@ -157,37 +165,41 @@ type metric struct {
 	additive   bool
 	samplerate float64
 	tags       map[string]string
+	mtags      trapmetrics.Tags
 }
 
-type cachedset struct {
-	name   string
-	fields map[string]map[string]bool
-	tags   map[string]string
-}
+// type cachedset struct {
+// 	name   string
+// 	fields map[string]map[string]bool
+// 	tags   map[string]string
+// }
 
-type cachedgauge struct {
-	name   string
-	fields map[string]interface{}
-	tags   map[string]string
-}
+// type cachedgauge struct {
+// 	name   string
+// 	fields map[string]interface{}
+// 	tags   map[string]string
+// }
 
-type cachedcounter struct {
-	name   string
-	fields map[string]interface{}
-	tags   map[string]string
-}
+// type cachedcounter struct {
+// 	name   string
+// 	fields map[string]interface{}
+// 	tags   map[string]string
+// }
 
-type cachedtimings struct {
-	name   string
-	fields map[string]RunningStats
-	tags   map[string]string
-}
+// type cachedtimings struct {
+// 	name   string
+// 	fields map[string]RunningStats
+// 	tags   map[string]string
+// }
 
 func (*Statsd) Description() string {
 	return "Statsd UDP/TCP Server"
 }
 
 const sampleConfig = `
+  ## Instance ID -- required
+  instance_id = ""
+
   ## Protocol, must be "tcp", "udp", "udp4" or "udp6" (default=udp)
   protocol = "udp"
 
@@ -205,27 +217,8 @@ const sampleConfig = `
   ## Address and port to host UDP listener on
   service_address = ":8125"
 
-  ## The following configuration options control when agent clears it's cache
-  ## of previous values. If set to false, then agent will only clear it's
-  ## cache when the daemon is restarted.
-  ## Reset gauges every interval (default=true)
-  delete_gauges = true
-  ## Reset counters every interval (default=true)
-  delete_counters = true
-  ## Reset sets every interval (default=true)
-  delete_sets = true
-  ## Reset timings & histograms every interval (default=true)
-  delete_timings = true
-
-  ## Percentiles to calculate for timing & histogram stats
-  percentiles = [50.0, 90.0, 99.0, 99.9, 99.95, 100.0]
-
   ## separator to use between elements of a statsd metric
   metric_separator = "_"
-
-  ## Parses tags in the datadog statsd format
-  ## http://docs.datadoghq.com/guides/dogstatsd/
-  parse_data_dog_tags = false
 
   ## Parses datadog extensions to the statsd format
   datadog_extensions = false
@@ -239,11 +232,6 @@ const sampleConfig = `
   ## Number of UDP messages allowed to queue up, once filled,
   ## the statsd server will start dropping packets
   allowed_pending_messages = 10000
-
-  ## Number of timing/histogram values to track per-measurement in the
-  ## calculation of percentiles. Raising this limit increases the accuracy
-  ## of percentiles but also increases the memory usage and cpu time.
-  percentile_limit = 1000
 `
 
 func (*Statsd) SampleConfig() string {
@@ -253,76 +241,95 @@ func (*Statsd) SampleConfig() string {
 func (s *Statsd) Gather(ctx context.Context, acc cua.Accumulator) error {
 	s.Lock()
 	defer s.Unlock()
-	now := time.Now()
-
-	for _, m := range s.timings {
-		// Defining a template to parse field names for timers allows us to split
-		// out multiple fields per timer. In this case we prefix each stat with the
-		// field name and store these all in a single measurement.
-		fields := make(map[string]interface{})
-		for fieldName, stats := range m.fields {
-			var prefix string
-			if fieldName != defaultFieldName {
-				prefix = fieldName + "_"
-			}
-			fields[prefix+"mean"] = stats.Mean()
-			fields[prefix+"stddev"] = stats.Stddev()
-			fields[prefix+"sum"] = stats.Sum()
-			fields[prefix+"upper"] = stats.Upper()
-			fields[prefix+"lower"] = stats.Lower()
-			fields[prefix+"count"] = stats.Count()
-			for _, percentile := range s.Percentiles {
-				name := fmt.Sprintf("%s%v_percentile", prefix, percentile.Value)
-				fields[name] = stats.Percentile(percentile.Value)
-			}
-		}
-
-		acc.AddFields(m.name, fields, m.tags, now)
-	}
-	if s.DeleteTimings {
-		s.timings = make(map[string]cachedtimings)
+	if _, err := s.metricDestination.Flush(ctx); err != nil {
+		acc.AddError(fmt.Errorf("submitting metrics: %w", err))
+		// s.Log.Warnf("submitting metrics: %s", err)
 	}
 
-	for _, m := range s.gauges {
-		acc.AddGauge(m.name, m.fields, m.tags, now)
-	}
-	if s.DeleteGauges {
-		s.gauges = make(map[string]cachedgauge)
-	}
+	// s.Lock()
+	// defer s.Unlock()
+	// now := time.Now()
 
-	for _, m := range s.counters {
-		acc.AddCounter(m.name, m.fields, m.tags, now)
-	}
-	if s.DeleteCounters {
-		s.counters = make(map[string]cachedcounter)
-	}
+	// for _, m := range s.timings {
+	// 	// Defining a template to parse field names for timers allows us to split
+	// 	// out multiple fields per timer. In this case we prefix each stat with the
+	// 	// field name and store these all in a single measurement.
+	// 	fields := make(map[string]interface{})
+	// 	for fieldName, stats := range m.fields {
+	// 		var prefix string
+	// 		if fieldName != defaultFieldName {
+	// 			prefix = fieldName + "_"
+	// 		}
+	// 		fields[prefix+"mean"] = stats.Mean()
+	// 		fields[prefix+"stddev"] = stats.Stddev()
+	// 		fields[prefix+"sum"] = stats.Sum()
+	// 		fields[prefix+"upper"] = stats.Upper()
+	// 		fields[prefix+"lower"] = stats.Lower()
+	// 		fields[prefix+"count"] = stats.Count()
+	// 		for _, percentile := range s.Percentiles {
+	// 			name := fmt.Sprintf("%s%v_percentile", prefix, percentile.Value)
+	// 			fields[name] = stats.Percentile(percentile.Value)
+	// 		}
+	// 	}
 
-	for _, m := range s.sets {
-		fields := make(map[string]interface{})
-		for field, set := range m.fields {
-			fields[field] = int64(len(set))
-		}
-		acc.AddFields(m.name, fields, m.tags, now)
-	}
-	if s.DeleteSets {
-		s.sets = make(map[string]cachedset)
-	}
+	// 	acc.AddFields(m.name, fields, m.tags, now)
+	// }
+	// if s.DeleteTimings {
+	// 	s.timings = make(map[string]cachedtimings)
+	// }
+
+	// for _, m := range s.gauges {
+	// 	acc.AddGauge(m.name, m.fields, m.tags, now)
+	// }
+	// if s.DeleteGauges {
+	// 	s.gauges = make(map[string]cachedgauge)
+	// }
+
+	// for _, m := range s.counters {
+	// 	acc.AddCounter(m.name, m.fields, m.tags, now)
+	// }
+	// if s.DeleteCounters {
+	// 	s.counters = make(map[string]cachedcounter)
+	// }
+
+	// for _, m := range s.sets {
+	// 	fields := make(map[string]interface{})
+	// 	for field, set := range m.fields {
+	// 		fields[field] = int64(len(set))
+	// 	}
+	// 	acc.AddFields(m.name, fields, m.tags, now)
+	// }
+	// if s.DeleteSets {
+	// 	s.sets = make(map[string]cachedset)
+	// }
 	return nil
 }
 
-func (s *Statsd) Start(ac cua.Accumulator) error {
-	if s.ParseDataDogTags {
-		s.DataDogExtensions = true
-		s.Log.Warn("'parse_data_dog_tags' config option is deprecated, please use 'datadog_extensions' instead")
+func (s *Statsd) Start(ctx context.Context, ac cua.Accumulator) error {
+	if s.InstanceID == "" {
+		return fmt.Errorf("invalid instance_id (empty)")
 	}
+
+	s.Log.Debug("initializing metric destination")
+
+	id := "statsd"
+	if s.InstanceID != "" {
+		id += ":" + s.InstanceID
+	}
+	dest, err := circmgr.NewMetricDestination(id, "statsd "+s.InstanceID, s.InstanceID, "", s.Log)
+	if err != nil {
+		return fmt.Errorf("new metric destination: %w", err)
+	}
+
+	s.metricDestination = dest
 
 	s.acc = ac
 
-	// Make data structures
-	s.gauges = make(map[string]cachedgauge)
-	s.counters = make(map[string]cachedcounter)
-	s.sets = make(map[string]cachedset)
-	s.timings = make(map[string]cachedtimings)
+	// // Make data structures
+	// s.gauges = make(map[string]cachedgauge)
+	// s.counters = make(map[string]cachedcounter)
+	// s.sets = make(map[string]cachedset)
+	// s.timings = make(map[string]cachedtimings)
 
 	s.Lock()
 	defer s.Unlock()
@@ -354,9 +361,10 @@ func (s *Statsd) Start(ac cua.Accumulator) error {
 		s.accept <- true
 	}
 
-	if s.ConvertNames {
-		s.Log.Warn("'convert_names' config option is deprecated, please use 'metric_separator' instead")
-	}
+	// // remove this and the config directive
+	// if s.ConvertNames {
+	// 	s.Log.Warn("'convert_names' config option is deprecated, please use 'metric_separator' instead")
+	// }
 
 	if s.MetricSeparator == "" {
 		s.MetricSeparator = defaultSeparator
@@ -379,7 +387,7 @@ func (s *Statsd) Start(ac cua.Accumulator) error {
 		s.wg.Add(1)
 		go func() {
 			defer s.wg.Done()
-			_ = s.udpListen(conn)
+			_ = s.udpListen(ctx, conn)
 		}()
 	} else {
 		address, err := net.ResolveTCPAddr("tcp", s.ServiceAddress)
@@ -397,7 +405,7 @@ func (s *Statsd) Start(ac cua.Accumulator) error {
 		s.wg.Add(1)
 		go func() {
 			defer s.wg.Done()
-			_ = s.tcpListen(listener)
+			_ = s.tcpListen(ctx, listener)
 		}()
 	}
 
@@ -406,17 +414,20 @@ func (s *Statsd) Start(ac cua.Accumulator) error {
 		s.wg.Add(1)
 		go func() {
 			defer s.wg.Done()
-			s.parser()
+			s.parser(ctx)
 		}()
 	}
+
 	s.Log.Infof("Started the statsd service on %q", s.ServiceAddress)
 	return nil
 }
 
 // tcpListen() starts listening for udp packets on the configured port.
-func (s *Statsd) tcpListen(listener *net.TCPListener) error {
+func (s *Statsd) tcpListen(ctx context.Context, listener *net.TCPListener) error {
 	for {
 		select {
+		case <-ctx.Done():
+			return nil
 		case <-s.done:
 			return nil
 		default:
@@ -455,7 +466,7 @@ func (s *Statsd) tcpListen(listener *net.TCPListener) error {
 }
 
 // udpListen starts listening for udp packets on the configured port.
-func (s *Statsd) udpListen(conn *net.UDPConn) error {
+func (s *Statsd) udpListen(ctx context.Context, conn *net.UDPConn) error {
 	if s.ReadBufferSize > 0 {
 		_ = s.UDPlistener.SetReadBuffer(s.ReadBufferSize)
 	}
@@ -463,6 +474,8 @@ func (s *Statsd) udpListen(conn *net.UDPConn) error {
 	buf := make([]byte, udpMaxPacketSize)
 	for {
 		select {
+		case <-ctx.Done():
+			return nil
 		case <-s.done:
 			return nil
 		default:
@@ -500,9 +513,11 @@ func (s *Statsd) udpListen(conn *net.UDPConn) error {
 // parser monitors the s.in channel, if there is a packet ready, it parses the
 // packet into statsd strings and then calls parseStatsdLine, which parses a
 // single statsd metric into a struct.
-func (s *Statsd) parser() {
+func (s *Statsd) parser(ctx context.Context) {
 	for {
 		select {
+		case <-ctx.Done():
+			return
 		case <-s.done:
 			return
 		case in := <-s.in:
@@ -514,7 +529,9 @@ func (s *Statsd) parser() {
 				switch {
 				case line == "":
 				case s.DataDogExtensions && strings.HasPrefix(line, "_e"):
-					_ = s.parseEventMessage(in.Time, line, in.Addr)
+					continue
+					// circonus has no "events" type of facility
+					// _ = s.parseEventMessage(in.Time, line, in.Addr)
 				default:
 					_ = s.parseStatsdLine(line)
 				}
@@ -563,9 +580,9 @@ func (s *Statsd) parseStatsdLine(line string) error {
 
 	// Add a metric for each bit available
 	for _, bit := range bits {
-		m := metric{}
-
-		m.bucket = bucketName
+		m := metric{
+			bucket: bucketName,
+		}
 
 		// Validate splitting the bit on "|"
 		pipesplit := strings.Split(bit, "|")
@@ -591,7 +608,7 @@ func (s *Statsd) parseStatsdLine(line string) error {
 
 		// Validate metric type
 		switch pipesplit[1] {
-		case "g", "c", "s", "ms", "h":
+		case "g", "c", "s", "ms", "h", "t":
 			m.mtype = pipesplit[1]
 		default:
 			s.Log.Errorf("Metric type %q unsupported", pipesplit[1])
@@ -631,7 +648,7 @@ func (s *Statsd) parseStatsdLine(line string) error {
 				v = int64(float64(v) / m.samplerate)
 			}
 			m.intvalue = v
-		case "s":
+		case "s", "t":
 			m.strvalue = pipesplit[0]
 		}
 
@@ -640,14 +657,22 @@ func (s *Statsd) parseStatsdLine(line string) error {
 		switch m.mtype {
 		case "c":
 			m.tags["metric_type"] = "counter"
+			m.tags["statsd_type"] = "count" // used by circonus
 		case "g":
 			m.tags["metric_type"] = "gauge"
+			m.tags["statsd_type"] = "gauge"
 		case "s":
 			m.tags["metric_type"] = "set"
+			m.tags["statsd_type"] = "count" // used by circonus
 		case "ms":
 			m.tags["metric_type"] = "timing"
+			m.tags["statsd_type"] = "timing" // used by circonus
 		case "h":
 			m.tags["metric_type"] = "histogram"
+			m.tags["statsd_type"] = "histogram"
+		case "t":
+			m.tags["metric_type"] = "text"
+			m.tags["statsd_type"] = "text"
 		}
 		if len(lineTags) > 0 {
 			for k, v := range lineTags {
@@ -655,14 +680,23 @@ func (s *Statsd) parseStatsdLine(line string) error {
 			}
 		}
 
-		// Make a unique key for the measurement name/tags
-		var tg []string
-		for k, v := range m.tags {
-			tg = append(tg, k+"="+v)
+		globalTags := circmgr.GetGlobalTags()
+		m.mtags = make(trapmetrics.Tags, len(m.tags)+len(globalTags))
+		if len(globalTags) > 0 {
+			m.mtags = append(m.mtags, globalTags...)
 		}
-		sort.Strings(tg)
-		tg = append(tg, m.name)
-		m.hash = strings.Join(tg, "")
+		for k, v := range m.tags {
+			m.mtags = append(m.mtags, trapmetrics.Tag{Category: k, Value: v})
+		}
+
+		// // Make a unique key for the measurement name/tags
+		// var tg []string
+		// for k, v := range m.tags {
+		// 	tg = append(tg, k+"="+v)
+		// }
+		// sort.Strings(tg)
+		// tg = append(tg, m.name)
+		// m.hash = strings.Join(tg, "")
 
 		s.aggregate(m)
 	}
@@ -704,10 +738,10 @@ func (s *Statsd) parseName(bucket string) (string, string, map[string]string) {
 		name, tags, field, _ = p.ApplyTemplate(name)
 	}
 
-	if s.ConvertNames {
-		name = strings.ReplaceAll(name, ".", "_")
-		name = strings.ReplaceAll(name, "-", "__")
-	}
+	// if s.ConvertNames {
+	// 	name = strings.ReplaceAll(name, ".", "_")
+	// 	name = strings.ReplaceAll(name, "-", "__")
+	// }
 	if field == "" {
 		field = defaultFieldName
 	}
@@ -737,86 +771,136 @@ func parseKeyValue(keyvalue string) (string, string) {
 func (s *Statsd) aggregate(m metric) {
 	switch m.mtype {
 	case "ms", "h":
-		// Check if the measurement exists
-		cached, ok := s.timings[m.hash]
-		if !ok {
-			cached = cachedtimings{
-				name:   m.name,
-				fields: make(map[string]RunningStats),
-				tags:   m.tags,
-			}
-		}
-		// Check if the field exists. If we've not enabled multiple fields per timer
-		// this will be the default field name, eg. "value"
-		field, ok := cached.fields[m.field]
-		if !ok {
-			field = RunningStats{
-				PercLimit: s.PercentileLimit,
-			}
+		if m.field != "" && m.field != "value" {
+			m.mtags = append(m.mtags, trapmetrics.Tag{Category: "field", Value: m.field})
 		}
 		if m.samplerate > 0 {
 			for i := 0; i < int(1.0/m.samplerate); i++ {
-				field.AddValue(m.floatvalue)
+				if err := s.metricDestination.HistogramRecordValue(m.name, m.mtags, m.floatvalue); err != nil {
+					s.Log.Warnf("adding histogram (%s): %s", m.name, err)
+				}
 			}
-		} else {
-			field.AddValue(m.floatvalue)
+			return
 		}
-		cached.fields[m.field] = field
-		s.timings[m.hash] = cached
+
+		if err := s.metricDestination.HistogramRecordValue(m.name, m.mtags, m.floatvalue); err != nil {
+			s.Log.Warnf("adding histogram (%s): %s", m.name, err)
+		}
+
+		// // Check if the measurement exists
+		// cached, ok := s.timings[m.hash]
+		// if !ok {
+		// 	cached = cachedtimings{
+		// 		name:   m.name,
+		// 		fields: make(map[string]RunningStats),
+		// 		tags:   m.tags,
+		// 	}
+		// }
+		// // Check if the field exists. If we've not enabled multiple fields per timer
+		// // this will be the default field name, eg. "value"
+		// field, ok := cached.fields[m.field]
+		// if !ok {
+		// 	field = RunningStats{
+		// 		PercLimit: s.PercentileLimit,
+		// 	}
+		// }
+		// if m.samplerate > 0 {
+		// 	for i := 0; i < int(1.0/m.samplerate); i++ {
+		// 		field.AddValue(m.floatvalue)
+		// 	}
+		// } else {
+		// 	field.AddValue(m.floatvalue)
+		// }
+		// cached.fields[m.field] = field
+		// s.timings[m.hash] = cached
 	case "c":
-		// check if the measurement exists
-		_, ok := s.counters[m.hash]
-		if !ok {
-			s.counters[m.hash] = cachedcounter{
-				name:   m.name,
-				fields: make(map[string]interface{}),
-				tags:   m.tags,
-			}
+		if m.field != "" && m.field != "value" {
+			m.mtags = append(m.mtags, trapmetrics.Tag{Category: "field", Value: m.field})
 		}
-		// check if the field exists
-		_, ok = s.counters[m.hash].fields[m.field]
-		if !ok {
-			s.counters[m.hash].fields[m.field] = int64(0)
+		v := m.intvalue
+		if m.samplerate > 0 {
+			v = int64(math.Round(float64(v) / m.samplerate))
 		}
-		s.counters[m.hash].fields[m.field] =
-			s.counters[m.hash].fields[m.field].(int64) + m.intvalue
+		// counters are recorded like histograms, backend mutates back into a counter
+		if err := s.metricDestination.HistogramRecordCountForValue(m.name, m.mtags, v, 0); err != nil {
+			s.Log.Warnf("recording counter (%s): %s", m.name, err)
+		}
+		// // check if the measurement exists
+		// _, ok := s.counters[m.hash]
+		// if !ok {
+		// 	s.counters[m.hash] = cachedcounter{
+		// 		name:   m.name,
+		// 		fields: make(map[string]interface{}),
+		// 		tags:   m.tags,
+		// 	}
+		// }
+		// // check if the field exists
+		// _, ok = s.counters[m.hash].fields[m.field]
+		// if !ok {
+		// 	s.counters[m.hash].fields[m.field] = int64(0)
+		// }
+		// s.counters[m.hash].fields[m.field] =
+		// 	s.counters[m.hash].fields[m.field].(int64) + m.intvalue
 	case "g":
-		// check if the measurement exists
-		_, ok := s.gauges[m.hash]
-		if !ok {
-			s.gauges[m.hash] = cachedgauge{
-				name:   m.name,
-				fields: make(map[string]interface{}),
-				tags:   m.tags,
-			}
+		if m.field != "" && m.field != "value" {
+			m.mtags = append(m.mtags, trapmetrics.Tag{Category: "field", Value: m.field})
 		}
-		// check if the field exists
-		_, ok = s.gauges[m.hash].fields[m.field]
-		if !ok {
-			s.gauges[m.hash].fields[m.field] = float64(0)
+		if err := s.metricDestination.GaugeAdd(m.name, m.mtags, m.floatvalue, nil); err != nil {
+			s.Log.Warnf("adjusting gauge (%s): %s", m.name, err)
 		}
-		if m.additive {
-			s.gauges[m.hash].fields[m.field] =
-				s.gauges[m.hash].fields[m.field].(float64) + m.floatvalue
-		} else {
-			s.gauges[m.hash].fields[m.field] = m.floatvalue
-		}
+		// // check if the measurement exists
+		// _, ok := s.gauges[m.hash]
+		// if !ok {
+		// 	s.gauges[m.hash] = cachedgauge{
+		// 		name:   m.name,
+		// 		fields: make(map[string]interface{}),
+		// 		tags:   m.tags,
+		// 	}
+		// }
+		// // check if the field exists
+		// _, ok = s.gauges[m.hash].fields[m.field]
+		// if !ok {
+		// 	s.gauges[m.hash].fields[m.field] = float64(0)
+		// }
+		// if m.additive {
+		// 	s.gauges[m.hash].fields[m.field] =
+		// 		s.gauges[m.hash].fields[m.field].(float64) + m.floatvalue
+		// } else {
+		// 	s.gauges[m.hash].fields[m.field] = m.floatvalue
+		// }
 	case "s":
-		// check if the measurement exists
-		_, ok := s.sets[m.hash]
-		if !ok {
-			s.sets[m.hash] = cachedset{
-				name:   m.name,
-				fields: make(map[string]map[string]bool),
-				tags:   m.tags,
-			}
+		if m.field != "" && m.field != "value" {
+			m.mtags = append(m.mtags, trapmetrics.Tag{Category: "field", Value: m.field})
 		}
-		// check if the field exists
-		_, ok = s.sets[m.hash].fields[m.field]
-		if !ok {
-			s.sets[m.hash].fields[m.field] = make(map[string]bool)
+		if m.strvalue != "" {
+			m.mtags = append(m.mtags, trapmetrics.Tag{Category: "set_id", Value: m.strvalue})
 		}
-		s.sets[m.hash].fields[m.field][m.strvalue] = true
+		// sets are recorded like histograms, backend mutates back into a counter
+		if err := s.metricDestination.HistogramRecordCountForValue(m.name, m.mtags, 1, 0); err != nil {
+			s.Log.Warnf("recording set (%s:%): %s", m.name, m.field, err)
+		}
+		// // check if the measurement exists
+		// _, ok := s.sets[m.hash]
+		// if !ok {
+		// 	s.sets[m.hash] = cachedset{
+		// 		name:   m.name,
+		// 		fields: make(map[string]map[string]bool),
+		// 		tags:   m.tags,
+		// 	}
+		// }
+		// // check if the field exists
+		// _, ok = s.sets[m.hash].fields[m.field]
+		// if !ok {
+		// 	s.sets[m.hash].fields[m.field] = make(map[string]bool)
+		// }
+		// s.sets[m.hash].fields[m.field][m.strvalue] = true
+	case "t":
+		if m.field != "" && m.field != "value" {
+			m.mtags = append(m.mtags, trapmetrics.Tag{Category: "field", Value: m.field})
+		}
+		if err := s.metricDestination.TextSet(m.name, m.mtags, m.strvalue, nil); err != nil {
+			s.Log.Warnf("setting text (%s): %s", m.name, err)
+		}
 	}
 }
 
@@ -942,10 +1026,10 @@ func init() {
 			TCPKeepAlive:           false,
 			MetricSeparator:        "_",
 			AllowedPendingMessages: defaultAllowPendingMessage,
-			DeleteCounters:         true,
-			DeleteGauges:           true,
-			DeleteSets:             true,
-			DeleteTimings:          true,
+			// DeleteCounters:         true,
+			// DeleteGauges:           true,
+			// DeleteSets:             true,
+			// DeleteTimings:          true,
 		}
 	})
 }

--- a/plugins/inputs/statsd/statsd_test.go
+++ b/plugins/inputs/statsd/statsd_test.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/circonus-labs/circonus-unified-agent/cua"
-	"github.com/circonus-labs/circonus-unified-agent/internal"
+	"github.com/maier/go-trapmetrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -28,12 +28,14 @@ func NewTestStatsd() *Statsd {
 	// Make data structures
 	s.done = make(chan struct{})
 	s.in = make(chan input, s.AllowedPendingMessages)
-	s.gauges = make(map[string]cachedgauge)
-	s.counters = make(map[string]cachedcounter)
-	s.sets = make(map[string]cachedset)
-	s.timings = make(map[string]cachedtimings)
+	// s.gauges = make(map[string]cachedgauge)
+	// s.counters = make(map[string]cachedcounter)
+	// s.sets = make(map[string]cachedset)
+	// s.timings = make(map[string]cachedtimings)
 
 	s.MetricSeparator = "_"
+
+	s.metricDestination, _ = trapmetrics.New(&trapmetrics.Config{})
 
 	return &s
 }
@@ -49,7 +51,7 @@ func TestConcurrentConns(t *testing.T) {
 	}
 
 	acc := &testutil.Accumulator{}
-	require.NoError(t, listener.Start(acc))
+	require.NoError(t, listener.Start(context.Background(), acc))
 	defer listener.Stop()
 
 	time.Sleep(time.Millisecond * 250)
@@ -80,7 +82,7 @@ func TestConcurrentConns1(t *testing.T) {
 	}
 
 	acc := &testutil.Accumulator{}
-	require.NoError(t, listener.Start(acc))
+	require.NoError(t, listener.Start(context.Background(), acc))
 	defer listener.Stop()
 
 	time.Sleep(time.Millisecond * 250)
@@ -109,7 +111,7 @@ func TestCloseConcurrentConns(t *testing.T) {
 	}
 
 	acc := &testutil.Accumulator{}
-	require.NoError(t, listener.Start(acc))
+	require.NoError(t, listener.Start(context.Background(), acc))
 
 	time.Sleep(time.Millisecond * 250)
 	_, err := net.Dial("tcp", "127.0.0.1:8125")
@@ -132,7 +134,7 @@ func BenchmarkUDP(b *testing.B) {
 
 	// send multiple messages to socket
 	for n := 0; n < b.N; n++ {
-		err := listener.Start(acc)
+		err := listener.Start(context.Background(), acc)
 		if err != nil {
 			panic(err)
 		}
@@ -179,7 +181,7 @@ func BenchmarkTCP(b *testing.B) {
 
 	// send multiple messages to socket
 	for n := 0; n < b.N; n++ {
-		err := listener.Start(acc)
+		err := listener.Start(context.Background(), acc)
 		if err != nil {
 			panic(err)
 		}
@@ -212,6 +214,7 @@ func TestParse_ValidLines(t *testing.T) {
 		"valid:45|g",
 		"valid.timer:45|ms",
 		"valid.timer:45|h",
+		"valid:foo|t",
 	}
 
 	for _, line := range validLines {
@@ -291,7 +294,7 @@ func TestParse_Gauges(t *testing.T) {
 	}
 
 	for _, test := range validations {
-		err := testValidateGauge(test.name, test.value, s.gauges)
+		err := testValidateGauge(test.name, test.value, s.metricDestination)
 		if err != nil {
 			t.Error(err.Error())
 		}
@@ -353,7 +356,7 @@ func TestParse_Sets(t *testing.T) {
 	}
 
 	for _, test := range validations {
-		err := testValidateSet(test.name, test.value, s.sets)
+		err := testValidateSet(test.name, test.value, s.metricDestination)
 		if err != nil {
 			t.Error(err.Error())
 		}
@@ -418,49 +421,51 @@ func TestParse_Counters(t *testing.T) {
 	}
 
 	for _, test := range validations {
-		err := testValidateCounter(test.name, test.value, s.counters)
+		err := testValidateCounter(test.name, test.value, s.metricDestination)
 		if err != nil {
 			t.Error(err.Error())
 		}
 	}
 }
 
-// Tests low-level functionality of timings
-func TestParse_Timings(t *testing.T) {
-	s := NewTestStatsd()
-	s.Percentiles = []internal.Number{{Value: 90.0}}
-	acc := &testutil.Accumulator{}
+// derivatives are not created as this is UI functionality
 
-	// Test that counters work
-	validLines := []string{
-		"test.timing:1|ms",
-		"test.timing:11|ms",
-		"test.timing:1|ms",
-		"test.timing:1|ms",
-		"test.timing:1|ms",
-	}
+// // Tests low-level functionality of timings
+// func TestParse_Timings(t *testing.T) {
+// 	s := NewTestStatsd()
+// 	// s.Percentiles = []internal.Number{{Value: 90.0}}
+// 	acc := &testutil.Accumulator{}
 
-	for _, line := range validLines {
-		err := s.parseStatsdLine(line)
-		if err != nil {
-			t.Errorf("Parsing line %s should not have resulted in an error\n", line)
-		}
-	}
+// 	// Test that counters work
+// 	validLines := []string{
+// 		"test.timing:1|ms",
+// 		"test.timing:11|ms",
+// 		"test.timing:1|ms",
+// 		"test.timing:1|ms",
+// 		"test.timing:1|ms",
+// 	}
 
-	_ = s.Gather(context.Background(), acc)
+// 	for _, line := range validLines {
+// 		err := s.parseStatsdLine(line)
+// 		if err != nil {
+// 			t.Errorf("Parsing line %s should not have resulted in an error\n", line)
+// 		}
+// 	}
 
-	valid := map[string]interface{}{
-		"90_percentile": float64(11),
-		"count":         int64(5),
-		"lower":         float64(1),
-		"mean":          float64(3),
-		"stddev":        float64(4),
-		"sum":           float64(15),
-		"upper":         float64(11),
-	}
+// 	_ = s.Gather(context.Background(), acc)
 
-	acc.AssertContainsFields(t, "test_timing", valid)
-}
+// 	valid := map[string]interface{}{
+// 		"90_percentile": float64(11),
+// 		"count":         int64(5),
+// 		"lower":         float64(1),
+// 		"mean":          float64(3),
+// 		"stddev":        float64(4),
+// 		"sum":           float64(15),
+// 		"upper":         float64(11),
+// 	}
+
+// 	acc.AssertContainsFields(t, "test_timing", valid)
+// }
 
 func TestParseScientificNotation(t *testing.T) {
 	s := NewTestStatsd()
@@ -520,33 +525,30 @@ func TestParse_InvalidSampleRate(t *testing.T) {
 	counterValidations := []struct {
 		name  string
 		value int64
-		cache map[string]cachedcounter
 	}{
 		{
 			"invalid_sample_rate",
 			45,
-			s.counters,
 		},
 		{
 			"invalid_sample_rate_2",
 			45,
-			s.counters,
 		},
 	}
 
 	for _, test := range counterValidations {
-		err := testValidateCounter(test.name, test.value, test.cache)
+		err := testValidateCounter(test.name, test.value, s.metricDestination)
 		if err != nil {
 			t.Error(err.Error())
 		}
 	}
 
-	err := testValidateGauge("invalid_sample_rate", 45, s.gauges)
+	err := testValidateGauge("invalid_sample_rate", 45, s.metricDestination)
 	if err != nil {
 		t.Error(err.Error())
 	}
 
-	err = testValidateSet("invalid_sample_rate", 1, s.sets)
+	err = testValidateSet("invalid_sample_rate", 1, s.metricDestination)
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -582,7 +584,7 @@ func TestParse_DefaultNameParsing(t *testing.T) {
 	}
 
 	for _, test := range validations {
-		err := testValidateCounter(test.name, test.value, s.counters)
+		err := testValidateCounter(test.name, test.value, s.metricDestination)
 		if err != nil {
 			t.Error(err.Error())
 		}
@@ -624,7 +626,7 @@ func TestParse_Template(t *testing.T) {
 
 	// Validate counters
 	for _, test := range validations {
-		err := testValidateCounter(test.name, test.value, s.counters)
+		err := testValidateCounter(test.name, test.value, s.metricDestination)
 		if err != nil {
 			t.Error(err.Error())
 		}
@@ -666,7 +668,7 @@ func TestParse_TemplateFilter(t *testing.T) {
 
 	// Validate counters
 	for _, test := range validations {
-		err := testValidateCounter(test.name, test.value, s.counters)
+		err := testValidateCounter(test.name, test.value, s.metricDestination)
 		if err != nil {
 			t.Error(err.Error())
 		}
@@ -704,7 +706,7 @@ func TestParse_TemplateSpecificity(t *testing.T) {
 
 	// Validate counters
 	for _, test := range validations {
-		err := testValidateCounter(test.name, test.value, s.counters)
+		err := testValidateCounter(test.name, test.value, s.metricDestination)
 		if err != nil {
 			t.Error(err.Error())
 		}
@@ -763,7 +765,7 @@ func TestParse_TemplateFields(t *testing.T) {
 	}
 	// Validate counters
 	for _, test := range counterTests {
-		err := testValidateCounter(test.name, test.value, s.counters, test.field)
+		err := testValidateCounter(test.name, test.value, s.metricDestination, test.field)
 		if err != nil {
 			t.Error(err.Error())
 		}
@@ -787,7 +789,7 @@ func TestParse_TemplateFields(t *testing.T) {
 	}
 	// Validate gauges
 	for _, test := range gaugeTests {
-		err := testValidateGauge(test.name, test.value, s.gauges, test.field)
+		err := testValidateGauge(test.name, test.value, s.metricDestination, test.field)
 		if err != nil {
 			t.Error(err.Error())
 		}
@@ -811,7 +813,7 @@ func TestParse_TemplateFields(t *testing.T) {
 	}
 	// Validate sets
 	for _, test := range setTests {
-		err := testValidateSet(test.name, test.value, s.sets, test.field)
+		err := testValidateSet(test.name, test.value, s.metricDestination, test.field)
 		if err != nil {
 			t.Error(err.Error())
 		}
@@ -984,18 +986,20 @@ func TestParse_DataDogTags(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			var acc testutil.Accumulator
+			// var acc testutil.Accumulator
 
 			s := NewTestStatsd()
 			s.DataDogExtensions = true
 
 			err := s.parseStatsdLine(tt.line)
 			require.NoError(t, err)
+			/* need to re-work this test, as there is no Gather - it just sends...
 			err = s.Gather(context.Background(), &acc)
 			require.NoError(t, err)
 
 			testutil.RequireMetricsEqual(t, tt.expected, acc.GetCUAMetrics(),
 				testutil.SortMetrics(), testutil.IgnoreTime())
+			*/
 		})
 	}
 }
@@ -1076,9 +1080,21 @@ func TestParse_MeasurementsWithSameName(t *testing.T) {
 		}
 	}
 
-	if len(s.counters) != 2 {
-		t.Errorf("Expected 2 separate measurements, found %d", len(s.counters))
+	_, err := s.metricDestination.CounterFetch("test_counter", trapmetrics.Tags{{Category: "host", Value: "localhost"}})
+	if err != nil {
+		t.Errorf(err.Error())
 	}
+	_, err = s.metricDestination.CounterFetch("test_counter", trapmetrics.Tags{
+		{Category: "host", Value: "localhost"},
+		{Category: "region", Value: "west"},
+	})
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	// if len(s.counters) != 2 {
+	// 	t.Errorf("Expected 2 separate measurements, found %d", len(s.counters))
+	// }
 }
 
 // Test that measurements with multiple bits, are treated as different outputs
@@ -1136,6 +1152,7 @@ func TestParse_MeasurementsWithMultipleValues(t *testing.T) {
 		}
 	}
 
+	/* need to re-work these histogram tests
 	if len(sSingle.timings) != 3 {
 		t.Errorf("Expected 3 measurement, found %d", len(sSingle.timings))
 	}
@@ -1159,54 +1176,55 @@ func TestParse_MeasurementsWithMultipleValues(t *testing.T) {
 			t.Errorf("Expected max input to be 1, got %f", cachedtiming.fields[defaultFieldName].upper)
 		}
 	}
+	*/
 
 	// test if sSingle and sMultiple did compute the same stats for valid.multiple.duplicate
-	if err := testValidateSet("valid_multiple_duplicate", 2, sSingle.sets); err != nil {
+	if err := testValidateSet("valid_multiple_duplicate", 2, sSingle.metricDestination); err != nil {
 		t.Error(err.Error())
 	}
 
-	if err := testValidateSet("valid_multiple_duplicate", 2, sMultiple.sets); err != nil {
+	if err := testValidateSet("valid_multiple_duplicate", 2, sMultiple.metricDestination); err != nil {
 		t.Error(err.Error())
 	}
 
-	if err := testValidateCounter("valid_multiple_duplicate", 5, sSingle.counters); err != nil {
+	if err := testValidateCounter("valid_multiple_duplicate", 5, sSingle.metricDestination); err != nil {
 		t.Error(err.Error())
 	}
 
-	if err := testValidateCounter("valid_multiple_duplicate", 5, sMultiple.counters); err != nil {
+	if err := testValidateCounter("valid_multiple_duplicate", 5, sMultiple.metricDestination); err != nil {
 		t.Error(err.Error())
 	}
 
-	if err := testValidateGauge("valid_multiple_duplicate", 1, sSingle.gauges); err != nil {
+	if err := testValidateGauge("valid_multiple_duplicate", 1, sSingle.metricDestination); err != nil {
 		t.Error(err.Error())
 	}
 
-	if err := testValidateGauge("valid_multiple_duplicate", 1, sMultiple.gauges); err != nil {
+	if err := testValidateGauge("valid_multiple_duplicate", 1, sMultiple.metricDestination); err != nil {
 		t.Error(err.Error())
 	}
 
 	// test if sSingle and sMultiple did compute the same stats for valid.multiple.mixed
-	if err := testValidateSet("valid_multiple_mixed", 1, sSingle.sets); err != nil {
+	if err := testValidateSet("valid_multiple_mixed", 1, sSingle.metricDestination); err != nil {
 		t.Error(err.Error())
 	}
 
-	if err := testValidateSet("valid_multiple_mixed", 1, sMultiple.sets); err != nil {
+	if err := testValidateSet("valid_multiple_mixed", 1, sMultiple.metricDestination); err != nil {
 		t.Error(err.Error())
 	}
 
-	if err := testValidateCounter("valid_multiple_mixed", 1, sSingle.counters); err != nil {
+	if err := testValidateCounter("valid_multiple_mixed", 1, sSingle.metricDestination); err != nil {
 		t.Error(err.Error())
 	}
 
-	if err := testValidateCounter("valid_multiple_mixed", 1, sMultiple.counters); err != nil {
+	if err := testValidateCounter("valid_multiple_mixed", 1, sMultiple.metricDestination); err != nil {
 		t.Error(err.Error())
 	}
 
-	if err := testValidateGauge("valid_multiple_mixed", 1, sSingle.gauges); err != nil {
+	if err := testValidateGauge("valid_multiple_mixed", 1, sSingle.metricDestination); err != nil {
 		t.Error(err.Error())
 	}
 
-	if err := testValidateGauge("valid_multiple_mixed", 1, sMultiple.gauges); err != nil {
+	if err := testValidateGauge("valid_multiple_mixed", 1, sMultiple.metricDestination); err != nil {
 		t.Error(err.Error())
 	}
 }
@@ -1216,8 +1234,8 @@ func TestParse_MeasurementsWithMultipleValues(t *testing.T) {
 func TestParse_TimingsMultipleFieldsWithTemplate(t *testing.T) {
 	s := NewTestStatsd()
 	s.Templates = []string{"measurement.field"}
-	s.Percentiles = []internal.Number{{Value: 90.0}}
-	acc := &testutil.Accumulator{}
+	// s.Percentiles = []internal.Number{{Value: 90.0}}
+	// acc := &testutil.Accumulator{}
 
 	validLines := []string{
 		"test_timing.success:1|ms",
@@ -1238,27 +1256,30 @@ func TestParse_TimingsMultipleFieldsWithTemplate(t *testing.T) {
 			t.Errorf("Parsing line %s should not have resulted in an error\n", line)
 		}
 	}
-	_ = s.Gather(context.Background(), acc)
 
-	valid := map[string]interface{}{
-		"success_90_percentile": float64(11),
-		"success_count":         int64(5),
-		"success_lower":         float64(1),
-		"success_mean":          float64(3),
-		"success_stddev":        float64(4),
-		"success_sum":           float64(15),
-		"success_upper":         float64(11),
+	// re-work test to verify histograms -- derivatives are not created
 
-		"error_90_percentile": float64(22),
-		"error_count":         int64(5),
-		"error_lower":         float64(2),
-		"error_mean":          float64(6),
-		"error_stddev":        float64(8),
-		"error_sum":           float64(30),
-		"error_upper":         float64(22),
-	}
+	// _ = s.Gather(context.Background(), acc)
 
-	acc.AssertContainsFields(t, "test_timing", valid)
+	// valid := map[string]interface{}{
+	// 	"success_90_percentile": float64(11),
+	// 	"success_count":         int64(5),
+	// 	"success_lower":         float64(1),
+	// 	"success_mean":          float64(3),
+	// 	"success_stddev":        float64(4),
+	// 	"success_sum":           float64(15),
+	// 	"success_upper":         float64(11),
+
+	// 	"error_90_percentile": float64(22),
+	// 	"error_count":         int64(5),
+	// 	"error_lower":         float64(2),
+	// 	"error_mean":          float64(6),
+	// 	"error_stddev":        float64(8),
+	// 	"error_sum":           float64(30),
+	// 	"error_upper":         float64(22),
+	// }
+
+	// acc.AssertContainsFields(t, "test_timing", valid)
 }
 
 // Tests low-level functionality of timings when multiple fields is enabled
@@ -1267,8 +1288,8 @@ func TestParse_TimingsMultipleFieldsWithTemplate(t *testing.T) {
 func TestParse_TimingsMultipleFieldsWithoutTemplate(t *testing.T) {
 	s := NewTestStatsd()
 	s.Templates = []string{}
-	s.Percentiles = []internal.Number{{Value: 90.0}}
-	acc := &testutil.Accumulator{}
+	// s.Percentiles = []internal.Number{{Value: 90.0}}
+	// acc := &testutil.Accumulator{}
 
 	validLines := []string{
 		"test_timing.success:1|ms",
@@ -1289,29 +1310,32 @@ func TestParse_TimingsMultipleFieldsWithoutTemplate(t *testing.T) {
 			t.Errorf("Parsing line %s should not have resulted in an error\n", line)
 		}
 	}
-	_ = s.Gather(context.Background(), acc)
 
-	expectedSuccess := map[string]interface{}{
-		"90_percentile": float64(11),
-		"count":         int64(5),
-		"lower":         float64(1),
-		"mean":          float64(3),
-		"stddev":        float64(4),
-		"sum":           float64(15),
-		"upper":         float64(11),
-	}
-	expectedError := map[string]interface{}{
-		"90_percentile": float64(22),
-		"count":         int64(5),
-		"lower":         float64(2),
-		"mean":          float64(6),
-		"stddev":        float64(8),
-		"sum":           float64(30),
-		"upper":         float64(22),
-	}
+	// re-work histogram tests -- derivatives are not created
 
-	acc.AssertContainsFields(t, "test_timing_success", expectedSuccess)
-	acc.AssertContainsFields(t, "test_timing_error", expectedError)
+	// _ = s.Gather(context.Background(), acc)
+
+	// expectedSuccess := map[string]interface{}{
+	// 	"90_percentile": float64(11),
+	// 	"count":         int64(5),
+	// 	"lower":         float64(1),
+	// 	"mean":          float64(3),
+	// 	"stddev":        float64(4),
+	// 	"sum":           float64(15),
+	// 	"upper":         float64(11),
+	// }
+	// expectedError := map[string]interface{}{
+	// 	"90_percentile": float64(22),
+	// 	"count":         int64(5),
+	// 	"lower":         float64(2),
+	// 	"mean":          float64(6),
+	// 	"stddev":        float64(8),
+	// 	"sum":           float64(30),
+	// 	"upper":         float64(22),
+	// }
+
+	// acc.AssertContainsFields(t, "test_timing_success", expectedSuccess)
+	// acc.AssertContainsFields(t, "test_timing_error", expectedError)
 }
 
 func BenchmarkParse(b *testing.B) {
@@ -1444,106 +1468,110 @@ func BenchmarkParseWith2Templates3TagsAndFilter(b *testing.B) {
 	}
 }
 
-func TestParse_Timings_Delete(t *testing.T) {
-	s := NewTestStatsd()
-	s.DeleteTimings = true
-	fakeacc := &testutil.Accumulator{}
-	var err error
+//
+// no reason to test deletes
+//
 
-	line := "timing:100|ms"
-	err = s.parseStatsdLine(line)
-	if err != nil {
-		t.Errorf("Parsing line %s should not have resulted in an error\n", line)
-	}
+// func TestParse_Timings_Delete(t *testing.T) {
+// 	s := NewTestStatsd()
+// 	s.DeleteTimings = true
+// 	fakeacc := &testutil.Accumulator{}
+// 	var err error
 
-	if len(s.timings) != 1 {
-		t.Errorf("Should be 1 timing, found %d", len(s.timings))
-	}
+// 	line := "timing:100|ms"
+// 	err = s.parseStatsdLine(line)
+// 	if err != nil {
+// 		t.Errorf("Parsing line %s should not have resulted in an error\n", line)
+// 	}
 
-	_ = s.Gather(context.Background(), fakeacc)
+// 	if len(s.timings) != 1 {
+// 		t.Errorf("Should be 1 timing, found %d", len(s.timings))
+// 	}
 
-	if len(s.timings) != 0 {
-		t.Errorf("All timings should have been deleted, found %d", len(s.timings))
-	}
-}
+// 	_ = s.Gather(context.Background(), fakeacc)
 
-// Tests the delete_gauges option
-func TestParse_Gauges_Delete(t *testing.T) {
-	s := NewTestStatsd()
-	s.DeleteGauges = true
-	fakeacc := &testutil.Accumulator{}
-	var err error
+// 	if len(s.timings) != 0 {
+// 		t.Errorf("All timings should have been deleted, found %d", len(s.timings))
+// 	}
+// }
 
-	line := "current.users:100|g"
-	err = s.parseStatsdLine(line)
-	if err != nil {
-		t.Errorf("Parsing line %s should not have resulted in an error\n", line)
-	}
+// // Tests the delete_gauges option
+// func TestParse_Gauges_Delete(t *testing.T) {
+// 	s := NewTestStatsd()
+// 	s.DeleteGauges = true
+// 	fakeacc := &testutil.Accumulator{}
+// 	var err error
 
-	err = testValidateGauge("current_users", 100, s.gauges)
-	if err != nil {
-		t.Error(err.Error())
-	}
+// 	line := "current.users:100|g"
+// 	err = s.parseStatsdLine(line)
+// 	if err != nil {
+// 		t.Errorf("Parsing line %s should not have resulted in an error\n", line)
+// 	}
 
-	_ = s.Gather(context.Background(), fakeacc)
+// 	err = testValidateGauge("current_users", 100, s.gauges)
+// 	if err != nil {
+// 		t.Error(err.Error())
+// 	}
 
-	err = testValidateGauge("current_users", 100, s.gauges)
-	if err == nil {
-		t.Error("current_users_gauge metric should have been deleted")
-	}
-}
+// 	_ = s.Gather(context.Background(), fakeacc)
 
-// Tests the delete_sets option
-func TestParse_Sets_Delete(t *testing.T) {
-	s := NewTestStatsd()
-	s.DeleteSets = true
-	fakeacc := &testutil.Accumulator{}
-	var err error
+// 	err = testValidateGauge("current_users", 100, s.gauges)
+// 	if err == nil {
+// 		t.Error("current_users_gauge metric should have been deleted")
+// 	}
+// }
 
-	line := "unique.user.ids:100|s"
-	err = s.parseStatsdLine(line)
-	if err != nil {
-		t.Errorf("Parsing line %s should not have resulted in an error\n", line)
-	}
+// // Tests the delete_sets option
+// func TestParse_Sets_Delete(t *testing.T) {
+// 	s := NewTestStatsd()
+// 	s.DeleteSets = true
+// 	fakeacc := &testutil.Accumulator{}
+// 	var err error
 
-	err = testValidateSet("unique_user_ids", 1, s.sets)
-	if err != nil {
-		t.Error(err.Error())
-	}
+// 	line := "unique.user.ids:100|s"
+// 	err = s.parseStatsdLine(line)
+// 	if err != nil {
+// 		t.Errorf("Parsing line %s should not have resulted in an error\n", line)
+// 	}
 
-	_ = s.Gather(context.Background(), fakeacc)
+// 	err = testValidateSet("unique_user_ids", 1, s.sets)
+// 	if err != nil {
+// 		t.Error(err.Error())
+// 	}
 
-	err = testValidateSet("unique_user_ids", 1, s.sets)
-	if err == nil {
-		t.Error("unique_user_ids_set metric should have been deleted")
-	}
-}
+// 	_ = s.Gather(context.Background(), fakeacc)
 
-// Tests the delete_counters option
-func TestParse_Counters_Delete(t *testing.T) {
-	s := NewTestStatsd()
-	s.DeleteCounters = true
-	fakeacc := &testutil.Accumulator{}
-	var err error
+// 	err = testValidateSet("unique_user_ids", 1, s.sets)
+// 	if err == nil {
+// 		t.Error("unique_user_ids_set metric should have been deleted")
+// 	}
+// }
 
-	line := "total.users:100|c"
-	err = s.parseStatsdLine(line)
-	if err != nil {
-		t.Errorf("Parsing line %s should not have resulted in an error\n", line)
-	}
+// // Tests the delete_counters option
+// func TestParse_Counters_Delete(t *testing.T) {
+// 	s := NewTestStatsd()
+// 	s.DeleteCounters = true
+// 	fakeacc := &testutil.Accumulator{}
+// 	var err error
 
-	err = testValidateCounter("total_users", 100, s.counters)
-	if err != nil {
-		t.Error(err.Error())
-	}
+// 	line := "total.users:100|c"
+// 	err = s.parseStatsdLine(line)
+// 	if err != nil {
+// 		t.Errorf("Parsing line %s should not have resulted in an error\n", line)
+// 	}
 
-	_ = s.Gather(context.Background(), fakeacc)
+// 	err = testValidateCounter("total_users", 100, s.counters)
+// 	if err != nil {
+// 		t.Error(err.Error())
+// 	}
 
-	err = testValidateCounter("total_users", 100, s.counters)
-	if err == nil {
-		t.Error("total_users_counter metric should have been deleted")
-	}
-}
+// 	_ = s.Gather(context.Background(), fakeacc)
+
+// 	err = testValidateCounter("total_users", 100, s.counters)
+// 	if err == nil {
+// 		t.Error("total_users_counter metric should have been deleted")
+// 	}
+// }
 
 func TestParseKeyValue(t *testing.T) {
 	k, v := parseKeyValue("foo=bar")
@@ -1566,8 +1594,8 @@ func TestParseKeyValue(t *testing.T) {
 // Test utility functions
 func testValidateSet(
 	name string,
-	value int64,
-	cache map[string]cachedset,
+	value int64, //nolint:unparam
+	dest *trapmetrics.TrapMetrics,
 	field ...string,
 ) error {
 	var f string
@@ -1576,48 +1604,71 @@ func testValidateSet(
 	} else {
 		f = "value"
 	}
-	var metric cachedset
-	var found bool
-	for _, v := range cache {
-		if v.name == name {
-			metric = v
-			found = true
-			break
-		}
-	}
-	if !found {
-		return fmt.Errorf("test Error: Metric name %s not found", name)
+	// var metric cachedset
+	// var found bool
+	// for _, v := range cache {
+	// 	if v.name == name {
+	// 		metric = v
+	// 		found = true
+	// 		break
+	// 	}
+	// }
+	// if !found {
+	// 	return fmt.Errorf("test Error: Metric name %s not found", name)
+	// }
+	// if value != int64(len(metric.fields[f])) {
+	// 	return fmt.Errorf("measurement: %s, expected %d, actual %d", name, value, len(metric.fields[f]))
+	// }
+
+	_, err := dest.HistogramFetch(name, trapmetrics.Tags{
+		{Category: "statsd_type", Value: "count"},
+		{Category: "set_id", Value: f},
+	})
+	if err != nil {
+		return err
 	}
 
-	if value != int64(len(metric.fields[f])) {
-		return fmt.Errorf("measurement: %s, expected %d, actual %d", name, value, len(metric.fields[f]))
-	}
+	// for _, val := range m.Samples {
+	// 	valueActual = val.(int64)
+	// 	break
+	// }
+
 	return nil
 }
 
 func testValidateCounter(
 	name string,
 	valueExpected int64,
-	cache map[string]cachedcounter,
-	field ...string,
+	dest *trapmetrics.TrapMetrics,
+	field ...string, //nolint:unparam
 ) error {
-	var f string
-	if len(field) > 0 {
-		f = field[0]
-	} else {
-		f = "value"
-	}
+	// var f string
+	// if len(field) > 0 {
+	// 	f = field[0]
+	// } else {
+	// 	f = "value"
+	// }
 	var valueActual int64
-	var found bool
-	for _, v := range cache {
-		if v.name == name {
-			valueActual = v.fields[f].(int64)
-			found = true
-			break
-		}
+	// var found bool
+	// for _, v := range cache {
+	// 	if v.name == name {
+	// 		valueActual = v.fields[f].(int64)
+	// 		found = true
+	// 		break
+	// 	}
+	// }
+	// if !found {
+	// 	return fmt.Errorf("test Error: Metric name %s not found", name)
+	// }
+
+	m, err := dest.HistogramFetch(name, trapmetrics.Tags{{Category: "statsd_type", Value: "count"}})
+	if err != nil {
+		return err
 	}
-	if !found {
-		return fmt.Errorf("test Error: Metric name %s not found", name)
+
+	for _, val := range m.Samples {
+		valueActual = val.(int64)
+		break
 	}
 
 	if valueExpected != valueActual {
@@ -1629,26 +1680,24 @@ func testValidateCounter(
 func testValidateGauge(
 	name string,
 	valueExpected float64,
-	cache map[string]cachedgauge,
-	field ...string,
+	dest *trapmetrics.TrapMetrics,
+	field ...string, //nolint:unparam
 ) error {
-	var f string
-	if len(field) > 0 {
-		f = field[0]
-	} else {
-		f = "value"
-	}
+	// var f string
+	// if len(field) > 0 {
+	// 	f = field[0]
+	// } else {
+	// 	f = "value"
+	// }
 	var valueActual float64
-	var found bool
-	for _, v := range cache {
-		if v.name == name {
-			valueActual = v.fields[f].(float64)
-			found = true
-			break
-		}
+
+	metric, err := dest.GaugeFetch(name, nil)
+	if err != nil {
+		return err
 	}
-	if !found {
-		return fmt.Errorf("test Error: Metric name %s not found", name)
+	for _, val := range metric.Samples {
+		valueActual = val.(float64)
+		break
 	}
 
 	if valueExpected != valueActual {
@@ -1666,7 +1715,7 @@ func TestTCP(t *testing.T) {
 		MaxTCPConnections:      2,
 	}
 	var acc testutil.Accumulator
-	require.NoError(t, statsd.Start(&acc))
+	require.NoError(t, statsd.Start(context.Background(), &acc))
 	defer statsd.Stop()
 
 	addr := statsd.TCPlistener.Addr().String()
@@ -1713,7 +1762,7 @@ func TestUdp(t *testing.T) {
 		AllowedPendingMessages: 250000,
 	}
 	var acc testutil.Accumulator
-	require.NoError(t, statsd.Start(&acc))
+	require.NoError(t, statsd.Start(context.Background(), &acc))
 	defer statsd.Stop()
 
 	conn, _ := net.Dial("udp", "127.0.0.1:8125")

--- a/plugins/inputs/statsd_deprecated/README.md
+++ b/plugins/inputs/statsd_deprecated/README.md
@@ -1,0 +1,246 @@
+# StatsD Input Plugin
+
+### Configuration
+
+```toml
+# Statsd Server
+[[inputs.statsd]]
+  ## Protocol, must be "tcp", "udp4", "udp6" or "udp" (default=udp)
+  protocol = "udp"
+
+  ## MaxTCPConnection - applicable when protocol is set to tcp (default=250)
+  max_tcp_connections = 250
+
+  ## Enable TCP keep alive probes (default=false)
+  tcp_keep_alive = false
+
+  ## Specifies the keep-alive period for an active network connection.
+  ## Only applies to TCP sockets and will be ignored if tcp_keep_alive is false.
+  ## Defaults to the OS configuration.
+  # tcp_keep_alive_period = "2h"
+
+  ## Address and port to host UDP listener on
+  service_address = ":8125"
+
+  ## The following configuration options control when agent clears it's cache
+  ## of previous values. If set to false, then agent will only clear it's
+  ## cache when the daemon is restarted.
+  ## Reset gauges every interval (default=true)
+  delete_gauges = true
+  ## Reset counters every interval (default=true)
+  delete_counters = true
+  ## Reset sets every interval (default=true)
+  delete_sets = true
+  ## Reset timings & histograms every interval (default=true)
+  delete_timings = true
+
+  ## Percentiles to calculate for timing & histogram stats.
+  percentiles = [50.0, 90.0, 99.0, 99.9, 99.95, 100.0]
+
+  ## separator to use between elements of a statsd metric
+  metric_separator = "_"
+
+  ## Parses extensions to statsd in the datadog statsd format
+  ## currently supports metrics and datadog tags.
+  ## http://docs.datadoghq.com/guides/dogstatsd/
+  datadog_extensions = false
+
+  ## Statsd data translation templates, more info can be read here:
+  ## https://github.com/circonus-labs/circonus-unified-agent/blob/master/docs/TEMPLATE_PATTERN.md
+  # templates = [
+  #     "cpu.* measurement*"
+  # ]
+
+  ## Number of UDP messages allowed to queue up, once filled,
+  ## the statsd server will start dropping packets
+  allowed_pending_messages = 10000
+
+  ## Number of timing/histogram values to track per-measurement in the
+  ## calculation of percentiles. Raising this limit increases the accuracy
+  ## of percentiles but also increases the memory usage and cpu time.
+  percentile_limit = 1000
+
+  ## Maximum socket buffer size in bytes, once the buffer fills up, metrics
+  ## will start dropping.  Defaults to the OS default.
+  # read_buffer_size = 65535
+```
+
+### Description
+
+The statsd plugin is a special type of plugin which runs a backgrounded statsd
+listener service while agent is running.
+
+The format of the statsd messages was based on the format described in the
+original [etsy statsd](https://github.com/etsy/statsd/blob/master/docs/metric_types.md)
+implementation. In short, the agent statsd listener will accept:
+
+* Gauges
+  * `users.current.den001.myapp:32|g` <- standard
+  * `users.current.den001.myapp:+10|g` <- additive
+  * `users.current.den001.myapp:-10|g`
+
+* Counters
+  * `deploys.test.myservice:1|c` <- increments by 1
+  * `deploys.test.myservice:101|c` <- increments by 101
+  * `deploys.test.myservice:1|c|@0.1` <- with sample rate, increments by 10
+
+* Sets
+  * `users.unique:101|s`
+  * `users.unique:101|s`
+  * `users.unique:102|s` <- would result in a count of 2 for `users.unique`
+  
+* Timings & Histograms
+  * `load.time:320|ms`
+  * `load.time.nanoseconds:1|h`
+  * `load.time:200|ms|@0.1` <- sampled 1/10 of the time
+
+It is possible to omit repetitive names and merge individual stats into a
+single line by separating them with additional colons:
+
+* `users.current.den001.myapp:32|g:+10|g:-10|g`
+* `deploys.test.myservice:1|c:101|c:1|c|@0.1`
+* `users.unique:101|s:101|s:102|s`
+* `load.time:320|ms:200|ms|@0.1`
+
+This also allows for mixed types in a single line:
+
+* `foo:1|c:200|ms`
+
+The string `foo:1|c:200|ms` is internally split into two individual metrics
+`foo:1|c` and `foo:200|ms` which are added to the aggregator separately.
+
+### Influx Statsd
+
+In order to take advantage of InfluxDB's tagging system, a couple
+additions to the standard statsd protocol have been made. First, tags
+may be specified in a manner similar to the line-protocol, like this:
+
+```text
+users.current,service=payroll,region=us-west:32|g
+```
+
+<!-- TODO Second, you can specify multiple fields within a measurement:
+
+```
+current.users,service=payroll,server=host01:west=10,east=10,central=2,south=10|g
+``` -->
+
+### Measurements
+
+Meta:
+
+* tags: `metric_type=<gauge|set|counter|timing|histogram>`
+
+Outputted measurements will depend entirely on the measurements that the user
+sends, but here is a brief rundown of what you can expect to find from each
+metric type:
+
+* Gauges
+  * Gauges are a constant data type. They are not subject to averaging, and they
+    don’t change unless you change them. That is, once you set a gauge value, it
+    will be a flat line on the graph until you change it again.
+
+* Counters
+  * Counters are the most basic type. They are treated as a count of a type of
+    event. They will continually increase unless you set `delete_counters=true`.
+
+* Sets
+  * Sets count the number of unique values passed to a key. For example, you
+    could count the number of users accessing your system using `users:<user_id>|s`.
+    No matter how many times the same user_id is sent, the count will only increase
+    by 1.
+
+* Timings & Histograms
+  * Timers are meant to track how long something took. They are an invaluable
+    tool for tracking application performance.
+  * The following aggregate measurements are made for timers:
+    * `statsd_<name>_lower`: The lower bound is the lowest value statsd saw
+      for that stat during that interval.
+    * `statsd_<name>_upper`: The upper bound is the highest value statsd saw
+      for that stat during that interval.
+    * `statsd_<name>_mean`: The mean is the average of all values statsd saw
+      for that stat during that interval.
+    * `statsd_<name>_stddev`: The stddev is the sample standard deviation
+      of all values statsd saw for that stat during that interval.
+    * `statsd_<name>_sum`: The sum is the sample sum of all values statsd saw
+      for that stat during that interval.
+    * `statsd_<name>_count`: The count is the number of timings statsd saw
+      for that stat during that interval. It is not averaged.
+    * `statsd_<name>_percentile_<P>` The `Pth` percentile is a value x such
+      that `P%` of all the values statsd saw for that stat during that time
+      period are below x. The most common value that people use for `P` is the
+      `90`, this is a great number to try to optimize.
+
+### Plugin arguments
+
+* **protocol** string: Protocol used in listener - tcp or udp options
+
+* **max_tcp_connections** []int: Maximum number of concurrent TCP connections to allow. Used when protocol is set to tcp.
+
+* **tcp_keep_alive** boolean: Enable TCP keep alive probes
+
+* **tcp_keep_alive_period** internal.Duration: Specifies the keep-alive period for an active network connection
+
+* **service_address** string: Address to listen for statsd UDP packets on
+
+* **delete_gauges** boolean: Delete gauges on every collection interval
+
+* **delete_counters** boolean: Delete counters on every collection interval
+
+* **delete_sets** boolean: Delete set counters on every collection interval
+
+* **delete_timings** boolean: Delete timings on every collection interval
+
+* **percentiles** []int: Percentiles to calculate for timing & histogram stats
+
+* **allowed_pending_messages** integer: Number of messages allowed to queue up waiting to be processed. When this fills, messages will be dropped and logged.
+
+* **percentile_limit** integer: Number of timing/histogram values to track per-measurement in the calculation of percentiles. Raising this limit increases the accuracy of percentiles but also increases the memory usage and cpu time.
+
+* **templates** []string: Templates for transforming statsd buckets into influx measurements and tags.
+
+* **datadog_extensions** boolean: Enable parsing of DataDog's extensions to dogstatsd format (http://docs.datadoghq.com/guides/dogstatsd/)
+
+### Statsd bucket -> InfluxDB line-protocol Templates
+
+The plugin supports specifying templates for transforming statsd buckets into
+InfluxDB measurement names and tags. The templates have a _measurement_ keyword,
+which can be used to specify parts of the bucket that are to be used in the
+measurement name. Other words in the template are used as tag names. For example,
+the following template:
+
+```toml
+templates = [
+    "measurement.measurement.region"
+]
+```
+
+would result in the following transformation:
+
+```text
+cpu.load.us-west:100|g
+=> cpu_load,region=us-west 100
+```
+
+Users can also filter the template to use based on the name of the bucket,
+using glob matching, like so:
+
+```toml
+templates = [
+    "cpu.* measurement.measurement.region",
+    "mem.* measurement.measurement.host"
+]
+```
+
+which would result in the following transformation:
+
+```text
+cpu.load.us-west:100|g
+=> cpu_load,region=us-west 100
+
+mem.cached.localhost:256|g
+=> mem_cached,host=localhost 256
+```
+
+Consult the [Template Patterns](/docs/TEMPLATE_PATTERN.md) documentation for
+additional details.

--- a/plugins/inputs/statsd_deprecated/datadog.go
+++ b/plugins/inputs/statsd_deprecated/datadog.go
@@ -1,0 +1,180 @@
+package statsd
+
+// this is adapted from datadog's apache licensed version at
+// https://github.com/DataDog/datadog-agent/blob/fcfc74f106ab1bd6991dfc6a7061c558d934158a/pkg/dogstatsd/parser.go#L173
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	priorityNormal = "normal"
+	priorityLow    = "low"
+
+	eventInfo    = "info"
+	eventWarning = "warning"
+	eventError   = "error"
+	eventSuccess = "success"
+)
+
+var uncommenter = strings.NewReplacer("\\n", "\n")
+
+func (s *Statsd) parseEventMessage(now time.Time, message string, defaultHostname string) error {
+	// _e{title.length,text.length}:title|text
+	//  [
+	//   |d:date_happened
+	//   |p:priority
+	//   |h:hostname
+	//   |t:alert_type
+	//   |s:source_type_nam
+	//   |#tag1,tag2
+	//  ]
+	//
+	//
+	// tag is key:value
+	messageRaw := strings.SplitN(message, ":", 2)
+	if len(messageRaw) < 2 || len(messageRaw[0]) < 7 || len(messageRaw[1]) < 3 {
+		return fmt.Errorf("Invalid message format")
+	}
+	header := messageRaw[0]
+	message = messageRaw[1]
+
+	rawLen := strings.SplitN(header[3:], ",", 2)
+	if len(rawLen) != 2 {
+		return fmt.Errorf("Invalid message format")
+	}
+
+	titleLen, err := strconv.ParseInt(rawLen[0], 10, 64)
+	if err != nil {
+		return fmt.Errorf("Invalid message format, could not parse title.length: '%s'", rawLen[0])
+	}
+	if len(rawLen[1]) < 1 {
+		return fmt.Errorf("Invalid message format, could not parse text.length: '%s'", rawLen[0])
+	}
+	textLen, err := strconv.ParseInt(rawLen[1][:len(rawLen[1])-1], 10, 64)
+	if err != nil {
+		return fmt.Errorf("Invalid message format, could not parse text.length: '%s'", rawLen[0])
+	}
+	if titleLen+textLen+1 > int64(len(message)) {
+		return fmt.Errorf("Invalid message format, title.length and text.length exceed total message length")
+	}
+
+	rawTitle := message[:titleLen]
+	rawText := message[titleLen+1 : titleLen+1+textLen]
+	message = message[titleLen+1+textLen:]
+
+	if len(rawTitle) == 0 || len(rawText) == 0 {
+		return fmt.Errorf("Invalid event message format: empty 'title' or 'text' field")
+	}
+
+	name := rawTitle
+	tags := make(map[string]string, strings.Count(message, ",")+2) // allocate for the approximate number of tags
+	fields := make(map[string]interface{}, 9)
+	fields["alert_type"] = eventInfo // default event type
+	fields["text"] = uncommenter.Replace(rawText)
+	if defaultHostname != "" {
+		tags["source"] = defaultHostname
+	}
+	fields["priority"] = priorityNormal
+	ts := now
+	if len(message) < 2 {
+		s.acc.AddFields(name, fields, tags, ts)
+		return nil
+	}
+
+	rawMetadataFields := strings.Split(message[1:], "|")
+	for i := range rawMetadataFields {
+		if len(rawMetadataFields[i]) < 2 {
+			return errors.New("too short metadata field")
+		}
+		switch rawMetadataFields[i][:2] {
+		case "d:":
+			ts, err := strconv.ParseInt(rawMetadataFields[i][2:], 10, 64)
+			if err != nil {
+				continue
+			}
+			fields["ts"] = ts
+		case "p:":
+			switch rawMetadataFields[i][2:] {
+			case priorityLow:
+				fields["priority"] = priorityLow
+			case priorityNormal: // we already used this as a default
+			default:
+				continue
+			}
+		case "h:":
+			tags["source"] = rawMetadataFields[i][2:]
+		case "t:":
+			switch rawMetadataFields[i][2:] {
+			case eventError, eventWarning, eventSuccess, eventInfo:
+				fields["alert_type"] = rawMetadataFields[i][2:] // already set for info
+			default:
+				continue
+			}
+		case "k:":
+			tags["aggregation_key"] = rawMetadataFields[i][2:]
+		case "s:":
+			fields["source_type_name"] = rawMetadataFields[i][2:]
+		default:
+			if rawMetadataFields[i][0] == '#' {
+				parseDataDogTags(tags, rawMetadataFields[i][1:])
+			} else {
+				return fmt.Errorf("unknown metadata type: '%s'", rawMetadataFields[i])
+			}
+		}
+	}
+	// Use source tag because 'host' is reserved tag key in agent.
+	// In datadog the host tag and `h:` are interchangeable, so we have to chech for the host tag.
+	if host, ok := tags["host"]; ok {
+		delete(tags, "host")
+		tags["source"] = host
+	}
+	s.acc.AddFields(name, fields, tags, ts)
+	return nil
+}
+
+func parseDataDogTags(tags map[string]string, message string) {
+	if len(message) == 0 {
+		return
+	}
+
+	start, i := 0, 0
+	var k string
+	var inVal bool // check if we are parsing the value part of the tag
+	for i = range message {
+		if message[i] == ',' {
+			if k == "" {
+				k = message[start:i]
+				tags[k] = "true" // this is because influx doesn't support empty tags
+				start = i + 1
+				continue
+			}
+			v := message[start:i]
+			if v == "" {
+				v = "true"
+			}
+			tags[k] = v
+			start = i + 1
+			k, inVal = "", false // reset state vars
+		} else if message[i] == ':' && !inVal {
+			k = message[start:i]
+			start = i + 1
+			inVal = true
+		}
+	}
+	if k == "" && start < i+1 {
+		tags[message[start:i+1]] = "true"
+	}
+	// grab the last value
+	if k != "" {
+		if start < i+1 {
+			tags[k] = message[start : i+1]
+			return
+		}
+		tags[k] = "true"
+	}
+}

--- a/plugins/inputs/statsd_deprecated/datadog_test.go
+++ b/plugins/inputs/statsd_deprecated/datadog_test.go
@@ -1,0 +1,486 @@
+package statsd
+
+import (
+	"testing"
+	"time"
+
+	"github.com/circonus-labs/circonus-unified-agent/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEventGather(t *testing.T) {
+	now := time.Now()
+	type expected struct {
+		title  string
+		tags   map[string]string
+		fields map[string]interface{}
+	}
+	tests := []struct {
+		name     string
+		message  string
+		hostname string
+		now      time.Time
+		err      bool
+		expected expected
+	}{{
+		name:     "basic",
+		message:  "_e{10,9}:test title|test text",
+		hostname: "default-hostname",
+		now:      now,
+		err:      false,
+		expected: expected{
+			title: "test title",
+			tags:  map[string]string{"source": "default-hostname"},
+			fields: map[string]interface{}{
+				"priority":   priorityNormal,
+				"alert_type": "info",
+				"text":       "test text",
+			},
+		},
+	},
+		{
+			name:     "escape some stuff",
+			message:  "_e{10,24}:test title|test\\line1\\nline2\\nline3",
+			hostname: "default-hostname",
+			now:      now.Add(1),
+			err:      false,
+			expected: expected{
+				title: "test title",
+				tags:  map[string]string{"source": "default-hostname"},
+				fields: map[string]interface{}{
+					"priority":   priorityNormal,
+					"alert_type": "info",
+					"text":       "test\\line1\nline2\nline3",
+				},
+			},
+		},
+		{
+			name:     "custom time",
+			message:  "_e{10,9}:test title|test text|d:21",
+			hostname: "default-hostname",
+			now:      now.Add(2),
+			err:      false,
+			expected: expected{
+				title: "test title",
+				tags:  map[string]string{"source": "default-hostname"},
+				fields: map[string]interface{}{
+					"priority":   priorityNormal,
+					"alert_type": "info",
+					"text":       "test text",
+					"ts":         int64(21),
+				},
+			},
+		},
+	}
+	acc := &testutil.Accumulator{}
+	s := NewTestStatsd()
+	require.NoError(t, s.Start(acc))
+	defer s.Stop()
+
+	for i := range tests {
+		i := i
+		t.Run(tests[i].name, func(t *testing.T) {
+			err := s.parseEventMessage(tests[i].now, tests[i].message, tests[i].hostname)
+			if tests[i].err {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, uint64(i+1), acc.NMetrics())
+
+			require.NoError(t, err)
+			require.Equal(t, tests[i].expected.title, acc.Metrics[i].Measurement)
+			require.Equal(t, tests[i].expected.tags, acc.Metrics[i].Tags)
+			require.Equal(t, tests[i].expected.fields, acc.Metrics[i].Fields)
+		})
+	}
+}
+
+// These tests adapted from tests in
+// https://github.com/DataDog/datadog-agent/blob/master/pkg/dogstatsd/parser_test.go
+// to ensure compatibility with the datadog-agent parser
+
+func TestEvents(t *testing.T) {
+	now := time.Now()
+	type args struct {
+		now      time.Time
+		message  string
+		hostname string
+	}
+	type expected struct {
+		title          string
+		text           interface{}
+		now            time.Time
+		ts             interface{}
+		priority       string
+		source         string
+		alertType      interface{}
+		aggregationKey string
+		sourceTypeName interface{}
+		checkTags      map[string]string
+	}
+
+	tests := []struct {
+		name     string
+		args     args
+		expected expected
+	}{
+		{
+			name: "event minimal",
+			args: args{
+				now:      now,
+				message:  "_e{10,9}:test title|test text",
+				hostname: "default-hostname",
+			},
+			expected: expected{
+				title:          "test title",
+				text:           "test text",
+				now:            now,
+				priority:       priorityNormal,
+				source:         "default-hostname",
+				alertType:      eventInfo,
+				aggregationKey: "",
+			},
+		},
+		{
+			name: "event multilines text",
+			args: args{
+				now:      now.Add(1),
+				message:  "_e{10,24}:test title|test\\line1\\nline2\\nline3",
+				hostname: "default-hostname",
+			},
+			expected: expected{
+				title:          "test title",
+				text:           "test\\line1\nline2\nline3",
+				now:            now.Add(1),
+				priority:       priorityNormal,
+				source:         "default-hostname",
+				alertType:      eventInfo,
+				aggregationKey: "",
+			},
+		},
+		{
+			name: "event pipe in title",
+			args: args{
+				now:      now.Add(2),
+				message:  "_e{10,24}:test|title|test\\line1\\nline2\\nline3",
+				hostname: "default-hostname",
+			},
+			expected: expected{
+				title:          "test|title",
+				text:           "test\\line1\nline2\nline3",
+				now:            now.Add(2),
+				priority:       priorityNormal,
+				source:         "default-hostname",
+				alertType:      eventInfo,
+				aggregationKey: "",
+			},
+		},
+		{
+			name: "event metadata timestamp",
+			args: args{
+				now:      now.Add(3),
+				message:  "_e{10,9}:test title|test text|d:21",
+				hostname: "default-hostname",
+			},
+			expected: expected{
+				title:          "test title",
+				text:           "test text",
+				now:            now.Add(3),
+				priority:       priorityNormal,
+				source:         "default-hostname",
+				alertType:      eventInfo,
+				aggregationKey: "",
+				ts:             int64(21),
+			},
+		},
+		{
+			name: "event metadata priority",
+			args: args{
+				now:      now.Add(4),
+				message:  "_e{10,9}:test title|test text|p:low",
+				hostname: "default-hostname",
+			},
+			expected: expected{
+				title:     "test title",
+				text:      "test text",
+				now:       now.Add(4),
+				priority:  priorityLow,
+				source:    "default-hostname",
+				alertType: eventInfo,
+			},
+		},
+		{
+			name: "event metadata hostname",
+			args: args{
+				now:      now.Add(5),
+				message:  "_e{10,9}:test title|test text|h:localhost",
+				hostname: "default-hostname",
+			},
+			expected: expected{
+				title:     "test title",
+				text:      "test text",
+				now:       now.Add(5),
+				priority:  priorityNormal,
+				source:    "localhost",
+				alertType: eventInfo,
+			},
+		},
+		{
+			name: "event metadata hostname in tag",
+			args: args{
+				now:      now.Add(6),
+				message:  "_e{10,9}:test title|test text|#host:localhost",
+				hostname: "default-hostname",
+			},
+			expected: expected{
+				title:     "test title",
+				text:      "test text",
+				now:       now.Add(6),
+				priority:  priorityNormal,
+				source:    "localhost",
+				alertType: eventInfo,
+			},
+		},
+		{
+			name: "event metadata empty host tag",
+			args: args{
+				now:      now.Add(7),
+				message:  "_e{10,9}:test title|test text|#host:,other:tag",
+				hostname: "default-hostname",
+			},
+			expected: expected{
+				title:     "test title",
+				text:      "test text",
+				now:       now.Add(7),
+				priority:  priorityNormal,
+				source:    "true",
+				alertType: eventInfo,
+				checkTags: map[string]string{"other": "tag", "source": "true"},
+			},
+		},
+		{
+			name: "event metadata alert type",
+			args: args{
+				now:      now.Add(8),
+				message:  "_e{10,9}:test title|test text|t:warning",
+				hostname: "default-hostname",
+			},
+			expected: expected{
+				title:     "test title",
+				text:      "test text",
+				now:       now.Add(8),
+				priority:  priorityNormal,
+				source:    "default-hostname",
+				alertType: eventWarning,
+			},
+		},
+		{
+			name: "event metadata aggregation key",
+			args: args{
+				now:      now.Add(9),
+				message:  "_e{10,9}:test title|test text|k:some aggregation key",
+				hostname: "default-hostname",
+			},
+			expected: expected{
+				title:          "test title",
+				text:           "test text",
+				now:            now.Add(9),
+				priority:       priorityNormal,
+				source:         "default-hostname",
+				alertType:      eventInfo,
+				aggregationKey: "some aggregation key",
+			},
+		},
+		{
+			name: "event metadata aggregation key",
+			args: args{
+				now:      now.Add(10),
+				message:  "_e{10,9}:test title|test text|k:some aggregation key",
+				hostname: "default-hostname",
+			},
+			expected: expected{
+				title:          "test title",
+				text:           "test text",
+				now:            now.Add(10),
+				priority:       priorityNormal,
+				source:         "default-hostname",
+				alertType:      eventInfo,
+				aggregationKey: "some aggregation key",
+			},
+		},
+		{
+			name: "event metadata source type",
+			args: args{
+				now:      now.Add(11),
+				message:  "_e{10,9}:test title|test text|s:this is the source",
+				hostname: "default-hostname",
+			},
+			expected: expected{
+				title:          "test title",
+				text:           "test text",
+				now:            now.Add(11),
+				priority:       priorityNormal,
+				source:         "default-hostname",
+				sourceTypeName: "this is the source",
+				alertType:      eventInfo,
+			},
+		},
+		{
+			name: "event metadata source type",
+			args: args{
+				now:      now.Add(11),
+				message:  "_e{10,9}:test title|test text|s:this is the source",
+				hostname: "default-hostname",
+			},
+			expected: expected{
+				title:          "test title",
+				text:           "test text",
+				now:            now.Add(11),
+				priority:       priorityNormal,
+				source:         "default-hostname",
+				sourceTypeName: "this is the source",
+				alertType:      eventInfo,
+			},
+		},
+		{
+			name: "event metadata source tags",
+			args: args{
+				now:      now.Add(11),
+				message:  "_e{10,9}:test title|test text|#tag1,tag2:test",
+				hostname: "default-hostname",
+			},
+			expected: expected{
+				title:     "test title",
+				text:      "test text",
+				now:       now.Add(11),
+				priority:  priorityNormal,
+				source:    "default-hostname",
+				alertType: eventInfo,
+				checkTags: map[string]string{"tag1": "true", "tag2": "test", "source": "default-hostname"},
+			},
+		},
+		{
+			name: "event metadata multiple",
+			args: args{
+				now:      now.Add(11),
+				message:  "_e{10,9}:test title|test text|t:warning|d:12345|p:low|h:some.host|k:aggKey|s:source test|#tag1,tag2:test",
+				hostname: "default-hostname",
+			},
+			expected: expected{
+				title:          "test title",
+				text:           "test text",
+				now:            now.Add(11),
+				priority:       priorityLow,
+				source:         "some.host",
+				ts:             int64(12345),
+				alertType:      eventWarning,
+				aggregationKey: "aggKey",
+				sourceTypeName: "source test",
+				checkTags:      map[string]string{"aggregation_key": "aggKey", "tag1": "true", "tag2": "test", "source": "some.host"},
+			},
+		},
+	}
+	s := NewTestStatsd()
+	acc := &testutil.Accumulator{}
+	require.NoError(t, s.Start(acc))
+	defer s.Stop()
+	for i := range tests {
+		i := i
+		t.Run(tests[i].name, func(t *testing.T) {
+			acc.ClearMetrics()
+			err := s.parseEventMessage(tests[i].args.now, tests[i].args.message, tests[i].args.hostname)
+			require.NoError(t, err)
+			m := acc.Metrics[0]
+			require.Equal(t, tests[i].expected.title, m.Measurement)
+			require.Equal(t, tests[i].expected.text, m.Fields["text"])
+			require.Equal(t, tests[i].expected.now, m.Time)
+			require.Equal(t, tests[i].expected.ts, m.Fields["ts"])
+			require.Equal(t, tests[i].expected.priority, m.Fields["priority"])
+			require.Equal(t, tests[i].expected.source, m.Tags["source"])
+			require.Equal(t, tests[i].expected.alertType, m.Fields["alert_type"])
+			require.Equal(t, tests[i].expected.aggregationKey, m.Tags["aggregation_key"])
+			require.Equal(t, tests[i].expected.sourceTypeName, m.Fields["source_type_name"])
+			if tests[i].expected.checkTags != nil {
+				require.Equal(t, tests[i].expected.checkTags, m.Tags)
+			}
+		})
+	}
+}
+
+func TestEventError(t *testing.T) {
+	now := time.Now()
+	s := NewTestStatsd()
+	acc := &testutil.Accumulator{}
+	require.NoError(t, s.Start(acc))
+	defer s.Stop()
+
+	// missing length header
+	err := s.parseEventMessage(now, "_e:title|text", "default-hostname")
+	require.Error(t, err)
+
+	// greater length than packet
+	err = s.parseEventMessage(now, "_e{10,10}:title|text", "default-hostname")
+	require.Error(t, err)
+
+	// zero length
+	err = s.parseEventMessage(now, "_e{0,0}:a|a", "default-hostname")
+	require.Error(t, err)
+
+	// missing title or text length
+	err = s.parseEventMessage(now, "_e{5555:title|text", "default-hostname")
+	require.Error(t, err)
+
+	// missing wrong len format
+	err = s.parseEventMessage(now, "_e{a,1}:title|text", "default-hostname")
+	require.Error(t, err)
+
+	err = s.parseEventMessage(now, "_e{1,a}:title|text", "default-hostname")
+	require.Error(t, err)
+
+	// missing title or text length
+	err = s.parseEventMessage(now, "_e{5,}:title|text", "default-hostname")
+	require.Error(t, err)
+
+	err = s.parseEventMessage(now, "_e{100,:title|text", "default-hostname")
+	require.Error(t, err)
+
+	err = s.parseEventMessage(now, "_e,100:title|text", "default-hostname")
+	require.Error(t, err)
+
+	err = s.parseEventMessage(now, "_e{,4}:title|text", "default-hostname")
+	require.Error(t, err)
+
+	err = s.parseEventMessage(now, "_e{}:title|text", "default-hostname")
+	require.Error(t, err)
+
+	err = s.parseEventMessage(now, "_e{,}:title|text", "default-hostname")
+	require.Error(t, err)
+
+	// not enough information
+	err = s.parseEventMessage(now, "_e|text", "default-hostname")
+	require.Error(t, err)
+
+	err = s.parseEventMessage(now, "_e:|text", "default-hostname")
+	require.Error(t, err)
+
+	// invalid timestamp
+	err = s.parseEventMessage(now, "_e{5,4}:title|text|d:abc", "default-hostname")
+	require.NoError(t, err)
+
+	// invalid priority
+	err = s.parseEventMessage(now, "_e{5,4}:title|text|p:urgent", "default-hostname")
+	require.NoError(t, err)
+
+	// invalid priority
+	err = s.parseEventMessage(now, "_e{5,4}:title|text|p:urgent", "default-hostname")
+	require.NoError(t, err)
+
+	// invalid alert type
+	err = s.parseEventMessage(now, "_e{5,4}:title|text|t:test", "default-hostname")
+	require.NoError(t, err)
+
+	// unknown metadata
+	err = s.parseEventMessage(now, "_e{5,4}:title|text|x:1234", "default-hostname")
+	require.Error(t, err)
+}

--- a/plugins/inputs/statsd_deprecated/running_stats.go
+++ b/plugins/inputs/statsd_deprecated/running_stats.go
@@ -1,0 +1,124 @@
+package statsd
+
+import (
+	"math"
+	"math/rand"
+	"sort"
+)
+
+const defaultPercentileLimit = 1000
+
+// RunningStats calculates a running mean, variance, standard deviation,
+// lower bound, upper bound, count, and can calculate estimated percentiles.
+// It is based on the incremental algorithm described here:
+//    https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
+type RunningStats struct {
+	k   float64
+	n   int64
+	ex  float64
+	ex2 float64
+
+	// Array used to calculate estimated percentiles
+	// We will store a maximum of PercLimit values, at which point we will start
+	// randomly replacing old values, hence it is an estimated percentile.
+	perc      []float64
+	PercLimit int
+
+	sum float64
+
+	lower float64
+	upper float64
+
+	// cache if we have sorted the list so that we never re-sort a sorted list,
+	// which can have very bad performance.
+	sorted bool
+}
+
+func (rs *RunningStats) AddValue(v float64) {
+	// Whenever a value is added, the list is no longer sorted.
+	rs.sorted = false
+
+	if rs.n == 0 {
+		rs.k = v
+		rs.upper = v
+		rs.lower = v
+		if rs.PercLimit == 0 {
+			rs.PercLimit = defaultPercentileLimit
+		}
+		rs.perc = make([]float64, 0, rs.PercLimit)
+	}
+
+	// These are used for the running mean and variance
+	rs.n++
+	rs.ex += v - rs.k
+	rs.ex2 += (v - rs.k) * (v - rs.k)
+
+	// add to running sum
+	rs.sum += v
+
+	// track upper and lower bounds
+	if v > rs.upper {
+		rs.upper = v
+	} else if v < rs.lower {
+		rs.lower = v
+	}
+
+	if len(rs.perc) < rs.PercLimit {
+		rs.perc = append(rs.perc, v)
+	} else {
+		// Reached limit, choose random index to overwrite in the percentile array
+		rs.perc[rand.Intn(len(rs.perc))] = v //nolint:gosec // G404
+	}
+}
+
+func (rs *RunningStats) Mean() float64 {
+	return rs.k + rs.ex/float64(rs.n)
+}
+
+func (rs *RunningStats) Variance() float64 {
+	return (rs.ex2 - (rs.ex*rs.ex)/float64(rs.n)) / float64(rs.n)
+}
+
+func (rs *RunningStats) Stddev() float64 {
+	return math.Sqrt(rs.Variance())
+}
+
+func (rs *RunningStats) Sum() float64 {
+	return rs.sum
+}
+
+func (rs *RunningStats) Upper() float64 {
+	return rs.upper
+}
+
+func (rs *RunningStats) Lower() float64 {
+	return rs.lower
+}
+
+func (rs *RunningStats) Count() int64 {
+	return rs.n
+}
+
+func (rs *RunningStats) Percentile(n float64) float64 {
+	if n > 100 {
+		n = 100
+	}
+
+	if !rs.sorted {
+		sort.Float64s(rs.perc)
+		rs.sorted = true
+	}
+
+	i := float64(len(rs.perc)) * n / float64(100)
+	return rs.perc[clamp(i, 0, len(rs.perc)-1)]
+}
+
+func clamp(i float64, min int, max int) int {
+	if i < float64(min) {
+		return min
+	}
+	if i > float64(max) {
+		return max
+	}
+	return int(i)
+}

--- a/plugins/inputs/statsd_deprecated/running_stats_test.go
+++ b/plugins/inputs/statsd_deprecated/running_stats_test.go
@@ -1,0 +1,166 @@
+package statsd
+
+import (
+	"math"
+	"testing"
+)
+
+// Test that a single metric is handled correctly
+func TestRunningStats_Single(t *testing.T) {
+	rs := RunningStats{}
+	values := []float64{10.1}
+
+	for _, v := range values {
+		rs.AddValue(v)
+	}
+
+	if rs.Mean() != 10.1 {
+		t.Errorf("Expected %v, got %v", 10.1, rs.Mean())
+	}
+	if rs.Upper() != 10.1 {
+		t.Errorf("Expected %v, got %v", 10.1, rs.Upper())
+	}
+	if rs.Lower() != 10.1 {
+		t.Errorf("Expected %v, got %v", 10.1, rs.Lower())
+	}
+	if rs.Percentile(100) != 10.1 {
+		t.Errorf("Expected %v, got %v", 10.1, rs.Percentile(100))
+	}
+	if rs.Percentile(99.95) != 10.1 {
+		t.Errorf("Expected %v, got %v", 10.1, rs.Percentile(99.95))
+	}
+	if rs.Percentile(90) != 10.1 {
+		t.Errorf("Expected %v, got %v", 10.1, rs.Percentile(90))
+	}
+	if rs.Percentile(50) != 10.1 {
+		t.Errorf("Expected %v, got %v", 10.1, rs.Percentile(50))
+	}
+	if rs.Percentile(0) != 10.1 {
+		t.Errorf("Expected %v, got %v", 10.1, rs.Percentile(0))
+	}
+	if rs.Count() != 1 {
+		t.Errorf("Expected %v, got %v", 1, rs.Count())
+	}
+	if rs.Variance() != 0 {
+		t.Errorf("Expected %v, got %v", 0, rs.Variance())
+	}
+	if rs.Stddev() != 0 {
+		t.Errorf("Expected %v, got %v", 0, rs.Stddev())
+	}
+}
+
+// Test that duplicate values are handled correctly
+func TestRunningStats_Duplicate(t *testing.T) {
+	rs := RunningStats{}
+	values := []float64{10.1, 10.1, 10.1, 10.1}
+
+	for _, v := range values {
+		rs.AddValue(v)
+	}
+
+	if rs.Mean() != 10.1 {
+		t.Errorf("Expected %v, got %v", 10.1, rs.Mean())
+	}
+	if rs.Upper() != 10.1 {
+		t.Errorf("Expected %v, got %v", 10.1, rs.Upper())
+	}
+	if rs.Lower() != 10.1 {
+		t.Errorf("Expected %v, got %v", 10.1, rs.Lower())
+	}
+	if rs.Percentile(100) != 10.1 {
+		t.Errorf("Expected %v, got %v", 10.1, rs.Percentile(100))
+	}
+	if rs.Percentile(99.95) != 10.1 {
+		t.Errorf("Expected %v, got %v", 10.1, rs.Percentile(99.95))
+	}
+	if rs.Percentile(90) != 10.1 {
+		t.Errorf("Expected %v, got %v", 10.1, rs.Percentile(90))
+	}
+	if rs.Percentile(50) != 10.1 {
+		t.Errorf("Expected %v, got %v", 10.1, rs.Percentile(50))
+	}
+	if rs.Percentile(0) != 10.1 {
+		t.Errorf("Expected %v, got %v", 10.1, rs.Percentile(0))
+	}
+	if rs.Count() != 4 {
+		t.Errorf("Expected %v, got %v", 4, rs.Count())
+	}
+	if rs.Variance() != 0 {
+		t.Errorf("Expected %v, got %v", 0, rs.Variance())
+	}
+	if rs.Stddev() != 0 {
+		t.Errorf("Expected %v, got %v", 0, rs.Stddev())
+	}
+}
+
+// Test a list of sample values, returns all correct values
+func TestRunningStats(t *testing.T) {
+	rs := RunningStats{}
+	values := []float64{10, 20, 10, 30, 20, 11, 12, 32, 45, 9, 5, 5, 5, 10, 23, 8}
+
+	for _, v := range values {
+		rs.AddValue(v)
+	}
+
+	if rs.Mean() != 15.9375 {
+		t.Errorf("Expected %v, got %v", 15.9375, rs.Mean())
+	}
+	if rs.Upper() != 45 {
+		t.Errorf("Expected %v, got %v", 45, rs.Upper())
+	}
+	if rs.Lower() != 5 {
+		t.Errorf("Expected %v, got %v", 5, rs.Lower())
+	}
+	if rs.Percentile(100) != 45 {
+		t.Errorf("Expected %v, got %v", 45, rs.Percentile(100))
+	}
+	if rs.Percentile(99.98) != 45 {
+		t.Errorf("Expected %v, got %v", 45, rs.Percentile(99.98))
+	}
+	if rs.Percentile(90) != 32 {
+		t.Errorf("Expected %v, got %v", 32, rs.Percentile(90))
+	}
+	if rs.Percentile(50.1) != 11 {
+		t.Errorf("Expected %v, got %v", 11, rs.Percentile(50.1))
+	}
+	if rs.Percentile(50) != 11 {
+		t.Errorf("Expected %v, got %v", 11, rs.Percentile(50))
+	}
+	if rs.Percentile(49.9) != 10 {
+		t.Errorf("Expected %v, got %v", 10, rs.Percentile(49.9))
+	}
+	if rs.Percentile(0) != 5 {
+		t.Errorf("Expected %v, got %v", 5, rs.Percentile(0))
+	}
+	if rs.Count() != 16 {
+		t.Errorf("Expected %v, got %v", 4, rs.Count())
+	}
+	if !fuzzyEqual(rs.Variance(), 124.93359, .00001) {
+		t.Errorf("Expected %v, got %v", 124.93359, rs.Variance())
+	}
+	if !fuzzyEqual(rs.Stddev(), 11.17736, .00001) {
+		t.Errorf("Expected %v, got %v", 11.17736, rs.Stddev())
+	}
+}
+
+// Test that the percentile limit is respected.
+func TestRunningStats_PercentileLimit(t *testing.T) {
+	rs := RunningStats{}
+	rs.PercLimit = 10
+	values := []float64{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}
+
+	for _, v := range values {
+		rs.AddValue(v)
+	}
+
+	if rs.Count() != 11 {
+		t.Errorf("Expected %v, got %v", 11, rs.Count())
+	}
+	if len(rs.perc) != 10 {
+		t.Errorf("Expected %v, got %v", 10, len(rs.perc))
+	}
+}
+
+func fuzzyEqual(a, b, epsilon float64) bool {
+	return math.Abs(a-b) <= epsilon
+}

--- a/plugins/inputs/statsd_deprecated/statsd.go
+++ b/plugins/inputs/statsd_deprecated/statsd.go
@@ -1,0 +1,951 @@
+package statsd
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/circonus-labs/circonus-unified-agent/cua"
+	"github.com/circonus-labs/circonus-unified-agent/internal"
+	"github.com/circonus-labs/circonus-unified-agent/plugins/inputs"
+	"github.com/circonus-labs/circonus-unified-agent/plugins/parsers/graphite"
+	"github.com/circonus-labs/circonus-unified-agent/selfstat"
+)
+
+const (
+	// udpMaxPacketSize is the UDP packet limit, see
+	// https://en.wikipedia.org/wiki/User_Datagram_Protocol#Packet_structure
+	udpMaxPacketSize int = 64 * 1024
+
+	defaultFieldName = "value"
+
+	defaultProtocol = "udp"
+
+	defaultSeparator           = "_"
+	defaultAllowPendingMessage = 10000
+	MaxTCPConnections          = 250
+
+	parserGoRoutines = 5
+)
+
+// Statsd allows the importing of statsd and dogstatsd data.
+type Statsd struct {
+	// Protocol used on listener - udp or tcp
+	Protocol string `toml:"protocol"`
+
+	// Address & Port to serve from
+	ServiceAddress string
+
+	// Number of messages allowed to queue up in between calls to Gather. If this
+	// fills up, packets will get dropped until the next Gather interval is ran.
+	AllowedPendingMessages int
+
+	// Percentiles specifies the percentiles that will be calculated for timing
+	// and histogram stats.
+	Percentiles     []internal.Number
+	PercentileLimit int
+
+	DeleteGauges   bool
+	DeleteCounters bool
+	DeleteSets     bool
+	DeleteTimings  bool
+	ConvertNames   bool
+
+	// MetricSeparator is the separator between parts of the metric name.
+	MetricSeparator string
+	// This flag enables parsing of tags in the dogstatsd extension to the
+	// statsd protocol (http://docs.datadoghq.com/guides/dogstatsd/)
+	ParseDataDogTags bool // depreciated in 1.10; use datadog_extensions
+
+	// Parses extensions to statsd in the datadog statsd format
+	// currently supports metrics and datadog tags.
+	// http://docs.datadoghq.com/guides/dogstatsd/
+	DataDogExtensions bool `toml:"datadog_extensions"`
+
+	// UDPPacketSize is deprecated, it's only here for legacy support
+	// we now always create 1 max size buffer and then copy only what we need
+	// into the in channel
+	// see https://github.com/circonus-labs/circonus-unified-agent/pull/992
+	UDPPacketSize int `toml:"udp_packet_size"`
+
+	ReadBufferSize int `toml:"read_buffer_size"`
+
+	sync.Mutex
+	// Lock for preventing a data race during resource cleanup
+	cleanup sync.Mutex
+	wg      sync.WaitGroup
+	// accept channel tracks how many active connections there are, if there
+	// is an available bool in accept, then we are below the maximum and can
+	// accept the connection
+	accept chan bool
+	// drops tracks the number of dropped metrics.
+	drops int
+	// malformed tracks the number of malformed packets
+	// malformed int
+
+	// Channel for all incoming statsd packets
+	in   chan input
+	done chan struct{}
+
+	// Cache gauges, counters & sets so they can be aggregated as they arrive
+	// gauges and counters map measurement/tags hash -> field name -> metrics
+	// sets and timings map measurement/tags hash -> metrics
+	gauges   map[string]cachedgauge
+	counters map[string]cachedcounter
+	sets     map[string]cachedset
+	timings  map[string]cachedtimings
+
+	// bucket -> influx templates
+	Templates []string
+
+	// Protocol listeners
+	UDPlistener *net.UDPConn
+	TCPlistener *net.TCPListener
+
+	// track current connections so we can close them in Stop()
+	conns map[string]*net.TCPConn
+
+	MaxTCPConnections int `toml:"max_tcp_connections"`
+
+	TCPKeepAlive       bool               `toml:"tcp_keep_alive"`
+	TCPKeepAlivePeriod *internal.Duration `toml:"tcp_keep_alive_period"`
+
+	graphiteParser *graphite.Parser
+
+	acc cua.Accumulator
+
+	MaxConnections     selfstat.Stat
+	CurrentConnections selfstat.Stat
+	TotalConnections   selfstat.Stat
+	TCPPacketsRecv     selfstat.Stat
+	TCPBytesRecv       selfstat.Stat
+	UDPPacketsRecv     selfstat.Stat
+	UDPPacketsDrop     selfstat.Stat
+	UDPBytesRecv       selfstat.Stat
+	ParseTimeNS        selfstat.Stat
+
+	Log cua.Logger
+
+	// A pool of byte slices to handle parsing
+	bufPool sync.Pool
+}
+
+type input struct {
+	*bytes.Buffer
+	time.Time
+	Addr string
+}
+
+// One statsd metric, form is <bucket>:<value>|<mtype>|@<samplerate>
+type metric struct {
+	name       string
+	field      string
+	bucket     string
+	hash       string
+	intvalue   int64
+	floatvalue float64
+	strvalue   string
+	mtype      string
+	additive   bool
+	samplerate float64
+	tags       map[string]string
+}
+
+type cachedset struct {
+	name   string
+	fields map[string]map[string]bool
+	tags   map[string]string
+}
+
+type cachedgauge struct {
+	name   string
+	fields map[string]interface{}
+	tags   map[string]string
+}
+
+type cachedcounter struct {
+	name   string
+	fields map[string]interface{}
+	tags   map[string]string
+}
+
+type cachedtimings struct {
+	name   string
+	fields map[string]RunningStats
+	tags   map[string]string
+}
+
+func (*Statsd) Description() string {
+	return "Statsd UDP/TCP Server"
+}
+
+const sampleConfig = `
+  ## Protocol, must be "tcp", "udp", "udp4" or "udp6" (default=udp)
+  protocol = "udp"
+
+  ## MaxTCPConnection - applicable when protocol is set to tcp (default=250)
+  max_tcp_connections = 250
+
+  ## Enable TCP keep alive probes (default=false)
+  tcp_keep_alive = false
+
+  ## Specifies the keep-alive period for an active network connection.
+  ## Only applies to TCP sockets and will be ignored if tcp_keep_alive is false.
+  ## Defaults to the OS configuration.
+  # tcp_keep_alive_period = "2h"
+
+  ## Address and port to host UDP listener on
+  service_address = ":8125"
+
+  ## The following configuration options control when agent clears it's cache
+  ## of previous values. If set to false, then agent will only clear it's
+  ## cache when the daemon is restarted.
+  ## Reset gauges every interval (default=true)
+  delete_gauges = true
+  ## Reset counters every interval (default=true)
+  delete_counters = true
+  ## Reset sets every interval (default=true)
+  delete_sets = true
+  ## Reset timings & histograms every interval (default=true)
+  delete_timings = true
+
+  ## Percentiles to calculate for timing & histogram stats
+  percentiles = [50.0, 90.0, 99.0, 99.9, 99.95, 100.0]
+
+  ## separator to use between elements of a statsd metric
+  metric_separator = "_"
+
+  ## Parses tags in the datadog statsd format
+  ## http://docs.datadoghq.com/guides/dogstatsd/
+  parse_data_dog_tags = false
+
+  ## Parses datadog extensions to the statsd format
+  datadog_extensions = false
+
+  ## Statsd data translation templates, more info can be read here:
+  ## https://github.com/circonus-labs/circonus-unified-agent/blob/master/docs/TEMPLATE_PATTERN.md
+  # templates = [
+  #     "cpu.* measurement*"
+  # ]
+
+  ## Number of UDP messages allowed to queue up, once filled,
+  ## the statsd server will start dropping packets
+  allowed_pending_messages = 10000
+
+  ## Number of timing/histogram values to track per-measurement in the
+  ## calculation of percentiles. Raising this limit increases the accuracy
+  ## of percentiles but also increases the memory usage and cpu time.
+  percentile_limit = 1000
+`
+
+func (*Statsd) SampleConfig() string {
+	return sampleConfig
+}
+
+func (s *Statsd) Gather(ctx context.Context, acc cua.Accumulator) error {
+	s.Lock()
+	defer s.Unlock()
+	now := time.Now()
+
+	for _, m := range s.timings {
+		// Defining a template to parse field names for timers allows us to split
+		// out multiple fields per timer. In this case we prefix each stat with the
+		// field name and store these all in a single measurement.
+		fields := make(map[string]interface{})
+		for fieldName, stats := range m.fields {
+			var prefix string
+			if fieldName != defaultFieldName {
+				prefix = fieldName + "_"
+			}
+			fields[prefix+"mean"] = stats.Mean()
+			fields[prefix+"stddev"] = stats.Stddev()
+			fields[prefix+"sum"] = stats.Sum()
+			fields[prefix+"upper"] = stats.Upper()
+			fields[prefix+"lower"] = stats.Lower()
+			fields[prefix+"count"] = stats.Count()
+			for _, percentile := range s.Percentiles {
+				name := fmt.Sprintf("%s%v_percentile", prefix, percentile.Value)
+				fields[name] = stats.Percentile(percentile.Value)
+			}
+		}
+
+		acc.AddFields(m.name, fields, m.tags, now)
+	}
+	if s.DeleteTimings {
+		s.timings = make(map[string]cachedtimings)
+	}
+
+	for _, m := range s.gauges {
+		acc.AddGauge(m.name, m.fields, m.tags, now)
+	}
+	if s.DeleteGauges {
+		s.gauges = make(map[string]cachedgauge)
+	}
+
+	for _, m := range s.counters {
+		acc.AddCounter(m.name, m.fields, m.tags, now)
+	}
+	if s.DeleteCounters {
+		s.counters = make(map[string]cachedcounter)
+	}
+
+	for _, m := range s.sets {
+		fields := make(map[string]interface{})
+		for field, set := range m.fields {
+			fields[field] = int64(len(set))
+		}
+		acc.AddFields(m.name, fields, m.tags, now)
+	}
+	if s.DeleteSets {
+		s.sets = make(map[string]cachedset)
+	}
+	return nil
+}
+
+func (s *Statsd) Start(ac cua.Accumulator) error {
+	if s.ParseDataDogTags {
+		s.DataDogExtensions = true
+		s.Log.Warn("'parse_data_dog_tags' config option is deprecated, please use 'datadog_extensions' instead")
+	}
+
+	s.acc = ac
+
+	// Make data structures
+	s.gauges = make(map[string]cachedgauge)
+	s.counters = make(map[string]cachedcounter)
+	s.sets = make(map[string]cachedset)
+	s.timings = make(map[string]cachedtimings)
+
+	s.Lock()
+	defer s.Unlock()
+	//
+	tags := map[string]string{
+		"address": s.ServiceAddress,
+	}
+	s.MaxConnections = selfstat.Register("statsd", "tcp_max_connections", tags)
+	s.MaxConnections.Set(int64(s.MaxTCPConnections))
+	s.CurrentConnections = selfstat.Register("statsd", "tcp_current_connections", tags)
+	s.TotalConnections = selfstat.Register("statsd", "tcp_total_connections", tags)
+	s.TCPPacketsRecv = selfstat.Register("statsd", "tcp_packets_received", tags)
+	s.TCPBytesRecv = selfstat.Register("statsd", "tcp_bytes_received", tags)
+	s.UDPPacketsRecv = selfstat.Register("statsd", "udp_packets_received", tags)
+	s.UDPPacketsDrop = selfstat.Register("statsd", "udp_packets_dropped", tags)
+	s.UDPBytesRecv = selfstat.Register("statsd", "udp_bytes_received", tags)
+	s.ParseTimeNS = selfstat.Register("statsd", "parse_time_ns", tags)
+
+	s.in = make(chan input, s.AllowedPendingMessages)
+	s.done = make(chan struct{})
+	s.accept = make(chan bool, s.MaxTCPConnections)
+	s.conns = make(map[string]*net.TCPConn)
+	s.bufPool = sync.Pool{
+		New: func() interface{} {
+			return new(bytes.Buffer)
+		},
+	}
+	for i := 0; i < s.MaxTCPConnections; i++ {
+		s.accept <- true
+	}
+
+	if s.ConvertNames {
+		s.Log.Warn("'convert_names' config option is deprecated, please use 'metric_separator' instead")
+	}
+
+	if s.MetricSeparator == "" {
+		s.MetricSeparator = defaultSeparator
+	}
+
+	if s.isUDP() {
+		address, err := net.ResolveUDPAddr(s.Protocol, s.ServiceAddress)
+		if err != nil {
+			return fmt.Errorf("resolve udp (%s): %w", s.ServiceAddress, err)
+		}
+
+		conn, err := net.ListenUDP(s.Protocol, address)
+		if err != nil {
+			return fmt.Errorf("listen (%s): %w", address.String(), err)
+		}
+
+		s.Log.Infof("UDP listening on %q", conn.LocalAddr().String())
+		s.UDPlistener = conn
+
+		s.wg.Add(1)
+		go func() {
+			defer s.wg.Done()
+			_ = s.udpListen(conn)
+		}()
+	} else {
+		address, err := net.ResolveTCPAddr("tcp", s.ServiceAddress)
+		if err != nil {
+			return fmt.Errorf("resolve (%s): %w", s.ServiceAddress, err)
+		}
+		listener, err := net.ListenTCP("tcp", address)
+		if err != nil {
+			return fmt.Errorf("listen (%s): %w", address.String(), err)
+		}
+
+		s.Log.Infof("TCP listening on %q", listener.Addr().String())
+		s.TCPlistener = listener
+
+		s.wg.Add(1)
+		go func() {
+			defer s.wg.Done()
+			_ = s.tcpListen(listener)
+		}()
+	}
+
+	for i := 1; i <= parserGoRoutines; i++ {
+		// Start the line parser
+		s.wg.Add(1)
+		go func() {
+			defer s.wg.Done()
+			s.parser()
+		}()
+	}
+	s.Log.Infof("Started the statsd service on %q", s.ServiceAddress)
+	return nil
+}
+
+// tcpListen() starts listening for udp packets on the configured port.
+func (s *Statsd) tcpListen(listener *net.TCPListener) error {
+	for {
+		select {
+		case <-s.done:
+			return nil
+		default:
+			// Accept connection:
+			conn, err := listener.AcceptTCP()
+			if err != nil {
+				return fmt.Errorf("accept: %w", err)
+			}
+
+			if s.TCPKeepAlive {
+				if err = conn.SetKeepAlive(true); err != nil {
+					return fmt.Errorf("set keep alive: %w", err)
+				}
+
+				if s.TCPKeepAlivePeriod != nil {
+					if err = conn.SetKeepAlivePeriod(s.TCPKeepAlivePeriod.Duration); err != nil {
+						return fmt.Errorf("set keep alive period: %w", err)
+					}
+				}
+			}
+
+			select {
+			case <-s.accept:
+				// not over connection limit, handle the connection properly.
+				s.wg.Add(1)
+				// generate a random id for this TCPConn
+				id := internal.RandomString(6)
+				s.remember(id, conn)
+				go s.handler(conn, id)
+			default:
+				// We are over the connection limit, refuse & close.
+				s.refuser(conn)
+			}
+		}
+	}
+}
+
+// udpListen starts listening for udp packets on the configured port.
+func (s *Statsd) udpListen(conn *net.UDPConn) error {
+	if s.ReadBufferSize > 0 {
+		_ = s.UDPlistener.SetReadBuffer(s.ReadBufferSize)
+	}
+
+	buf := make([]byte, udpMaxPacketSize)
+	for {
+		select {
+		case <-s.done:
+			return nil
+		default:
+			n, addr, err := conn.ReadFromUDP(buf)
+			if err != nil {
+				if !strings.Contains(err.Error(), "closed network") {
+					s.Log.Errorf("Error reading: %s", err.Error())
+					continue
+				}
+				return fmt.Errorf("read: %w", err)
+			}
+			s.UDPPacketsRecv.Incr(1)
+			s.UDPBytesRecv.Incr(int64(n))
+			b := s.bufPool.Get().(*bytes.Buffer)
+			b.Reset()
+			b.Write(buf[:n])
+			select {
+			case s.in <- input{
+				Buffer: b,
+				Time:   time.Now(),
+				Addr:   addr.IP.String()}:
+			default:
+				s.UDPPacketsDrop.Incr(1)
+				s.drops++
+				if s.drops == 1 || s.AllowedPendingMessages == 0 || s.drops%s.AllowedPendingMessages == 0 {
+					s.Log.Errorf("Statsd message queue full. "+
+						"We have dropped %d messages so far. "+
+						"You may want to increase allowed_pending_messages in the config", s.drops)
+				}
+			}
+		}
+	}
+}
+
+// parser monitors the s.in channel, if there is a packet ready, it parses the
+// packet into statsd strings and then calls parseStatsdLine, which parses a
+// single statsd metric into a struct.
+func (s *Statsd) parser() {
+	for {
+		select {
+		case <-s.done:
+			return
+		case in := <-s.in:
+			start := time.Now()
+			lines := strings.Split(in.Buffer.String(), "\n")
+			s.bufPool.Put(in.Buffer)
+			for _, line := range lines {
+				line = strings.TrimSpace(line)
+				switch {
+				case line == "":
+				case s.DataDogExtensions && strings.HasPrefix(line, "_e"):
+					_ = s.parseEventMessage(in.Time, line, in.Addr)
+				default:
+					_ = s.parseStatsdLine(line)
+				}
+			}
+			elapsed := time.Since(start)
+			s.ParseTimeNS.Set(elapsed.Nanoseconds())
+		}
+	}
+}
+
+// parseStatsdLine will parse the given statsd line, validating it as it goes.
+// If the line is valid, it will be cached for the next call to Gather()
+func (s *Statsd) parseStatsdLine(line string) error {
+	s.Lock()
+	defer s.Unlock()
+
+	lineTags := make(map[string]string)
+	if s.DataDogExtensions {
+		recombinedSegments := make([]string, 0)
+		// datadog tags look like this:
+		// users.online:1|c|@0.5|#country:china,environment:production
+		// users.online:1|c|#sometagwithnovalue
+		// we will split on the pipe and remove any elements that are datadog
+		// tags, parse them, and rebuild the line sans the datadog tags
+		pipesplit := strings.Split(line, "|")
+		for _, segment := range pipesplit {
+			if len(segment) > 0 && segment[0] == '#' {
+				// we have ourselves a tag; they are comma separated
+				parseDataDogTags(lineTags, segment[1:])
+			} else {
+				recombinedSegments = append(recombinedSegments, segment)
+			}
+		}
+		line = strings.Join(recombinedSegments, "|")
+	}
+
+	// Validate splitting the line on ":"
+	bits := strings.Split(line, ":")
+	if len(bits) < 2 {
+		s.Log.Errorf("Splitting ':', unable to parse metric: %s", line)
+		return errors.New("error Parsing statsd line")
+	}
+
+	// Extract bucket name from individual metric bits
+	bucketName, bits := bits[0], bits[1:]
+
+	// Add a metric for each bit available
+	for _, bit := range bits {
+		m := metric{}
+
+		m.bucket = bucketName
+
+		// Validate splitting the bit on "|"
+		pipesplit := strings.Split(bit, "|")
+		if len(pipesplit) < 2 {
+			s.Log.Errorf("Splitting '|', unable to parse metric: %s", line)
+			return errors.New("error parsing statsd line")
+		} else if len(pipesplit) > 2 {
+			sr := pipesplit[2]
+
+			if strings.Contains(sr, "@") && len(sr) > 1 {
+				samplerate, err := strconv.ParseFloat(sr[1:], 64)
+				if err != nil {
+					s.Log.Errorf("Parsing sample rate: %s", err.Error())
+				} else {
+					// sample rate successfully parsed
+					m.samplerate = samplerate
+				}
+			} else {
+				s.Log.Debugf("Sample rate must be in format like: "+
+					"@0.1, @0.5, etc. Ignoring sample rate for line: %s", line)
+			}
+		}
+
+		// Validate metric type
+		switch pipesplit[1] {
+		case "g", "c", "s", "ms", "h":
+			m.mtype = pipesplit[1]
+		default:
+			s.Log.Errorf("Metric type %q unsupported", pipesplit[1])
+			return errors.New("error parsing statsd line")
+		}
+
+		// Parse the value
+		if strings.HasPrefix(pipesplit[0], "-") || strings.HasPrefix(pipesplit[0], "+") {
+			if m.mtype != "g" && m.mtype != "c" {
+				s.Log.Errorf("+- values are only supported for gauges & counters, unable to parse metric: %s", line)
+				return errors.New("error parsing statsd line")
+			}
+			m.additive = true
+		}
+
+		switch m.mtype {
+		case "g", "ms", "h":
+			v, err := strconv.ParseFloat(pipesplit[0], 64)
+			if err != nil {
+				s.Log.Errorf("Parsing value to float64, unable to parse metric: %s", line)
+				return errors.New("error parsing statsd line")
+			}
+			m.floatvalue = v
+		case "c":
+			var v int64
+			v, err := strconv.ParseInt(pipesplit[0], 10, 64)
+			if err != nil {
+				v2, err2 := strconv.ParseFloat(pipesplit[0], 64)
+				if err2 != nil {
+					s.Log.Errorf("Parsing value to int64, unable to parse metric: %s", line)
+					return errors.New("error parsing statsd line")
+				}
+				v = int64(v2)
+			}
+			// If a sample rate is given with a counter, divide value by the rate
+			if m.samplerate != 0 && m.mtype == "c" {
+				v = int64(float64(v) / m.samplerate)
+			}
+			m.intvalue = v
+		case "s":
+			m.strvalue = pipesplit[0]
+		}
+
+		// Parse the name & tags from bucket
+		m.name, m.field, m.tags = s.parseName(m.bucket)
+		switch m.mtype {
+		case "c":
+			m.tags["metric_type"] = "counter"
+		case "g":
+			m.tags["metric_type"] = "gauge"
+		case "s":
+			m.tags["metric_type"] = "set"
+		case "ms":
+			m.tags["metric_type"] = "timing"
+		case "h":
+			m.tags["metric_type"] = "histogram"
+		}
+		if len(lineTags) > 0 {
+			for k, v := range lineTags {
+				m.tags[k] = v
+			}
+		}
+
+		// Make a unique key for the measurement name/tags
+		var tg []string
+		for k, v := range m.tags {
+			tg = append(tg, k+"="+v)
+		}
+		sort.Strings(tg)
+		tg = append(tg, m.name)
+		m.hash = strings.Join(tg, "")
+
+		s.aggregate(m)
+	}
+
+	return nil
+}
+
+// parseName parses the given bucket name with the list of bucket maps in the
+// config file. If there is a match, it will parse the name of the metric and
+// map of tags.
+// Return values are (<name>, <field>, <tags>)
+func (s *Statsd) parseName(bucket string) (string, string, map[string]string) {
+	tags := make(map[string]string)
+
+	bucketparts := strings.Split(bucket, ",")
+	// Parse out any tags in the bucket
+	if len(bucketparts) > 1 {
+		for _, btag := range bucketparts[1:] {
+			k, v := parseKeyValue(btag)
+			if k != "" {
+				tags[k] = v
+			}
+		}
+	}
+
+	var field string
+	name := bucketparts[0]
+
+	p := s.graphiteParser
+	var err error
+
+	if p == nil || s.graphiteParser.Separator != s.MetricSeparator {
+		p, err = graphite.NewGraphiteParser(s.MetricSeparator, s.Templates, nil)
+		s.graphiteParser = p
+	}
+
+	if err == nil {
+		p.DefaultTags = tags
+		name, tags, field, _ = p.ApplyTemplate(name)
+	}
+
+	if s.ConvertNames {
+		name = strings.ReplaceAll(name, ".", "_")
+		name = strings.ReplaceAll(name, "-", "__")
+	}
+	if field == "" {
+		field = defaultFieldName
+	}
+
+	return name, field, tags
+}
+
+// Parse the key,value out of a string that looks like "key=value"
+func parseKeyValue(keyvalue string) (string, string) {
+	var key, val string
+
+	split := strings.Split(keyvalue, "=")
+	// Must be exactly 2 to get anything meaningful out of them
+	if len(split) == 2 {
+		key = split[0]
+		val = split[1]
+	} else if len(split) == 1 {
+		val = split[0]
+	}
+
+	return key, val
+}
+
+// aggregate takes in a metric. It then
+// aggregates and caches the current value(s). It does not deal with the
+// Delete* options, because those are dealt with in the Gather function.
+func (s *Statsd) aggregate(m metric) {
+	switch m.mtype {
+	case "ms", "h":
+		// Check if the measurement exists
+		cached, ok := s.timings[m.hash]
+		if !ok {
+			cached = cachedtimings{
+				name:   m.name,
+				fields: make(map[string]RunningStats),
+				tags:   m.tags,
+			}
+		}
+		// Check if the field exists. If we've not enabled multiple fields per timer
+		// this will be the default field name, eg. "value"
+		field, ok := cached.fields[m.field]
+		if !ok {
+			field = RunningStats{
+				PercLimit: s.PercentileLimit,
+			}
+		}
+		if m.samplerate > 0 {
+			for i := 0; i < int(1.0/m.samplerate); i++ {
+				field.AddValue(m.floatvalue)
+			}
+		} else {
+			field.AddValue(m.floatvalue)
+		}
+		cached.fields[m.field] = field
+		s.timings[m.hash] = cached
+	case "c":
+		// check if the measurement exists
+		_, ok := s.counters[m.hash]
+		if !ok {
+			s.counters[m.hash] = cachedcounter{
+				name:   m.name,
+				fields: make(map[string]interface{}),
+				tags:   m.tags,
+			}
+		}
+		// check if the field exists
+		_, ok = s.counters[m.hash].fields[m.field]
+		if !ok {
+			s.counters[m.hash].fields[m.field] = int64(0)
+		}
+		s.counters[m.hash].fields[m.field] =
+			s.counters[m.hash].fields[m.field].(int64) + m.intvalue
+	case "g":
+		// check if the measurement exists
+		_, ok := s.gauges[m.hash]
+		if !ok {
+			s.gauges[m.hash] = cachedgauge{
+				name:   m.name,
+				fields: make(map[string]interface{}),
+				tags:   m.tags,
+			}
+		}
+		// check if the field exists
+		_, ok = s.gauges[m.hash].fields[m.field]
+		if !ok {
+			s.gauges[m.hash].fields[m.field] = float64(0)
+		}
+		if m.additive {
+			s.gauges[m.hash].fields[m.field] =
+				s.gauges[m.hash].fields[m.field].(float64) + m.floatvalue
+		} else {
+			s.gauges[m.hash].fields[m.field] = m.floatvalue
+		}
+	case "s":
+		// check if the measurement exists
+		_, ok := s.sets[m.hash]
+		if !ok {
+			s.sets[m.hash] = cachedset{
+				name:   m.name,
+				fields: make(map[string]map[string]bool),
+				tags:   m.tags,
+			}
+		}
+		// check if the field exists
+		_, ok = s.sets[m.hash].fields[m.field]
+		if !ok {
+			s.sets[m.hash].fields[m.field] = make(map[string]bool)
+		}
+		s.sets[m.hash].fields[m.field][m.strvalue] = true
+	}
+}
+
+// handler handles a single TCP Connection
+func (s *Statsd) handler(conn *net.TCPConn, id string) {
+	s.CurrentConnections.Incr(1)
+	s.TotalConnections.Incr(1)
+	// connection cleanup function
+	defer func() {
+		s.wg.Done()
+		conn.Close()
+		// Add one connection potential back to channel when this one closes
+		s.accept <- true
+		s.forget(id)
+		s.CurrentConnections.Incr(-1)
+	}()
+
+	var remoteIP string
+	if addr, ok := conn.RemoteAddr().(*net.TCPAddr); ok {
+		remoteIP = addr.IP.String()
+	}
+
+	var n int
+	scanner := bufio.NewScanner(conn)
+	for {
+		select {
+		case <-s.done:
+			return
+		default:
+			if !scanner.Scan() {
+				return
+			}
+			n = len(scanner.Bytes())
+			if n == 0 {
+				continue
+			}
+			s.TCPBytesRecv.Incr(int64(n))
+			s.TCPPacketsRecv.Incr(1)
+
+			b := s.bufPool.Get().(*bytes.Buffer)
+			b.Reset()
+			b.Write(scanner.Bytes())
+			b.WriteByte('\n')
+
+			select {
+			case s.in <- input{Buffer: b, Time: time.Now(), Addr: remoteIP}:
+			default:
+				s.drops++
+				if s.drops == 1 || s.drops%s.AllowedPendingMessages == 0 {
+					s.Log.Errorf("Statsd message queue full. "+
+						"We have dropped %d messages so far. "+
+						"You may want to increase allowed_pending_messages in the config", s.drops)
+				}
+			}
+		}
+	}
+}
+
+// refuser refuses a TCP connection
+func (s *Statsd) refuser(conn *net.TCPConn) {
+	conn.Close()
+	s.Log.Infof("Refused TCP Connection from %s", conn.RemoteAddr())
+	s.Log.Warn("Maximum TCP Connections reached, you may want to adjust max_tcp_connections")
+}
+
+// forget a TCP connection
+func (s *Statsd) forget(id string) {
+	s.cleanup.Lock()
+	defer s.cleanup.Unlock()
+	delete(s.conns, id)
+}
+
+// remember a TCP connection
+func (s *Statsd) remember(id string, conn *net.TCPConn) {
+	s.cleanup.Lock()
+	defer s.cleanup.Unlock()
+	s.conns[id] = conn
+}
+
+func (s *Statsd) Stop() {
+	s.Lock()
+	s.Log.Infof("Stopping the statsd service")
+	close(s.done)
+	if s.isUDP() {
+		s.UDPlistener.Close()
+	} else {
+		s.TCPlistener.Close()
+		// Close all open TCP connections
+		//  - get all conns from the s.conns map and put into slice
+		//  - this is so the forget() function doesnt conflict with looping
+		//    over the s.conns map
+		var conns []*net.TCPConn
+		s.cleanup.Lock()
+		for _, conn := range s.conns {
+			conns = append(conns, conn)
+		}
+		s.cleanup.Unlock()
+		for _, conn := range conns {
+			conn.Close()
+		}
+	}
+	s.Unlock()
+
+	s.wg.Wait()
+
+	s.Lock()
+	close(s.in)
+	s.Log.Infof("Stopped listener service on %q", s.ServiceAddress)
+	s.Unlock()
+}
+
+// IsUDP returns true if the protocol is UDP, false otherwise.
+func (s *Statsd) isUDP() bool {
+	return strings.HasPrefix(s.Protocol, "udp")
+}
+
+func init() {
+	inputs.Add("statsd", func() cua.Input {
+		return &Statsd{
+			Protocol:               defaultProtocol,
+			ServiceAddress:         ":8125",
+			MaxTCPConnections:      250,
+			TCPKeepAlive:           false,
+			MetricSeparator:        "_",
+			AllowedPendingMessages: defaultAllowPendingMessage,
+			DeleteCounters:         true,
+			DeleteGauges:           true,
+			DeleteSets:             true,
+			DeleteTimings:          true,
+		}
+	})
+}

--- a/plugins/inputs/statsd_deprecated/statsd_test.go
+++ b/plugins/inputs/statsd_deprecated/statsd_test.go
@@ -1,0 +1,1751 @@
+package statsd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/circonus-labs/circonus-unified-agent/cua"
+	"github.com/circonus-labs/circonus-unified-agent/internal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/circonus-labs/circonus-unified-agent/testutil"
+)
+
+const (
+	testMsg         = "test.tcp.msg:100|c"
+	producerThreads = 10
+)
+
+func NewTestStatsd() *Statsd {
+	s := Statsd{Log: testutil.Logger{}}
+
+	// Make data structures
+	s.done = make(chan struct{})
+	s.in = make(chan input, s.AllowedPendingMessages)
+	s.gauges = make(map[string]cachedgauge)
+	s.counters = make(map[string]cachedcounter)
+	s.sets = make(map[string]cachedset)
+	s.timings = make(map[string]cachedtimings)
+
+	s.MetricSeparator = "_"
+
+	return &s
+}
+
+// Test that MaxTCPConnections is respected
+func TestConcurrentConns(t *testing.T) {
+	listener := Statsd{
+		Log:                    testutil.Logger{},
+		Protocol:               "tcp",
+		ServiceAddress:         "localhost:8125",
+		AllowedPendingMessages: 10000,
+		MaxTCPConnections:      2,
+	}
+
+	acc := &testutil.Accumulator{}
+	require.NoError(t, listener.Start(acc))
+	defer listener.Stop()
+
+	time.Sleep(time.Millisecond * 250)
+	_, err := net.Dial("tcp", "127.0.0.1:8125")
+	assert.NoError(t, err)
+	_, err = net.Dial("tcp", "127.0.0.1:8125")
+	assert.NoError(t, err)
+
+	// Connection over the limit:
+	conn, err := net.Dial("tcp", "127.0.0.1:8125")
+	assert.NoError(t, err)
+	_, _ = net.Dial("tcp", "127.0.0.1:8125")
+	assert.NoError(t, err)
+	_, err = conn.Write([]byte(testMsg))
+	assert.NoError(t, err)
+	time.Sleep(time.Millisecond * 100)
+	assert.Zero(t, acc.NFields())
+}
+
+// Test that MaxTCPConnections is respected when max==1
+func TestConcurrentConns1(t *testing.T) {
+	listener := Statsd{
+		Log:                    testutil.Logger{},
+		Protocol:               "tcp",
+		ServiceAddress:         "localhost:8125",
+		AllowedPendingMessages: 10000,
+		MaxTCPConnections:      1,
+	}
+
+	acc := &testutil.Accumulator{}
+	require.NoError(t, listener.Start(acc))
+	defer listener.Stop()
+
+	time.Sleep(time.Millisecond * 250)
+	_, err := net.Dial("tcp", "127.0.0.1:8125")
+	assert.NoError(t, err)
+
+	// Connection over the limit:
+	conn, err := net.Dial("tcp", "127.0.0.1:8125")
+	assert.NoError(t, err)
+	_, _ = net.Dial("tcp", "127.0.0.1:8125")
+	assert.NoError(t, err)
+	_, err = conn.Write([]byte(testMsg))
+	assert.NoError(t, err)
+	time.Sleep(time.Millisecond * 100)
+	assert.Zero(t, acc.NFields())
+}
+
+// Test that MaxTCPConnections is respected
+func TestCloseConcurrentConns(t *testing.T) {
+	listener := Statsd{
+		Log:                    testutil.Logger{},
+		Protocol:               "tcp",
+		ServiceAddress:         "localhost:8125",
+		AllowedPendingMessages: 10000,
+		MaxTCPConnections:      2,
+	}
+
+	acc := &testutil.Accumulator{}
+	require.NoError(t, listener.Start(acc))
+
+	time.Sleep(time.Millisecond * 250)
+	_, err := net.Dial("tcp", "127.0.0.1:8125")
+	assert.NoError(t, err)
+	_, err = net.Dial("tcp", "127.0.0.1:8125")
+	assert.NoError(t, err)
+
+	listener.Stop()
+}
+
+// benchmark how long it takes to accept & process 100,000 metrics:
+func BenchmarkUDP(b *testing.B) {
+	listener := Statsd{
+		Log:                    testutil.Logger{},
+		Protocol:               "udp",
+		ServiceAddress:         "localhost:8125",
+		AllowedPendingMessages: 250000,
+	}
+	acc := &testutil.Accumulator{Discard: true}
+
+	// send multiple messages to socket
+	for n := 0; n < b.N; n++ {
+		err := listener.Start(acc)
+		if err != nil {
+			panic(err)
+		}
+
+		time.Sleep(time.Millisecond * 250)
+		conn, err := net.Dial("udp", "127.0.0.1:8125")
+		if err != nil {
+			panic(err)
+		}
+
+		var wg sync.WaitGroup
+		for i := 1; i <= producerThreads; i++ {
+			wg.Add(1)
+			go sendRequests(conn, &wg)
+		}
+		wg.Wait()
+
+		// wait for 250,000 metrics to get added to accumulator
+		for len(listener.in) > 0 {
+			fmt.Printf("Left in buffer: %v \n", len(listener.in))
+			time.Sleep(time.Millisecond)
+		}
+		listener.Stop()
+	}
+}
+
+func sendRequests(conn io.Writer, wg *sync.WaitGroup) {
+	defer wg.Done()
+	for i := 0; i < 25000; i++ {
+		fmt.Fprint(conn, testMsg)
+	}
+}
+
+// benchmark how long it takes to accept & process 100,000 metrics:
+func BenchmarkTCP(b *testing.B) {
+	listener := Statsd{
+		Log:                    testutil.Logger{},
+		Protocol:               "tcp",
+		ServiceAddress:         "localhost:8125",
+		AllowedPendingMessages: 250000,
+		MaxTCPConnections:      250,
+	}
+	acc := &testutil.Accumulator{Discard: true}
+
+	// send multiple messages to socket
+	for n := 0; n < b.N; n++ {
+		err := listener.Start(acc)
+		if err != nil {
+			panic(err)
+		}
+
+		time.Sleep(time.Millisecond * 250)
+		conn, err := net.Dial("tcp", "127.0.0.1:8125")
+		if err != nil {
+			panic(err)
+		}
+		var wg sync.WaitGroup
+		for i := 1; i <= producerThreads; i++ {
+			wg.Add(1)
+			go sendRequests(conn, &wg)
+		}
+		wg.Wait()
+		// wait for 250,000 metrics to get added to accumulator
+		for len(listener.in) > 0 {
+			time.Sleep(time.Millisecond)
+		}
+		listener.Stop()
+	}
+}
+
+// Valid lines should be parsed and their values should be cached
+func TestParse_ValidLines(t *testing.T) {
+	s := NewTestStatsd()
+	validLines := []string{
+		"valid:45|c",
+		"valid:45|s",
+		"valid:45|g",
+		"valid.timer:45|ms",
+		"valid.timer:45|h",
+	}
+
+	for _, line := range validLines {
+		err := s.parseStatsdLine(line)
+		if err != nil {
+			t.Errorf("Parsing line %s should not have resulted in an error\n", line)
+		}
+	}
+}
+
+// Tests low-level functionality of gauges
+func TestParse_Gauges(t *testing.T) {
+	s := NewTestStatsd()
+
+	// Test that gauge +- values work
+	validLines := []string{
+		"plus.minus:100|g",
+		"plus.minus:-10|g",
+		"plus.minus:+30|g",
+		"plus.plus:100|g",
+		"plus.plus:+100|g",
+		"plus.plus:+100|g",
+		"minus.minus:100|g",
+		"minus.minus:-100|g",
+		"minus.minus:-100|g",
+		"lone.plus:+100|g",
+		"lone.minus:-100|g",
+		"overwrite:100|g",
+		"overwrite:300|g",
+		"scientific.notation:4.696E+5|g",
+		"scientific.notation.minus:4.7E-5|g",
+	}
+
+	for _, line := range validLines {
+		err := s.parseStatsdLine(line)
+		if err != nil {
+			t.Errorf("Parsing line %s should not have resulted in an error\n", line)
+		}
+	}
+
+	validations := []struct {
+		name  string
+		value float64
+	}{
+		{
+			"scientific_notation",
+			469600,
+		},
+		{
+			"scientific_notation_minus",
+			0.000047,
+		},
+		{
+			"plus_minus",
+			120,
+		},
+		{
+			"plus_plus",
+			300,
+		},
+		{
+			"minus_minus",
+			-100,
+		},
+		{
+			"lone_plus",
+			100,
+		},
+		{
+			"lone_minus",
+			-100,
+		},
+		{
+			"overwrite",
+			300,
+		},
+	}
+
+	for _, test := range validations {
+		err := testValidateGauge(test.name, test.value, s.gauges)
+		if err != nil {
+			t.Error(err.Error())
+		}
+	}
+}
+
+// Tests low-level functionality of sets
+func TestParse_Sets(t *testing.T) {
+	s := NewTestStatsd()
+
+	// Test that sets work
+	validLines := []string{
+		"unique.user.ids:100|s",
+		"unique.user.ids:100|s",
+		"unique.user.ids:100|s",
+		"unique.user.ids:100|s",
+		"unique.user.ids:100|s",
+		"unique.user.ids:101|s",
+		"unique.user.ids:102|s",
+		"unique.user.ids:102|s",
+		"unique.user.ids:123456789|s",
+		"oneuser.id:100|s",
+		"oneuser.id:100|s",
+		"scientific.notation.sets:4.696E+5|s",
+		"scientific.notation.sets:4.696E+5|s",
+		"scientific.notation.sets:4.697E+5|s",
+		"string.sets:foobar|s",
+		"string.sets:foobar|s",
+		"string.sets:bar|s",
+	}
+
+	for _, line := range validLines {
+		err := s.parseStatsdLine(line)
+		if err != nil {
+			t.Errorf("Parsing line %s should not have resulted in an error\n", line)
+		}
+	}
+
+	validations := []struct {
+		name  string
+		value int64
+	}{
+		{
+			"scientific_notation_sets",
+			2,
+		},
+		{
+			"unique_user_ids",
+			4,
+		},
+		{
+			"oneuser_id",
+			1,
+		},
+		{
+			"string_sets",
+			2,
+		},
+	}
+
+	for _, test := range validations {
+		err := testValidateSet(test.name, test.value, s.sets)
+		if err != nil {
+			t.Error(err.Error())
+		}
+	}
+}
+
+// Tests low-level functionality of counters
+func TestParse_Counters(t *testing.T) {
+	s := NewTestStatsd()
+
+	// Test that counters work
+	validLines := []string{
+		"small.inc:1|c",
+		"big.inc:100|c",
+		"big.inc:1|c",
+		"big.inc:100000|c",
+		"big.inc:1000000|c",
+		"small.inc:1|c",
+		"zero.init:0|c",
+		"sample.rate:1|c|@0.1",
+		"sample.rate:1|c",
+		"scientific.notation:4.696E+5|c",
+		"negative.test:100|c",
+		"negative.test:-5|c",
+	}
+
+	for _, line := range validLines {
+		err := s.parseStatsdLine(line)
+		if err != nil {
+			t.Errorf("Parsing line %s should not have resulted in an error\n", line)
+		}
+	}
+
+	validations := []struct {
+		name  string
+		value int64
+	}{
+		{
+			"scientific_notation",
+			469600,
+		},
+		{
+			"small_inc",
+			2,
+		},
+		{
+			"big_inc",
+			1100101,
+		},
+		{
+			"zero_init",
+			0,
+		},
+		{
+			"sample_rate",
+			11,
+		},
+		{
+			"negative_test",
+			95,
+		},
+	}
+
+	for _, test := range validations {
+		err := testValidateCounter(test.name, test.value, s.counters)
+		if err != nil {
+			t.Error(err.Error())
+		}
+	}
+}
+
+// Tests low-level functionality of timings
+func TestParse_Timings(t *testing.T) {
+	s := NewTestStatsd()
+	s.Percentiles = []internal.Number{{Value: 90.0}}
+	acc := &testutil.Accumulator{}
+
+	// Test that counters work
+	validLines := []string{
+		"test.timing:1|ms",
+		"test.timing:11|ms",
+		"test.timing:1|ms",
+		"test.timing:1|ms",
+		"test.timing:1|ms",
+	}
+
+	for _, line := range validLines {
+		err := s.parseStatsdLine(line)
+		if err != nil {
+			t.Errorf("Parsing line %s should not have resulted in an error\n", line)
+		}
+	}
+
+	_ = s.Gather(context.Background(), acc)
+
+	valid := map[string]interface{}{
+		"90_percentile": float64(11),
+		"count":         int64(5),
+		"lower":         float64(1),
+		"mean":          float64(3),
+		"stddev":        float64(4),
+		"sum":           float64(15),
+		"upper":         float64(11),
+	}
+
+	acc.AssertContainsFields(t, "test_timing", valid)
+}
+
+func TestParseScientificNotation(t *testing.T) {
+	s := NewTestStatsd()
+	sciNotationLines := []string{
+		"scientific.notation:4.6968460083008E-5|ms",
+		"scientific.notation:4.6968460083008E-5|g",
+		"scientific.notation:4.6968460083008E-5|c",
+		"scientific.notation:4.6968460083008E-5|h",
+	}
+	for _, line := range sciNotationLines {
+		err := s.parseStatsdLine(line)
+		if err != nil {
+			t.Errorf("Parsing line [%s] should not have resulted in error: %s\n", line, err)
+		}
+	}
+}
+
+// Invalid lines should return an error
+func TestParse_InvalidLines(t *testing.T) {
+	s := NewTestStatsd()
+	invalidLines := []string{
+		"i.dont.have.a.pipe:45g",
+		"i.dont.have.a.colon45|c",
+		"invalid.metric.type:45|e",
+		"invalid.plus.minus.non.gauge:+10|s",
+		"invalid.plus.minus.non.gauge:+10|ms",
+		"invalid.plus.minus.non.gauge:+10|h",
+		"invalid.value:foobar|c",
+		"invalid.value:d11|c",
+		"invalid.value:1d1|c",
+	}
+	for _, line := range invalidLines {
+		err := s.parseStatsdLine(line)
+		if err == nil {
+			t.Errorf("Parsing line %s should have resulted in an error\n", line)
+		}
+	}
+}
+
+// Invalid sample rates should be ignored and not applied
+func TestParse_InvalidSampleRate(t *testing.T) {
+	s := NewTestStatsd()
+	invalidLines := []string{
+		"invalid.sample.rate:45|c|0.1",
+		"invalid.sample.rate.2:45|c|@foo",
+		"invalid.sample.rate:45|g|@0.1",
+		"invalid.sample.rate:45|s|@0.1",
+	}
+
+	for _, line := range invalidLines {
+		err := s.parseStatsdLine(line)
+		if err != nil {
+			t.Errorf("Parsing line %s should not have resulted in an error\n", line)
+		}
+	}
+
+	counterValidations := []struct {
+		name  string
+		value int64
+		cache map[string]cachedcounter
+	}{
+		{
+			"invalid_sample_rate",
+			45,
+			s.counters,
+		},
+		{
+			"invalid_sample_rate_2",
+			45,
+			s.counters,
+		},
+	}
+
+	for _, test := range counterValidations {
+		err := testValidateCounter(test.name, test.value, test.cache)
+		if err != nil {
+			t.Error(err.Error())
+		}
+	}
+
+	err := testValidateGauge("invalid_sample_rate", 45, s.gauges)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	err = testValidateSet("invalid_sample_rate", 1, s.sets)
+	if err != nil {
+		t.Error(err.Error())
+	}
+}
+
+// Names should be parsed like . -> _
+func TestParse_DefaultNameParsing(t *testing.T) {
+	s := NewTestStatsd()
+	validLines := []string{
+		"valid:1|c",
+		"valid.foo-bar:11|c",
+	}
+
+	for _, line := range validLines {
+		err := s.parseStatsdLine(line)
+		if err != nil {
+			t.Errorf("Parsing line %s should not have resulted in an error\n", line)
+		}
+	}
+
+	validations := []struct {
+		name  string
+		value int64
+	}{
+		{
+			"valid",
+			1,
+		},
+		{
+			"valid_foo-bar",
+			11,
+		},
+	}
+
+	for _, test := range validations {
+		err := testValidateCounter(test.name, test.value, s.counters)
+		if err != nil {
+			t.Error(err.Error())
+		}
+	}
+}
+
+// Test that template name transformation works
+func TestParse_Template(t *testing.T) {
+	s := NewTestStatsd()
+	s.Templates = []string{
+		"measurement.measurement.host.service",
+	}
+
+	lines := []string{
+		"cpu.idle.localhost:1|c",
+		"cpu.busy.host01.myservice:11|c",
+	}
+
+	for _, line := range lines {
+		err := s.parseStatsdLine(line)
+		if err != nil {
+			t.Errorf("Parsing line %s should not have resulted in an error\n", line)
+		}
+	}
+
+	validations := []struct {
+		name  string
+		value int64
+	}{
+		{
+			"cpu_idle",
+			1,
+		},
+		{
+			"cpu_busy",
+			11,
+		},
+	}
+
+	// Validate counters
+	for _, test := range validations {
+		err := testValidateCounter(test.name, test.value, s.counters)
+		if err != nil {
+			t.Error(err.Error())
+		}
+	}
+}
+
+// Test that template filters properly
+func TestParse_TemplateFilter(t *testing.T) {
+	s := NewTestStatsd()
+	s.Templates = []string{
+		"cpu.idle.* measurement.measurement.host",
+	}
+
+	lines := []string{
+		"cpu.idle.localhost:1|c",
+		"cpu.busy.host01.myservice:11|c",
+	}
+
+	for _, line := range lines {
+		err := s.parseStatsdLine(line)
+		if err != nil {
+			t.Errorf("Parsing line %s should not have resulted in an error\n", line)
+		}
+	}
+
+	validations := []struct {
+		name  string
+		value int64
+	}{
+		{
+			"cpu_idle",
+			1,
+		},
+		{
+			"cpu_busy_host01_myservice",
+			11,
+		},
+	}
+
+	// Validate counters
+	for _, test := range validations {
+		err := testValidateCounter(test.name, test.value, s.counters)
+		if err != nil {
+			t.Error(err.Error())
+		}
+	}
+}
+
+// Test that most specific template is chosen
+func TestParse_TemplateSpecificity(t *testing.T) {
+	s := NewTestStatsd()
+	s.Templates = []string{
+		"cpu.* measurement.foo.host",
+		"cpu.idle.* measurement.measurement.host",
+	}
+
+	lines := []string{
+		"cpu.idle.localhost:1|c",
+	}
+
+	for _, line := range lines {
+		err := s.parseStatsdLine(line)
+		if err != nil {
+			t.Errorf("Parsing line %s should not have resulted in an error\n", line)
+		}
+	}
+
+	validations := []struct {
+		name  string
+		value int64
+	}{
+		{
+			"cpu_idle",
+			1,
+		},
+	}
+
+	// Validate counters
+	for _, test := range validations {
+		err := testValidateCounter(test.name, test.value, s.counters)
+		if err != nil {
+			t.Error(err.Error())
+		}
+	}
+}
+
+// Test that most specific template is chosen
+func TestParse_TemplateFields(t *testing.T) {
+	s := NewTestStatsd()
+	s.Templates = []string{
+		"* measurement.measurement.field",
+	}
+
+	lines := []string{
+		"my.counter.f1:1|c",
+		"my.counter.f1:1|c",
+		"my.counter.f2:1|c",
+		"my.counter.f3:10|c",
+		"my.counter.f3:100|c",
+		"my.gauge.f1:10.1|g",
+		"my.gauge.f2:10.1|g",
+		"my.gauge.f1:0.9|g",
+		"my.set.f1:1|s",
+		"my.set.f1:2|s",
+		"my.set.f1:1|s",
+		"my.set.f2:100|s",
+	}
+
+	for _, line := range lines {
+		err := s.parseStatsdLine(line)
+		if err != nil {
+			t.Errorf("Parsing line %s should not have resulted in an error\n", line)
+		}
+	}
+
+	counterTests := []struct {
+		name  string
+		value int64
+		field string
+	}{
+		{
+			"my_counter",
+			2,
+			"f1",
+		},
+		{
+			"my_counter",
+			1,
+			"f2",
+		},
+		{
+			"my_counter",
+			110,
+			"f3",
+		},
+	}
+	// Validate counters
+	for _, test := range counterTests {
+		err := testValidateCounter(test.name, test.value, s.counters, test.field)
+		if err != nil {
+			t.Error(err.Error())
+		}
+	}
+
+	gaugeTests := []struct {
+		name  string
+		value float64
+		field string
+	}{
+		{
+			"my_gauge",
+			0.9,
+			"f1",
+		},
+		{
+			"my_gauge",
+			10.1,
+			"f2",
+		},
+	}
+	// Validate gauges
+	for _, test := range gaugeTests {
+		err := testValidateGauge(test.name, test.value, s.gauges, test.field)
+		if err != nil {
+			t.Error(err.Error())
+		}
+	}
+
+	setTests := []struct {
+		name  string
+		value int64
+		field string
+	}{
+		{
+			"my_set",
+			2,
+			"f1",
+		},
+		{
+			"my_set",
+			1,
+			"f2",
+		},
+	}
+	// Validate sets
+	for _, test := range setTests {
+		err := testValidateSet(test.name, test.value, s.sets, test.field)
+		if err != nil {
+			t.Error(err.Error())
+		}
+	}
+}
+
+// Test that fields are parsed correctly
+func TestParse_Fields(t *testing.T) {
+	if false {
+		t.Errorf("TODO")
+	}
+}
+
+// Test that tags within the bucket are parsed correctly
+func TestParse_Tags(t *testing.T) {
+	s := NewTestStatsd()
+
+	tests := []struct {
+		bucket string
+		name   string
+		tags   map[string]string
+	}{
+		{
+			"cpu.idle,host=localhost",
+			"cpu_idle",
+			map[string]string{
+				"host": "localhost",
+			},
+		},
+		{
+			"cpu.idle,host=localhost,region=west",
+			"cpu_idle",
+			map[string]string{
+				"host":   "localhost",
+				"region": "west",
+			},
+		},
+		{
+			"cpu.idle,host=localhost,color=red,region=west",
+			"cpu_idle",
+			map[string]string{
+				"host":   "localhost",
+				"region": "west",
+				"color":  "red",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		name, _, tags := s.parseName(test.bucket)
+		if name != test.name {
+			t.Errorf("Expected: %s, got %s", test.name, name)
+		}
+
+		for k, v := range test.tags {
+			actual, ok := tags[k]
+			if !ok {
+				t.Errorf("Expected key: %s not found", k)
+			}
+			if actual != v {
+				t.Errorf("Expected %s, got %s", v, actual)
+			}
+		}
+	}
+}
+
+func TestParse_DataDogTags(t *testing.T) {
+	tests := []struct {
+		name     string
+		line     string
+		expected []cua.Metric
+	}{
+		{
+			name: "counter",
+			line: "my_counter:1|c|#host:localhost,environment:prod,endpoint:/:tenant?/oauth/ro",
+			expected: []cua.Metric{
+				testutil.MustMetric(
+					"my_counter",
+					map[string]string{
+						"endpoint":    "/:tenant?/oauth/ro",
+						"environment": "prod",
+						"host":        "localhost",
+						"metric_type": "counter",
+					},
+					map[string]interface{}{
+						"value": 1,
+					},
+					time.Now(),
+					cua.Counter,
+				),
+			},
+		},
+		{
+			name: "gauge",
+			line: "my_gauge:10.1|g|#live",
+			expected: []cua.Metric{
+				testutil.MustMetric(
+					"my_gauge",
+					map[string]string{
+						"live":        "true",
+						"metric_type": "gauge",
+					},
+					map[string]interface{}{
+						"value": 10.1,
+					},
+					time.Now(),
+					cua.Gauge,
+				),
+			},
+		},
+		{
+			name: "set",
+			line: "my_set:1|s|#host:localhost",
+			expected: []cua.Metric{
+				testutil.MustMetric(
+					"my_set",
+					map[string]string{
+						"host":        "localhost",
+						"metric_type": "set",
+					},
+					map[string]interface{}{
+						"value": 1,
+					},
+					time.Now(),
+				),
+			},
+		},
+		{
+			name: "timer",
+			line: "my_timer:3|ms|@0.1|#live,host:localhost",
+			expected: []cua.Metric{
+				testutil.MustMetric(
+					"my_timer",
+					map[string]string{
+						"host":        "localhost",
+						"live":        "true",
+						"metric_type": "timing",
+					},
+					map[string]interface{}{
+						"count":  10,
+						"lower":  float64(3),
+						"mean":   float64(3),
+						"stddev": float64(0),
+						"sum":    float64(30),
+						"upper":  float64(3),
+					},
+					time.Now(),
+				),
+			},
+		},
+		{
+			name: "empty tag set",
+			line: "cpu:42|c|#",
+			expected: []cua.Metric{
+				testutil.MustMetric(
+					"cpu",
+					map[string]string{
+						"metric_type": "counter",
+					},
+					map[string]interface{}{
+						"value": 42,
+					},
+					time.Now(),
+					cua.Counter,
+				),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			var acc testutil.Accumulator
+
+			s := NewTestStatsd()
+			s.DataDogExtensions = true
+
+			err := s.parseStatsdLine(tt.line)
+			require.NoError(t, err)
+			err = s.Gather(context.Background(), &acc)
+			require.NoError(t, err)
+
+			testutil.RequireMetricsEqual(t, tt.expected, acc.GetCUAMetrics(),
+				testutil.SortMetrics(), testutil.IgnoreTime())
+		})
+	}
+}
+
+// Test that statsd buckets are parsed to measurement names properly
+func TestParseName(t *testing.T) {
+	s := NewTestStatsd()
+
+	tests := []struct {
+		inName  string
+		outName string
+	}{
+		{
+			"foobar",
+			"foobar",
+		},
+		{
+			"foo.bar",
+			"foo_bar",
+		},
+		{
+			"foo.bar-baz",
+			"foo_bar-baz",
+		},
+	}
+
+	for _, test := range tests {
+		name, _, _ := s.parseName(test.inName)
+		if name != test.outName {
+			t.Errorf("Expected: %s, got %s", test.outName, name)
+		}
+	}
+
+	// Test with separator == "."
+	s.MetricSeparator = "."
+
+	tests = []struct {
+		inName  string
+		outName string
+	}{
+		{
+			"foobar",
+			"foobar",
+		},
+		{
+			"foo.bar",
+			"foo.bar",
+		},
+		{
+			"foo.bar-baz",
+			"foo.bar-baz",
+		},
+	}
+
+	for _, test := range tests {
+		name, _, _ := s.parseName(test.inName)
+		if name != test.outName {
+			t.Errorf("Expected: %s, got %s", test.outName, name)
+		}
+	}
+}
+
+// Test that measurements with the same name, but different tags, are treated
+// as different outputs
+func TestParse_MeasurementsWithSameName(t *testing.T) {
+	s := NewTestStatsd()
+
+	// Test that counters work
+	validLines := []string{
+		"test.counter,host=localhost:1|c",
+		"test.counter,host=localhost,region=west:1|c",
+	}
+
+	for _, line := range validLines {
+		err := s.parseStatsdLine(line)
+		if err != nil {
+			t.Errorf("Parsing line %s should not have resulted in an error\n", line)
+		}
+	}
+
+	if len(s.counters) != 2 {
+		t.Errorf("Expected 2 separate measurements, found %d", len(s.counters))
+	}
+}
+
+// Test that measurements with multiple bits, are treated as different outputs
+// but are equal to their single-measurement representation
+func TestParse_MeasurementsWithMultipleValues(t *testing.T) {
+	singleLines := []string{
+		"valid.multiple:0|ms|@0.1",
+		"valid.multiple:0|ms|",
+		"valid.multiple:1|ms",
+		"valid.multiple.duplicate:1|c",
+		"valid.multiple.duplicate:1|c",
+		"valid.multiple.duplicate:2|c",
+		"valid.multiple.duplicate:1|c",
+		"valid.multiple.duplicate:1|h",
+		"valid.multiple.duplicate:1|h",
+		"valid.multiple.duplicate:2|h",
+		"valid.multiple.duplicate:1|h",
+		"valid.multiple.duplicate:1|s",
+		"valid.multiple.duplicate:1|s",
+		"valid.multiple.duplicate:2|s",
+		"valid.multiple.duplicate:1|s",
+		"valid.multiple.duplicate:1|g",
+		"valid.multiple.duplicate:1|g",
+		"valid.multiple.duplicate:2|g",
+		"valid.multiple.duplicate:1|g",
+		"valid.multiple.mixed:1|c",
+		"valid.multiple.mixed:1|ms",
+		"valid.multiple.mixed:2|s",
+		"valid.multiple.mixed:1|g",
+	}
+
+	multipleLines := []string{
+		"valid.multiple:0|ms|@0.1:0|ms|:1|ms",
+		"valid.multiple.duplicate:1|c:1|c:2|c:1|c",
+		"valid.multiple.duplicate:1|h:1|h:2|h:1|h",
+		"valid.multiple.duplicate:1|s:1|s:2|s:1|s",
+		"valid.multiple.duplicate:1|g:1|g:2|g:1|g",
+		"valid.multiple.mixed:1|c:1|ms:2|s:1|g",
+	}
+
+	sSingle := NewTestStatsd()
+	sMultiple := NewTestStatsd()
+
+	for _, line := range singleLines {
+		err := sSingle.parseStatsdLine(line)
+		if err != nil {
+			t.Errorf("Parsing line %s should not have resulted in an error\n", line)
+		}
+	}
+
+	for _, line := range multipleLines {
+		err := sMultiple.parseStatsdLine(line)
+		if err != nil {
+			t.Errorf("Parsing line %s should not have resulted in an error\n", line)
+		}
+	}
+
+	if len(sSingle.timings) != 3 {
+		t.Errorf("Expected 3 measurement, found %d", len(sSingle.timings))
+	}
+
+	if cachedtiming, ok := sSingle.timings["metric_type=timingvalid_multiple"]; !ok {
+		t.Errorf("Expected cached measurement with hash 'metric_type=timingvalid_multiple' not found")
+	} else {
+		if cachedtiming.name != "valid_multiple" {
+			t.Errorf("Expected the name to be 'valid_multiple', got %s", cachedtiming.name)
+		}
+
+		// A 0 at samplerate 0.1 will add 10 values of 0,
+		// A 0 with invalid samplerate will add a single 0,
+		// plus the last bit of value 1
+		// which adds up to 12 individual datapoints to be cached
+		if cachedtiming.fields[defaultFieldName].n != 12 {
+			t.Errorf("Expected 12 additions, got %d", cachedtiming.fields[defaultFieldName].n)
+		}
+
+		if cachedtiming.fields[defaultFieldName].upper != 1 {
+			t.Errorf("Expected max input to be 1, got %f", cachedtiming.fields[defaultFieldName].upper)
+		}
+	}
+
+	// test if sSingle and sMultiple did compute the same stats for valid.multiple.duplicate
+	if err := testValidateSet("valid_multiple_duplicate", 2, sSingle.sets); err != nil {
+		t.Error(err.Error())
+	}
+
+	if err := testValidateSet("valid_multiple_duplicate", 2, sMultiple.sets); err != nil {
+		t.Error(err.Error())
+	}
+
+	if err := testValidateCounter("valid_multiple_duplicate", 5, sSingle.counters); err != nil {
+		t.Error(err.Error())
+	}
+
+	if err := testValidateCounter("valid_multiple_duplicate", 5, sMultiple.counters); err != nil {
+		t.Error(err.Error())
+	}
+
+	if err := testValidateGauge("valid_multiple_duplicate", 1, sSingle.gauges); err != nil {
+		t.Error(err.Error())
+	}
+
+	if err := testValidateGauge("valid_multiple_duplicate", 1, sMultiple.gauges); err != nil {
+		t.Error(err.Error())
+	}
+
+	// test if sSingle and sMultiple did compute the same stats for valid.multiple.mixed
+	if err := testValidateSet("valid_multiple_mixed", 1, sSingle.sets); err != nil {
+		t.Error(err.Error())
+	}
+
+	if err := testValidateSet("valid_multiple_mixed", 1, sMultiple.sets); err != nil {
+		t.Error(err.Error())
+	}
+
+	if err := testValidateCounter("valid_multiple_mixed", 1, sSingle.counters); err != nil {
+		t.Error(err.Error())
+	}
+
+	if err := testValidateCounter("valid_multiple_mixed", 1, sMultiple.counters); err != nil {
+		t.Error(err.Error())
+	}
+
+	if err := testValidateGauge("valid_multiple_mixed", 1, sSingle.gauges); err != nil {
+		t.Error(err.Error())
+	}
+
+	if err := testValidateGauge("valid_multiple_mixed", 1, sMultiple.gauges); err != nil {
+		t.Error(err.Error())
+	}
+}
+
+// Tests low-level functionality of timings when multiple fields is enabled
+// and a measurement template has been defined which can parse field names
+func TestParse_TimingsMultipleFieldsWithTemplate(t *testing.T) {
+	s := NewTestStatsd()
+	s.Templates = []string{"measurement.field"}
+	s.Percentiles = []internal.Number{{Value: 90.0}}
+	acc := &testutil.Accumulator{}
+
+	validLines := []string{
+		"test_timing.success:1|ms",
+		"test_timing.success:11|ms",
+		"test_timing.success:1|ms",
+		"test_timing.success:1|ms",
+		"test_timing.success:1|ms",
+		"test_timing.error:2|ms",
+		"test_timing.error:22|ms",
+		"test_timing.error:2|ms",
+		"test_timing.error:2|ms",
+		"test_timing.error:2|ms",
+	}
+
+	for _, line := range validLines {
+		err := s.parseStatsdLine(line)
+		if err != nil {
+			t.Errorf("Parsing line %s should not have resulted in an error\n", line)
+		}
+	}
+	_ = s.Gather(context.Background(), acc)
+
+	valid := map[string]interface{}{
+		"success_90_percentile": float64(11),
+		"success_count":         int64(5),
+		"success_lower":         float64(1),
+		"success_mean":          float64(3),
+		"success_stddev":        float64(4),
+		"success_sum":           float64(15),
+		"success_upper":         float64(11),
+
+		"error_90_percentile": float64(22),
+		"error_count":         int64(5),
+		"error_lower":         float64(2),
+		"error_mean":          float64(6),
+		"error_stddev":        float64(8),
+		"error_sum":           float64(30),
+		"error_upper":         float64(22),
+	}
+
+	acc.AssertContainsFields(t, "test_timing", valid)
+}
+
+// Tests low-level functionality of timings when multiple fields is enabled
+// but a measurement template hasn't been defined so we can't parse field names
+// In this case the behaviour should be the same as normal behaviour
+func TestParse_TimingsMultipleFieldsWithoutTemplate(t *testing.T) {
+	s := NewTestStatsd()
+	s.Templates = []string{}
+	s.Percentiles = []internal.Number{{Value: 90.0}}
+	acc := &testutil.Accumulator{}
+
+	validLines := []string{
+		"test_timing.success:1|ms",
+		"test_timing.success:11|ms",
+		"test_timing.success:1|ms",
+		"test_timing.success:1|ms",
+		"test_timing.success:1|ms",
+		"test_timing.error:2|ms",
+		"test_timing.error:22|ms",
+		"test_timing.error:2|ms",
+		"test_timing.error:2|ms",
+		"test_timing.error:2|ms",
+	}
+
+	for _, line := range validLines {
+		err := s.parseStatsdLine(line)
+		if err != nil {
+			t.Errorf("Parsing line %s should not have resulted in an error\n", line)
+		}
+	}
+	_ = s.Gather(context.Background(), acc)
+
+	expectedSuccess := map[string]interface{}{
+		"90_percentile": float64(11),
+		"count":         int64(5),
+		"lower":         float64(1),
+		"mean":          float64(3),
+		"stddev":        float64(4),
+		"sum":           float64(15),
+		"upper":         float64(11),
+	}
+	expectedError := map[string]interface{}{
+		"90_percentile": float64(22),
+		"count":         int64(5),
+		"lower":         float64(2),
+		"mean":          float64(6),
+		"stddev":        float64(8),
+		"sum":           float64(30),
+		"upper":         float64(22),
+	}
+
+	acc.AssertContainsFields(t, "test_timing_success", expectedSuccess)
+	acc.AssertContainsFields(t, "test_timing_error", expectedError)
+}
+
+func BenchmarkParse(b *testing.B) {
+	s := NewTestStatsd()
+	validLines := []string{
+		"test.timing.success:1|ms",
+		"test.timing.success:11|ms",
+		"test.timing.success:1|ms",
+		"test.timing.success:1|ms",
+		"test.timing.success:1|ms",
+		"test.timing.error:2|ms",
+		"test.timing.error:22|ms",
+		"test.timing.error:2|ms",
+		"test.timing.error:2|ms",
+		"test.timing.error:2|ms",
+	}
+	for n := 0; n < b.N; n++ {
+		for _, line := range validLines {
+			err := s.parseStatsdLine(line)
+			if err != nil {
+				b.Errorf("Parsing line %s should not have resulted in an error\n", line)
+			}
+		}
+	}
+}
+
+func BenchmarkParseWithTemplate(b *testing.B) {
+	s := NewTestStatsd()
+	s.Templates = []string{"measurement.measurement.field"}
+	validLines := []string{
+		"test.timing.success:1|ms",
+		"test.timing.success:11|ms",
+		"test.timing.success:1|ms",
+		"test.timing.success:1|ms",
+		"test.timing.success:1|ms",
+		"test.timing.error:2|ms",
+		"test.timing.error:22|ms",
+		"test.timing.error:2|ms",
+		"test.timing.error:2|ms",
+		"test.timing.error:2|ms",
+	}
+	for n := 0; n < b.N; n++ {
+		for _, line := range validLines {
+			err := s.parseStatsdLine(line)
+			if err != nil {
+				b.Errorf("Parsing line %s should not have resulted in an error\n", line)
+			}
+		}
+	}
+}
+
+func BenchmarkParseWithTemplateAndFilter(b *testing.B) {
+	s := NewTestStatsd()
+	s.Templates = []string{"cpu* measurement.measurement.field"}
+	validLines := []string{
+		"test.timing.success:1|ms",
+		"test.timing.success:11|ms",
+		"test.timing.success:1|ms",
+		"cpu.timing.success:1|ms",
+		"cpu.timing.success:1|ms",
+		"cpu.timing.error:2|ms",
+		"cpu.timing.error:22|ms",
+		"test.timing.error:2|ms",
+		"test.timing.error:2|ms",
+		"test.timing.error:2|ms",
+	}
+	for n := 0; n < b.N; n++ {
+		for _, line := range validLines {
+			err := s.parseStatsdLine(line)
+			if err != nil {
+				b.Errorf("Parsing line %s should not have resulted in an error\n", line)
+			}
+		}
+	}
+}
+
+func BenchmarkParseWith2TemplatesAndFilter(b *testing.B) {
+	s := NewTestStatsd()
+	s.Templates = []string{
+		"cpu1* measurement.measurement.field",
+		"cpu2* measurement.measurement.field",
+	}
+	validLines := []string{
+		"test.timing.success:1|ms",
+		"test.timing.success:11|ms",
+		"test.timing.success:1|ms",
+		"cpu1.timing.success:1|ms",
+		"cpu1.timing.success:1|ms",
+		"cpu2.timing.error:2|ms",
+		"cpu2.timing.error:22|ms",
+		"test.timing.error:2|ms",
+		"test.timing.error:2|ms",
+		"test.timing.error:2|ms",
+	}
+	for n := 0; n < b.N; n++ {
+		for _, line := range validLines {
+			err := s.parseStatsdLine(line)
+			if err != nil {
+				b.Errorf("Parsing line %s should not have resulted in an error\n", line)
+			}
+		}
+	}
+}
+
+func BenchmarkParseWith2Templates3TagsAndFilter(b *testing.B) {
+	s := NewTestStatsd()
+	s.Templates = []string{
+		"cpu1* measurement.measurement.region.city.rack.field",
+		"cpu2* measurement.measurement.region.city.rack.field",
+	}
+	validLines := []string{
+		"test.timing.us-east.nyc.rack01.success:1|ms",
+		"test.timing.us-east.nyc.rack01.success:11|ms",
+		"test.timing.us-west.sf.rack01.success:1|ms",
+		"cpu1.timing.us-west.sf.rack01.success:1|ms",
+		"cpu1.timing.us-east.nyc.rack01.success:1|ms",
+		"cpu2.timing.us-east.nyc.rack01.error:2|ms",
+		"cpu2.timing.us-west.sf.rack01.error:22|ms",
+		"test.timing.us-west.sf.rack01.error:2|ms",
+		"test.timing.us-west.sf.rack01.error:2|ms",
+		"test.timing.us-east.nyc.rack01.error:2|ms",
+	}
+	for n := 0; n < b.N; n++ {
+		for _, line := range validLines {
+			err := s.parseStatsdLine(line)
+			if err != nil {
+				b.Errorf("Parsing line %s should not have resulted in an error\n", line)
+			}
+		}
+	}
+}
+
+func TestParse_Timings_Delete(t *testing.T) {
+	s := NewTestStatsd()
+	s.DeleteTimings = true
+	fakeacc := &testutil.Accumulator{}
+	var err error
+
+	line := "timing:100|ms"
+	err = s.parseStatsdLine(line)
+	if err != nil {
+		t.Errorf("Parsing line %s should not have resulted in an error\n", line)
+	}
+
+	if len(s.timings) != 1 {
+		t.Errorf("Should be 1 timing, found %d", len(s.timings))
+	}
+
+	_ = s.Gather(context.Background(), fakeacc)
+
+	if len(s.timings) != 0 {
+		t.Errorf("All timings should have been deleted, found %d", len(s.timings))
+	}
+}
+
+// Tests the delete_gauges option
+func TestParse_Gauges_Delete(t *testing.T) {
+	s := NewTestStatsd()
+	s.DeleteGauges = true
+	fakeacc := &testutil.Accumulator{}
+	var err error
+
+	line := "current.users:100|g"
+	err = s.parseStatsdLine(line)
+	if err != nil {
+		t.Errorf("Parsing line %s should not have resulted in an error\n", line)
+	}
+
+	err = testValidateGauge("current_users", 100, s.gauges)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	_ = s.Gather(context.Background(), fakeacc)
+
+	err = testValidateGauge("current_users", 100, s.gauges)
+	if err == nil {
+		t.Error("current_users_gauge metric should have been deleted")
+	}
+}
+
+// Tests the delete_sets option
+func TestParse_Sets_Delete(t *testing.T) {
+	s := NewTestStatsd()
+	s.DeleteSets = true
+	fakeacc := &testutil.Accumulator{}
+	var err error
+
+	line := "unique.user.ids:100|s"
+	err = s.parseStatsdLine(line)
+	if err != nil {
+		t.Errorf("Parsing line %s should not have resulted in an error\n", line)
+	}
+
+	err = testValidateSet("unique_user_ids", 1, s.sets)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	_ = s.Gather(context.Background(), fakeacc)
+
+	err = testValidateSet("unique_user_ids", 1, s.sets)
+	if err == nil {
+		t.Error("unique_user_ids_set metric should have been deleted")
+	}
+}
+
+// Tests the delete_counters option
+func TestParse_Counters_Delete(t *testing.T) {
+	s := NewTestStatsd()
+	s.DeleteCounters = true
+	fakeacc := &testutil.Accumulator{}
+	var err error
+
+	line := "total.users:100|c"
+	err = s.parseStatsdLine(line)
+	if err != nil {
+		t.Errorf("Parsing line %s should not have resulted in an error\n", line)
+	}
+
+	err = testValidateCounter("total_users", 100, s.counters)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	_ = s.Gather(context.Background(), fakeacc)
+
+	err = testValidateCounter("total_users", 100, s.counters)
+	if err == nil {
+		t.Error("total_users_counter metric should have been deleted")
+	}
+}
+
+func TestParseKeyValue(t *testing.T) {
+	k, v := parseKeyValue("foo=bar")
+	if k != "foo" {
+		t.Errorf("Expected %s, got %s", "foo", k)
+	}
+	if v != "bar" {
+		t.Errorf("Expected %s, got %s", "bar", v)
+	}
+
+	k2, v2 := parseKeyValue("baz")
+	if k2 != "" {
+		t.Errorf("Expected %s, got %s", "", k2)
+	}
+	if v2 != "baz" {
+		t.Errorf("Expected %s, got %s", "baz", v2)
+	}
+}
+
+// Test utility functions
+func testValidateSet(
+	name string,
+	value int64,
+	cache map[string]cachedset,
+	field ...string,
+) error {
+	var f string
+	if len(field) > 0 {
+		f = field[0]
+	} else {
+		f = "value"
+	}
+	var metric cachedset
+	var found bool
+	for _, v := range cache {
+		if v.name == name {
+			metric = v
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("test Error: Metric name %s not found", name)
+	}
+
+	if value != int64(len(metric.fields[f])) {
+		return fmt.Errorf("measurement: %s, expected %d, actual %d", name, value, len(metric.fields[f]))
+	}
+	return nil
+}
+
+func testValidateCounter(
+	name string,
+	valueExpected int64,
+	cache map[string]cachedcounter,
+	field ...string,
+) error {
+	var f string
+	if len(field) > 0 {
+		f = field[0]
+	} else {
+		f = "value"
+	}
+	var valueActual int64
+	var found bool
+	for _, v := range cache {
+		if v.name == name {
+			valueActual = v.fields[f].(int64)
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("test Error: Metric name %s not found", name)
+	}
+
+	if valueExpected != valueActual {
+		return fmt.Errorf("measurement: %s, expected %d, actual %d", name, valueExpected, valueActual)
+	}
+	return nil
+}
+
+func testValidateGauge(
+	name string,
+	valueExpected float64,
+	cache map[string]cachedgauge,
+	field ...string,
+) error {
+	var f string
+	if len(field) > 0 {
+		f = field[0]
+	} else {
+		f = "value"
+	}
+	var valueActual float64
+	var found bool
+	for _, v := range cache {
+		if v.name == name {
+			valueActual = v.fields[f].(float64)
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("test Error: Metric name %s not found", name)
+	}
+
+	if valueExpected != valueActual {
+		return fmt.Errorf("Measurement: %s, expected %f, actual %f", name, valueExpected, valueActual)
+	}
+	return nil
+}
+
+func TestTCP(t *testing.T) {
+	statsd := Statsd{
+		Log:                    testutil.Logger{},
+		Protocol:               "tcp",
+		ServiceAddress:         "localhost:0",
+		AllowedPendingMessages: 10000,
+		MaxTCPConnections:      2,
+	}
+	var acc testutil.Accumulator
+	require.NoError(t, statsd.Start(&acc))
+	defer statsd.Stop()
+
+	addr := statsd.TCPlistener.Addr().String()
+
+	conn, _ := net.Dial("tcp", addr)
+	_, err := conn.Write([]byte("cpu.time_idle:42|c\n"))
+	require.NoError(t, err)
+	err = conn.Close()
+	require.NoError(t, err)
+
+	for {
+		err = statsd.Gather(context.Background(), &acc)
+		require.NoError(t, err)
+
+		if len(acc.Metrics) > 0 {
+			break
+		}
+	}
+
+	testutil.RequireMetricsEqual(t,
+		[]cua.Metric{
+			testutil.MustMetric(
+				"cpu_time_idle",
+				map[string]string{
+					"metric_type": "counter",
+				},
+				map[string]interface{}{
+					"value": 42,
+				},
+				time.Now(),
+				cua.Counter,
+			),
+		},
+		acc.GetCUAMetrics(),
+		testutil.IgnoreTime(),
+	)
+}
+
+func TestUdp(t *testing.T) {
+	statsd := Statsd{
+		Log:                    testutil.Logger{},
+		Protocol:               "udp",
+		ServiceAddress:         "localhost:8125",
+		AllowedPendingMessages: 250000,
+	}
+	var acc testutil.Accumulator
+	require.NoError(t, statsd.Start(&acc))
+	defer statsd.Stop()
+
+	conn, _ := net.Dial("udp", "127.0.0.1:8125")
+	_, err := conn.Write([]byte("cpu.time_idle:42|c\n"))
+	require.NoError(t, err)
+	err = conn.Close()
+	require.NoError(t, err)
+
+	for {
+		err = statsd.Gather(context.Background(), &acc)
+		require.NoError(t, err)
+
+		if len(acc.Metrics) > 0 {
+			break
+		}
+	}
+
+	testutil.RequireMetricsEqual(t,
+		[]cua.Metric{
+			testutil.MustMetric(
+				"cpu_time_idle",
+				map[string]string{
+					"metric_type": "counter",
+				},
+				map[string]interface{}{
+					"value": 42,
+				},
+				time.Now(),
+				cua.Counter,
+			),
+		},
+		acc.GetCUAMetrics(),
+		testutil.IgnoreTime(),
+	)
+}

--- a/plugins/inputs/win_eventlog/util.go
+++ b/plugins/inputs/win_eventlog/util.go
@@ -129,7 +129,7 @@ func walkXML(nodes []xmlnode, parents []string, separator string, f func(xmlnode
 				parentName = strings.Join([]string{parentName, attr.Value}, separator)
 			}
 		}
-		nodeParents := append(parents, parentName)
+		nodeParents := append(parents, parentName) //nolint:gocritic
 		if f(node, nodeParents, separator) {
 			walkXML(node.Nodes, nodeParents, separator, f)
 		}

--- a/plugins/inputs/x509_cert/x509_cert.go
+++ b/plugins/inputs/x509_cert/x509_cert.go
@@ -180,7 +180,7 @@ func getTags(cert *x509.Certificate, location string) map[string]string {
 	tags["issuer_common_name"] = cert.Issuer.CommonName
 	tags["issuer_serial_number"] = cert.Issuer.SerialNumber
 
-	san := append(cert.DNSNames, cert.EmailAddresses...)
+	san := append(cert.DNSNames, cert.EmailAddresses...) //nolint:gocritic
 	for _, ip := range cert.IPAddresses {
 		san = append(san, ip.String())
 	}

--- a/plugins/outputs/circonus/metric_destination.go
+++ b/plugins/outputs/circonus/metric_destination.go
@@ -1,7 +1,6 @@
 package circonus
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
@@ -105,9 +104,9 @@ func (c *Circonus) initMetricDestination(id, name, instanceID string) error {
 		name = "default"
 	}
 
-	dest, err := circmgr.NewMetricDestination(id, name, instanceID, c.CheckNamePrefix, c.Log)
+	dest, err := circmgr.NewMetricDestination(plugID, name, instanceID, c.CheckNamePrefix, c.Log)
 	if err != nil {
-		return fmt.Errorf("new metric destination: %w", err)
+		return err
 	}
 
 	c.metricDestinations[id] = &metricDestination{

--- a/plugins/outputs/circonus/metrics.go
+++ b/plugins/outputs/circonus/metrics.go
@@ -42,7 +42,7 @@ func (c *Circonus) metricProcessor(id int, metrics []cua.Metric) int64 {
 	}
 
 	if agentDestination != nil {
-		if err := agentDestination.metrics.GaugeAdd(metricVolume+"_batch", nil, numMetrics, nil); err != nil {
+		if err := agentDestination.metrics.GaugeAdd(metricVolume+"_batch", nil, numMetrics, &start); err != nil {
 			c.Log.Warnf("adding gauge (%s): %s", metricVolume+"_batch", err)
 		}
 		agentDestination.queuedMetrics++


### PR DESCRIPTION
* upd: (snmp) one input to handle both dm and regular output
* add: (snmp) text metric capability for syntax integer
* add: (circmgr) same check name prefix handling as regular circ output
* upd: (circmgr) use plugin and instance in cache file names
* upd: (circmgr) reduce verbosity in new metric dest err msg
* add: (circout) timestamp to agent metric
* add: (statsd) new dm statsd input
* add: (agent) context to input Start
* add: (circmgr) global tags for dm inputs
* upd: dependencies (go-trapcheck, go-trapmetrics)
