### PR TITLE
v0.0.33

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,11 +29,11 @@ builds:
             - -s
             - -w
             - -extldflags "-static"
-            - -X main.version={{.Version}}
-            - -X main.commit={{.ShortCommit}}
-            - -X main.branch={{.Branch}}
-            - -X main.buildDate={{.Date}}
-            - -X main.buildTag={{.Tag}}
+            - -X github.com/circonus-labs/circonus-unified-agent/internal/release.version={{.Version}}
+            - -X github.com/circonus-labs/circonus-unified-agent/internal/release.commit={{.ShortCommit}}
+            - -X github.com/circonus-labs/circonus-unified-agent/internal/release.branch={{.Branch}}
+            - -X github.com/circonus-labs/circonus-unified-agent/internal/release.buildDate={{.Date}}
+            - -X github.com/circonus-labs/circonus-unified-agent/internal/release.buildTag={{.Tag}}
 dockers:
     -
         goos: linux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v0.0.33
 
+* add: check tags for host check with os meta data
 * add: (snmp) context awareness during collection
 * add: (snmp) log timing msg for gather taking >1m
 * fix: (circout) lint struct alignment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# v0.0.33
+
+* add: (snmp) context awareness during collection
+* add: (snmp) log timing msg for gather taking >1m
+* fix: (circout) lint struct alignment
+* add: (circmgr) cache_no_verify to use checks from cache w/o verifying via API
+* fix: (snmp) convert octet-string to hex to avoid control characters emitted in metrics
+* upd: dependencies (go-trapcheck,go-trapmetrics)
+* fix: lint issues
+* build(deps): bump github.com/shirou/gopsutil/v3 from 3.21.5 to 3.21.6
+* fix: adding basic parsing for Windows machines w/o IE
+* build(deps): bump github.com/gosnmp/gosnmp from 1.31.0 to 1.32.0
+* build(deps): bump github.com/shirou/gopsutil/v3 from 3.21.4 to 3.21.5
+* add: dependabot config
+
 # v0.0.32
 
 * upd: switch trap packages to circonus-labs

--- a/cmd/circonus-unified-agent/circonus-unified-agent.go
+++ b/cmd/circonus-unified-agent/circonus-unified-agent.go
@@ -22,6 +22,7 @@ import (
 	"github.com/circonus-labs/circonus-unified-agent/internal"
 	"github.com/circonus-labs/circonus-unified-agent/internal/circonus"
 	"github.com/circonus-labs/circonus-unified-agent/internal/goplugin"
+	"github.com/circonus-labs/circonus-unified-agent/internal/release"
 	"github.com/circonus-labs/circonus-unified-agent/logger"
 	_ "github.com/circonus-labs/circonus-unified-agent/plugins/aggregators/all"
 	"github.com/circonus-labs/circonus-unified-agent/plugins/inputs"
@@ -247,7 +248,7 @@ func formatFullVersion() string {
 		if commit == "" {
 			commit = "unknown"
 		}
-		if buildTag != "" {
+		if buildTag == "" {
 			buildTag = "n/a"
 		}
 		git := fmt.Sprintf("(git: %s %s %s)", branch, commit, buildTag)
@@ -261,7 +262,19 @@ func formatFullVersion() string {
 	return strings.Join(parts, " ")
 }
 
+func setReleaseInfo() {
+	ri := release.GetInfo()
+
+	version = ri.Version
+	commit = ri.Commit
+	branch = ri.Branch
+	buildDate = ri.BuildDate
+	buildTag = ri.BuildTag
+}
+
 func main() {
+	setReleaseInfo()
+
 	flag.Usage = func() { usageExit(0) }
 	flag.Parse()
 	args := flag.Args()

--- a/config/config.go
+++ b/config/config.go
@@ -208,6 +208,7 @@ type CirconusConfig struct {
 	APITLSCA        string            `toml:"api_tls_ca"`        // optional: api ca cert file
 	CacheConfigs    bool              `toml:"cache_configs"`     // optional: cache check bundle configurations - efficient for large number of inputs
 	CacheDir        string            `toml:"cache_dir"`         // optional: where to cache the check bundle configurations - must be read/write for user running cua
+	CacheNoVerify   bool              `toml:"cache_no_verify"`   // optional: don't verify checks loaded from cache, just use them
 	DebugAPI        bool              `toml:"debug_api"`         // optional: debug circonus api calls
 	TraceMetrics    string            `toml:"trace_metrics"`     // optional: output json sent to broker (path to write files to or `-` for logger)
 	DebugChecks     map[string]string `toml:"debug_checks"`      // optional: use when instructed by circonus support

--- a/go.mod
+++ b/go.mod
@@ -26,8 +26,8 @@ require (
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869
 	github.com/cenkalti/backoff v2.0.0+incompatible // indirect
 	github.com/circonus-labs/go-apiclient v0.7.15
-	github.com/circonus-labs/go-trapcheck v0.0.1
-	github.com/circonus-labs/go-trapmetrics v0.0.1
+	github.com/circonus-labs/go-trapcheck v0.0.4
+	github.com/circonus-labs/go-trapmetrics v0.0.4
 	github.com/cisco-ie/nx-telemetry-proto v0.0.0-20190531143454-82441e232cf6
 	github.com/cockroachdb/apd v1.1.0 // indirect
 	github.com/containerd/containerd v1.4.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -26,8 +26,8 @@ require (
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869
 	github.com/cenkalti/backoff v2.0.0+incompatible // indirect
 	github.com/circonus-labs/go-apiclient v0.7.15
-	github.com/circonus-labs/go-trapcheck v0.0.4
-	github.com/circonus-labs/go-trapmetrics v0.0.4
+	github.com/circonus-labs/go-trapcheck v0.0.5
+	github.com/circonus-labs/go-trapmetrics v0.0.5
 	github.com/cisco-ie/nx-telemetry-proto v0.0.0-20190531143454-82441e232cf6
 	github.com/cockroachdb/apd v1.1.0 // indirect
 	github.com/containerd/containerd v1.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -123,10 +123,10 @@ github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6D
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/circonus-labs/go-apiclient v0.7.15 h1:r9sUdc+EDM0tL6Z6u03dac8fxYvlz1kPhxlNwkoIoqM=
 github.com/circonus-labs/go-apiclient v0.7.15/go.mod h1:RFgkvdYEkimzgu3V2vVYlS1bitjOz1SF6uw109ieNeY=
-github.com/circonus-labs/go-trapcheck v0.0.1 h1:GvXzsbz8i3RmEnR+RWSRCOCfFxZW6vad0cRlshVnmm0=
-github.com/circonus-labs/go-trapcheck v0.0.1/go.mod h1:CVuyNYI9UsJhXTJJojLeHaSryo47XWNJe94YjxsXEv0=
-github.com/circonus-labs/go-trapmetrics v0.0.1 h1:H6SyGF8ChkIS58LP/iwexX02yGda6QDqFc1AgubvK+s=
-github.com/circonus-labs/go-trapmetrics v0.0.1/go.mod h1:i4iLXXqAGrEvaekuxJPKMpZEeayuK321SJOU+T+LF0U=
+github.com/circonus-labs/go-trapcheck v0.0.4 h1:jJs4tgBBWomh3zLsaPKKUIK8qOnjZii0TxXYgvrVkMA=
+github.com/circonus-labs/go-trapcheck v0.0.4/go.mod h1:CVuyNYI9UsJhXTJJojLeHaSryo47XWNJe94YjxsXEv0=
+github.com/circonus-labs/go-trapmetrics v0.0.4 h1:UbUZO3Dlz43lPmi1rtog4bPVr2EWtQJKaiovrj/k+Dk=
+github.com/circonus-labs/go-trapmetrics v0.0.4/go.mod h1:L+xLup69tvMXrsIwtSGiVRn6LjDR485cKz66HWcPFDo=
 github.com/cisco-ie/nx-telemetry-proto v0.0.0-20190531143454-82441e232cf6 h1:57RI0wFkG/smvVTcz7F43+R0k+Hvci3jAVQF9lyMoOo=
 github.com/cisco-ie/nx-telemetry-proto v0.0.0-20190531143454-82441e232cf6/go.mod h1:ugEfq4B8T8ciw/h5mCkgdiDRFS4CkqqhH2dymDB4knc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=

--- a/go.sum
+++ b/go.sum
@@ -123,10 +123,10 @@ github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6D
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/circonus-labs/go-apiclient v0.7.15 h1:r9sUdc+EDM0tL6Z6u03dac8fxYvlz1kPhxlNwkoIoqM=
 github.com/circonus-labs/go-apiclient v0.7.15/go.mod h1:RFgkvdYEkimzgu3V2vVYlS1bitjOz1SF6uw109ieNeY=
-github.com/circonus-labs/go-trapcheck v0.0.4 h1:jJs4tgBBWomh3zLsaPKKUIK8qOnjZii0TxXYgvrVkMA=
-github.com/circonus-labs/go-trapcheck v0.0.4/go.mod h1:CVuyNYI9UsJhXTJJojLeHaSryo47XWNJe94YjxsXEv0=
-github.com/circonus-labs/go-trapmetrics v0.0.4 h1:UbUZO3Dlz43lPmi1rtog4bPVr2EWtQJKaiovrj/k+Dk=
-github.com/circonus-labs/go-trapmetrics v0.0.4/go.mod h1:L+xLup69tvMXrsIwtSGiVRn6LjDR485cKz66HWcPFDo=
+github.com/circonus-labs/go-trapcheck v0.0.5 h1:UDFzp5q+Emp9OmACWBT9nVZm0mAdjMfFoHgJmbtI1Wo=
+github.com/circonus-labs/go-trapcheck v0.0.5/go.mod h1:CVuyNYI9UsJhXTJJojLeHaSryo47XWNJe94YjxsXEv0=
+github.com/circonus-labs/go-trapmetrics v0.0.5 h1:KBn3rbDeOdyXINJhAF9pbmcXjAvM2aP4hrWjx2ZfplQ=
+github.com/circonus-labs/go-trapmetrics v0.0.5/go.mod h1:XEEahtoj/s6vUL1vJmV89WI3MLs+NW7+RvxSCYAGRJ0=
 github.com/cisco-ie/nx-telemetry-proto v0.0.0-20190531143454-82441e232cf6 h1:57RI0wFkG/smvVTcz7F43+R0k+Hvci3jAVQF9lyMoOo=
 github.com/cisco-ie/nx-telemetry-proto v0.0.0-20190531143454-82441e232cf6/go.mod h1:ugEfq4B8T8ciw/h5mCkgdiDRFS4CkqqhH2dymDB4knc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=

--- a/internal/http.go
+++ b/internal/http.go
@@ -25,11 +25,11 @@ func AuthHandler(username, password, realm string, onError BasicAuthErrorFunc) f
 }
 
 type basicAuthHandler struct {
+	next     http.Handler
+	onError  BasicAuthErrorFunc
 	username string
 	password string
 	realm    string
-	onError  BasicAuthErrorFunc
-	next     http.Handler
 }
 
 func (h *basicAuthHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
@@ -64,9 +64,9 @@ func GenericAuthHandler(credentials string, onError GenericAuthErrorFunc) func(h
 
 // Generic auth scheme handler - exact match on `Authorization: <credentials>`
 type genericAuthHandler struct {
-	credentials string
-	onError     GenericAuthErrorFunc
 	next        http.Handler
+	onError     GenericAuthErrorFunc
+	credentials string
 }
 
 func (h *genericAuthHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
@@ -100,9 +100,9 @@ func IPRangeHandler(network []*net.IPNet, onError ErrorFunc) func(h http.Handler
 }
 
 type ipRangeHandler struct {
-	network []*net.IPNet
-	onError ErrorFunc
 	next    http.Handler
+	onError ErrorFunc
+	network []*net.IPNet
 }
 
 func (h *ipRangeHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -51,8 +51,8 @@ type Number struct {
 }
 
 type ReadWaitCloser struct {
-	pipeReader *io.PipeReader
 	wg         sync.WaitGroup
+	pipeReader *io.PipeReader
 }
 
 // SetVersion sets the agent version

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -338,10 +338,10 @@ func TestAlignTime(t *testing.T) {
 	}
 
 	tests := []struct {
-		name     string
 		now      time.Time
-		interval time.Duration
 		expected time.Time
+		name     string
+		interval time.Duration
 	}{
 		{
 			name:     "aligned",

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -1,0 +1,45 @@
+package release
+
+const (
+	// NAME is the name of this application.
+	NAME = "circonus-unified-agent"
+	// ENVPREFIX is the environment variable prefix.
+	ENVPREFIX = "CUA"
+)
+
+// defined during build (e.g. goreleaser, see .goreleaser.yml).
+var (
+	// branch of relase in git repo.
+	branch = "undef"
+	// commit of relase in git repo.
+	commit = "undef"
+	// buildDate of release.
+	buildDate = "undef"
+	// buildTag of release.
+	buildTag = "none"
+	// version of the release.
+	version = "Dev"
+)
+
+// Info contains release information.
+type Info struct {
+	Name      string
+	Version   string
+	Branch    string
+	Commit    string
+	BuildDate string
+	BuildTag  string
+	EnvPrefix string
+}
+
+func GetInfo() *Info {
+	return &Info{
+		Name:      NAME,
+		Version:   version,
+		Branch:    branch,
+		Commit:    commit,
+		BuildDate: buildDate,
+		BuildTag:  buildTag,
+		EnvPrefix: ENVPREFIX,
+	}
+}

--- a/plugins/inputs/dcos/client.go
+++ b/plugins/inputs/dcos/client.go
@@ -32,16 +32,16 @@ type Client interface {
 
 type APIError struct {
 	URL         string
-	StatusCode  int
 	Title       string
 	Description string
+	StatusCode  int
 }
 
 // Login is request data for logging in.
 type Login struct {
 	UID   string `json:"uid"`
-	Exp   int64  `json:"exp"`
 	Token string `json:"token"`
+	Exp   int64  `json:"exp"`
 }
 
 // LoginError is the response when login fails.
@@ -80,23 +80,22 @@ type DataPoint struct {
 
 // Metrics are the DCOS metrics
 type Metrics struct {
-	Datapoints []DataPoint            `json:"datapoints"`
 	Dimensions map[string]interface{} `json:"dimensions"`
+	Datapoints []DataPoint            `json:"datapoints"`
 }
 
 // AuthToken is the authentication token.
 type AuthToken struct {
-	Text   string
 	Expire time.Time
+	Text   string
 }
 
 // ClusterClient is a Client that uses the cluster URL.
 type ClusterClient struct {
 	clusterURL *url.URL
 	httpClient *http.Client
-	// credentials *Credentials
-	token     string
-	semaphore chan struct{}
+	semaphore  chan struct{}
+	token      string
 }
 
 type claims struct {

--- a/plugins/inputs/dcos/client_test.go
+++ b/plugins/inputs/dcos/client_test.go
@@ -20,11 +20,11 @@ func TestLogin(t *testing.T) {
 	defer ts.Close()
 
 	var tests = []struct {
-		name          string
-		responseCode  int
-		responseBody  string
 		expectedError error
+		name          string
+		responseBody  string
 		expectedToken string
+		responseCode  int
 	}{
 		{
 			name:          "Login successful",
@@ -85,11 +85,11 @@ func TestGetSummary(t *testing.T) {
 	defer ts.Close()
 
 	var tests = []struct {
-		name          string
-		responseCode  int
-		responseBody  string
-		expectedValue *Summary
 		expectedError error
+		expectedValue *Summary
+		name          string
+		responseBody  string
+		responseCode  int
 	}{
 		{
 			name:          "No nodes",
@@ -152,11 +152,11 @@ func TestGetNodeMetrics(t *testing.T) {
 	defer ts.Close()
 
 	var tests = []struct {
-		name          string
-		responseCode  int
-		responseBody  string
-		expectedValue *Metrics
 		expectedError error
+		expectedValue *Metrics
+		name          string
+		responseBody  string
+		responseCode  int
 	}{
 		{
 			name:          "Empty Body",
@@ -195,11 +195,11 @@ func TestGetContainerMetrics(t *testing.T) {
 	defer ts.Close()
 
 	var tests = []struct {
-		name          string
-		responseCode  int
-		responseBody  string
-		expectedValue *Metrics
 		expectedError error
+		expectedValue *Metrics
+		name          string
+		responseBody  string
+		responseCode  int
 	}{
 		{
 			name:          "204 No Content",

--- a/plugins/inputs/dcos/creds.go
+++ b/plugins/inputs/dcos/creds.go
@@ -21,10 +21,9 @@ type Credentials interface {
 }
 
 type ServiceAccount struct {
-	AccountID  string
 	PrivateKey *rsa.PrivateKey
-
-	auth *AuthToken
+	auth       *AuthToken
+	AccountID  string
 }
 
 type TokenCreds struct {

--- a/plugins/inputs/dcos/dcos.go
+++ b/plugins/inputs/dcos/dcos.go
@@ -43,32 +43,25 @@ var (
 )
 
 type DCOS struct {
-	ClusterURL string `toml:"cluster_url"`
-
+	appFilter       filter.Filter
+	client          Client
+	containerFilter filter.Filter
+	nodeFilter      filter.Filter
+	creds           Credentials
+	tls.ClientConfig
+	TokenFile                string
 	ServiceAccountID         string `toml:"service_account_id"`
 	ServiceAccountPrivateKey string
-
-	TokenFile string
-
-	NodeInclude      []string
-	NodeExclude      []string
-	ContainerInclude []string
-	ContainerExclude []string
-	AppInclude       []string
-	AppExclude       []string
-
-	MaxConnections  int
-	ResponseTimeout internal.Duration
-	tls.ClientConfig
-
-	client Client
-	creds  Credentials
-
-	initialized     bool
-	nodeFilter      filter.Filter
-	containerFilter filter.Filter
-	appFilter       filter.Filter
-	// taskNameFilter  filter.Filter
+	ClusterURL               string `toml:"cluster_url"`
+	NodeExclude              []string
+	NodeInclude              []string
+	AppInclude               []string
+	ContainerExclude         []string
+	ContainerInclude         []string
+	AppExclude               []string
+	MaxConnections           int
+	ResponseTimeout          internal.Duration
+	initialized              bool
 }
 
 func (d *DCOS) Description() string {
@@ -239,9 +232,7 @@ func (d *DCOS) createPoints(m *Metrics) []*point {
 			fieldKey += "_bytes"
 		}
 
-		if strings.HasPrefix(fieldKey, "dcos_metrics_module_") {
-			fieldKey = strings.TrimPrefix(fieldKey, "dcos_metrics_module_")
-		}
+		fieldKey = strings.TrimPrefix(fieldKey, "dcos_metrics_module_")
 
 		tagset := make([]string, 0, len(tags))
 		for k, v := range tags {

--- a/plugins/inputs/dcos/dcos_test.go
+++ b/plugins/inputs/dcos/dcos_test.go
@@ -49,9 +49,9 @@ func (c *mockClient) GetAppMetrics(ctx context.Context, node, container string) 
 
 func TestAddNodeMetrics(t *testing.T) {
 	var tests = []struct {
-		name    string
 		metrics *Metrics
 		check   func(*testutil.Accumulator) []bool
+		name    string
 	}{
 		{
 			name: "basic datapoint conversion",
@@ -209,9 +209,9 @@ func TestAddNodeMetrics(t *testing.T) {
 
 func TestAddContainerMetrics(t *testing.T) {
 	var tests = []struct {
-		name    string
 		metrics *Metrics
 		check   func(*testutil.Accumulator) []bool
+		name    string
 	}{
 		{
 			name: "container",
@@ -281,9 +281,9 @@ func TestAddContainerMetrics(t *testing.T) {
 
 func TestAddAppMetrics(t *testing.T) {
 	var tests = []struct {
-		name    string
 		metrics *Metrics
 		check   func(*testutil.Accumulator) []bool
+		name    string
 	}{
 		{
 			name: "tags are optional",
@@ -356,11 +356,11 @@ func TestAddAppMetrics(t *testing.T) {
 
 func TestGatherFilterNode(t *testing.T) {
 	var tests = []struct {
+		client      Client
+		check       func(*testutil.Accumulator) []bool
 		name        string
 		nodeInclude []string
 		nodeExclude []string
-		client      Client
-		check       func(*testutil.Accumulator) []bool
 	}{
 		{
 			name: "cluster without nodes has no metrics",

--- a/plugins/inputs/rabbitmq/rabbitmq.go
+++ b/plugins/inputs/rabbitmq/rabbitmq.go
@@ -37,32 +37,26 @@ const DefaultClientTimeout = 4
 // RabbitMQ defines the configuration necessary for gathering metrics,
 // see the sample config for further details
 type RabbitMQ struct {
-	URL      string `toml:"url"`
-	Username string `toml:"username"`
-	Password string `toml:"password"`
-	tls.ClientConfig
-
-	ResponseHeaderTimeout internal.Duration `toml:"header_timeout"`
-	ClientTimeout         internal.Duration `toml:"client_timeout"`
-
-	Nodes     []string `toml:"nodes"`
-	Queues    []string `toml:"queues"`
-	Exchanges []string `toml:"exchanges"`
-
-	QueueInclude              []string `toml:"queue_name_include"`
-	QueueExclude              []string `toml:"queue_name_exclude"`
-	FederationUpstreamInclude []string `toml:"federation_upstream_include"`
-	FederationUpstreamExclude []string `toml:"federation_upstream_exclude"`
-
-	Client *http.Client `toml:"-"`
-
-	filterCreated     bool
-	excludeEveryQueue bool
-	queueFilter       filter.Filter
-	upstreamFilter    filter.Filter
-
-	Log             cua.Logger
 	versionLastSent time.Time
+	Log             cua.Logger
+	upstreamFilter  filter.Filter
+	queueFilter     filter.Filter
+	Client          *http.Client `toml:"-"`
+	tls.ClientConfig
+	Password                  string            `toml:"password"`
+	Username                  string            `toml:"username"`
+	URL                       string            `toml:"url"`
+	QueueInclude              []string          `toml:"queue_name_include"`
+	Exchanges                 []string          `toml:"exchanges"`
+	FederationUpstreamInclude []string          `toml:"federation_upstream_include"`
+	FederationUpstreamExclude []string          `toml:"federation_upstream_exclude"`
+	Queues                    []string          `toml:"queues"`
+	Nodes                     []string          `toml:"nodes"`
+	QueueExclude              []string          `toml:"queue_name_exclude"`
+	ClientTimeout             internal.Duration `toml:"client_timeout"`
+	ResponseHeaderTimeout     internal.Duration `toml:"header_timeout"`
+	filterCreated             bool
+	excludeEveryQueue         bool
 }
 
 // OverviewResponse ...
@@ -148,24 +142,23 @@ type Queue struct {
 
 // Node ...
 type Node struct {
-	Name string
-
-	DiskFree                 int64   `json:"disk_free"`
+	Name                     string
+	MnesiaDiskTxCount        int64   `json:"mnesia_disk_tx_count"`
 	DiskFreeLimit            int64   `json:"disk_free_limit"`
-	DiskFreeAlarm            bool    `json:"disk_free_alarm"`
+	IoWriteBytes             int64   `json:"io_write_bytes"`
 	FdTotal                  int64   `json:"fd_total"`
 	FdUsed                   int64   `json:"fd_used"`
 	MemLimit                 int64   `json:"mem_limit"`
 	MemUsed                  int64   `json:"mem_used"`
-	MemAlarm                 bool    `json:"mem_alarm"`
+	IoWriteAvgTimeDetails    Details `json:"io_write_avg_time_details"`
 	ProcTotal                int64   `json:"proc_total"`
 	ProcUsed                 int64   `json:"proc_used"`
 	RunQueue                 int64   `json:"run_queue"`
 	SocketsTotal             int64   `json:"sockets_total"`
 	SocketsUsed              int64   `json:"sockets_used"`
-	Running                  bool    `json:"running"`
+	IoWriteAvgTime           int64   `json:"io_write_avg_time"`
 	Uptime                   int64   `json:"uptime"`
-	MnesiaDiskTxCount        int64   `json:"mnesia_disk_tx_count"`
+	DiskFree                 int64   `json:"disk_free"`
 	MnesiaDiskTxCountDetails Details `json:"mnesia_disk_tx_count_details"`
 	MnesiaRAMTxCount         int64   `json:"mnesia_ram_tx_count"`
 	MnesiaRAMTxCountDetails  Details `json:"mnesia_ram_tx_count_details"`
@@ -177,18 +170,18 @@ type Node struct {
 	IoReadAvgTimeDetails     Details `json:"io_read_avg_time_details"`
 	IoReadBytes              int64   `json:"io_read_bytes"`
 	IoReadBytesDetails       Details `json:"io_read_bytes_details"`
-	IoWriteAvgTime           int64   `json:"io_write_avg_time"`
-	IoWriteAvgTimeDetails    Details `json:"io_write_avg_time_details"`
-	IoWriteBytes             int64   `json:"io_write_bytes"`
 	IoWriteBytesDetails      Details `json:"io_write_bytes_details"`
+	Running                  bool    `json:"running"`
+	MemAlarm                 bool    `json:"mem_alarm"`
+	DiskFreeAlarm            bool    `json:"disk_free_alarm"`
 }
 
 type Exchange struct {
-	Name         string
 	MessageStats `json:"message_stats"`
+	Name         string
 	Type         string
-	Internal     bool
 	Vhost        string
+	Internal     bool
 	Durable      bool
 	AutoDelete   bool `json:"auto_delete"`
 }

--- a/plugins/inputs/snmp/snmp.go
+++ b/plugins/inputs/snmp/snmp.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"math"
@@ -340,8 +341,8 @@ type RTableRow struct {
 }
 
 type walkError struct {
-	msg string
 	err error
+	msg string
 }
 
 func (e *walkError) Error() string {
@@ -691,7 +692,7 @@ func fieldConvert(conv string, sv gosnmp.SnmpPDU) (interface{}, error) {
 
 	if conv == "" {
 		if bs, ok := v.([]byte); ok {
-			return string(bs), nil
+			return hex.EncodeToString(bs), nil
 		}
 		return v, nil
 	}
@@ -817,11 +818,11 @@ func fieldConvert(conv string, sv gosnmp.SnmpPDU) (interface{}, error) {
 }
 
 type snmpTableCache struct {
+	err     error
 	mibName string
 	oidNum  string
 	oidText string
 	fields  []Field
-	err     error
 }
 
 var snmpTableCaches map[string]snmpTableCache
@@ -910,12 +911,12 @@ func snmpTableCall(oid string) (mibName string, oidNum string, oidText string, f
 }
 
 type TranslateItem struct {
+	err        error
+	valMap     map[string]string
 	mibName    string
 	oidNum     string
 	oidText    string
 	conversion string
-	valMap     map[string]string
-	err        error
 }
 
 var snmpTranslateCachesLock sync.Mutex

--- a/plugins/inputs/snmp/snmp_test.go
+++ b/plugins/inputs/snmp/snmp_test.go
@@ -22,8 +22,8 @@ import (
 )
 
 type testSNMPConnection struct {
-	host   string
 	values map[string]interface{}
+	host   string
 }
 
 func (tsc *testSNMPConnection) Host() string {

--- a/plugins/outputs/circonus/circonus.go
+++ b/plugins/outputs/circonus/circonus.go
@@ -59,8 +59,8 @@ type Circonus struct {
 
 // processors handle incoming batches
 type processors struct {
-	metrics chan []cua.Metric
 	wg      sync.WaitGroup
+	metrics chan []cua.Metric
 }
 
 // Init performs initialization of a Circonus client.
@@ -217,6 +217,7 @@ func (c *Circonus) emitAgentVersion() {
 	if agentDestination != nil {
 		ts := time.Now()
 		_ = agentDestination.metrics.TextSet("cua_version", nil, agentVersion, &ts)
+		agentDestination.queuedMetrics++
 	}
 }
 


### PR DESCRIPTION
* add: check tags for host check with os meta data
* add: (snmp) context awareness during collection
* add: (snmp) log timing msg for gather taking >1m
* fix: (circout) lint struct alignment
* add: (circmgr) cache_no_verify to use checks from cache w/o verifying via API
* fix: (snmp) convert octet-string to hex to avoid control characters emitted in metrics
* upd: dependencies (go-trapcheck,go-trapmetrics)
* fix: lint issues
* build(deps): bump github.com/shirou/gopsutil/v3 from 3.21.5 to 3.21.6
* fix: adding basic parsing for Windows machines w/o IE
* build(deps): bump github.com/gosnmp/gosnmp from 1.31.0 to 1.32.0
* build(deps): bump github.com/shirou/gopsutil/v3 from 3.21.4 to 3.21.5
* add: dependabot config
