### PR TITLE
Fix broker id example

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -416,7 +416,7 @@ var agentConfig = `
     ## Broker
     ## Optional
     ## Explicit broker id or blank (default blank, auto select)
-    # broker = "/broker/35"
+    # broker = "35"
 
     ## Cache check configurations
     ## Optional

--- a/etc/example-circonus-unified-agent.conf
+++ b/etc/example-circonus-unified-agent.conf
@@ -127,7 +127,7 @@
     ## Broker
     ## Optional
     ## Explicit broker id or blank (default blank, auto select)
-    # broker = "/broker/35"
+    # broker = "35"
 
     ## Cache check configurations
     ## Optional

--- a/etc/example-circonus-unified-agent_windows.conf
+++ b/etc/example-circonus-unified-agent_windows.conf
@@ -127,7 +127,7 @@
     ## Broker
     ## Optional
     ## Explicit broker id or blank (default blank, auto select)
-    # broker = "/broker/35"
+    # broker = "35"
 
     ## Cache check configurations
     ## Optional

--- a/plugins/outputs/circonus/README.md
+++ b/plugins/outputs/circonus/README.md
@@ -41,7 +41,7 @@ check configuration click [here][docs].
   ## Broker
   ## Optional: explicit broker id or blank (default blank, auto select)
   ## example:
-  # broker = "/broker/35"
+  # broker = "35"
 ```
 
 ### Configuration Options


### PR DESCRIPTION
The comments state to use stand alone broker id, but the old examples used brokers/brokerid. Broker ID alone seems to be correct.