### PR TITLE
prometheus input plugin

### DIFF
--- a/plugins/inputs/prometheus/README.md
+++ b/plugins/inputs/prometheus/README.md
@@ -9,7 +9,7 @@ in Prometheus format.
 # Read metrics from one or many prometheus clients
 [[inputs.prometheus]]
   ## instance_id is a required value on input plugins
-  instance_id = ["prometheus"]
+  instance_id = "prometheus"
   ## An array of urls to scrape metrics from.
   urls = ["http://localhost:9100/metrics"]
 
@@ -108,7 +108,7 @@ If you want to monitor Caddy, you need to use Caddy with its Prometheus plugin:
 ```toml
 [[inputs.prometheus]]
   ## instance_id is a required value on input plugins
-  instance_id = ["caddy"]
+  instance_id = "caddy"
   ## An array of urls to scrape metrics from.
   urls = ["http://localhost:9180/metrics"]
 ```

--- a/plugins/inputs/prometheus/README.md
+++ b/plugins/inputs/prometheus/README.md
@@ -8,6 +8,8 @@ in Prometheus format.
 ```toml
 # Read metrics from one or many prometheus clients
 [[inputs.prometheus]]
+  ## instance_id is a required value on input plugins
+  instance_id = ["prometheus"]
   ## An array of urls to scrape metrics from.
   urls = ["http://localhost:9100/metrics"]
 
@@ -105,7 +107,9 @@ If you want to monitor Caddy, you need to use Caddy with its Prometheus plugin:
 
 ```toml
 [[inputs.prometheus]]
-#   ## An array of urls to scrape metrics from.
+  ## instance_id is a required value on input plugins
+  instance_id = ["caddy"]
+  ## An array of urls to scrape metrics from.
   urls = ["http://localhost:9180/metrics"]
 ```
 

--- a/plugins/inputs/prometheus/parser.go
+++ b/plugins/inputs/prometheus/parser.go
@@ -88,13 +88,15 @@ func ParseV2(buf []byte, header http.Header) ([]cua.Metric, error) {
 					metric, err := metric.New("prometheus", tags, fields, t, valueType(mf.GetType()))
 					if err == nil {
 						metrics = append(metrics, metric)
+					} else {
+						return nil, fmt.Errorf("metric new: %w", err)
 					}
 				}
 			}
 		}
 	}
 
-	return metrics, fmt.Errorf("metric new: %w", err)
+	return metrics, nil
 }
 
 // Get Quantiles for summary metric & Buckets for histogram
@@ -231,12 +233,14 @@ func Parse(buf []byte, header http.Header) ([]cua.Metric, error) {
 				metric, err := metric.New(metricName, tags, fields, t, valueType(mf.GetType()))
 				if err == nil {
 					metrics = append(metrics, metric)
+				} else {
+					return nil, fmt.Errorf("metric new: %w", err)
 				}
 			}
 		}
 	}
 
-	return metrics, fmt.Errorf("metric new: %w", err)
+	return metrics, nil
 }
 
 func valueType(mt dto.MetricType) cua.ValueType {

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -67,7 +67,7 @@ type Prometheus struct {
 
 var sampleConfig = `
   ## instance_id is required on input plugins
-  instance_id = ["prometheus"]
+  instance_id = "prometheus"
   ## An array of urls to scrape metrics from.
   urls = ["http://localhost:9100/metrics"]
 

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -66,6 +66,8 @@ type Prometheus struct {
 }
 
 var sampleConfig = `
+  ## instance_id is required on input plugins
+  instance_id = ["prometheus"]
   ## An array of urls to scrape metrics from.
   urls = ["http://localhost:9100/metrics"]
 


### PR DESCRIPTION
fix up the prometheus input plugin so on a successful parse of information it won't return an error.

Also, updated the self contained example TOML to show that an instance_id is required in the input plugin config.