### PR TITLE
v0.0.41 CIRC-7756 CIRC-7877 CIRC-7781 CIRC-7980

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * add: processor support (amd64,x86_64,aarch64,arm64) [CIRC-7877]
 * fix: handle booleans as numerics [CIRC-7781]
 * upd: on windows, check for config in "C:\Program Files\Circonus\Circonus-Unified-Agent\etc\circonus-unified-agent.conf" [CIRC-7980]
+* doc: update doc/WINDOWS_SERVICE.md to reflect where installer is actually putting the files [CIRC-7980]
 
 # v0.0.40
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.0.41
+
+* add: --apiurl argument to installer [CIRC-7756]
+* add: processor support (amd64,x86_64,aarch64,arm64) [CIRC-7877]
+* fix: handle booleans as numerics [CIRC-7781]
+
 # v0.0.40
 
 * fix(snmp): bad slice indexing for oid components

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * add: --apiurl argument to installer [CIRC-7756]
 * add: processor support (amd64,x86_64,aarch64,arm64) [CIRC-7877]
 * fix: handle booleans as numerics [CIRC-7781]
+* upd: on windows, check for config in "C:\Program Files\Circonus\Circonus-Unified-Agent\etc\circonus-unified-agent.conf" [CIRC-7980]
 
 # v0.0.40
 

--- a/config/config.go
+++ b/config/config.go
@@ -762,7 +762,9 @@ func (c *Config) LoadDirectory(path string) error {
 // Try to find a default config file at these locations (in order):
 //   1. $CUA_CONFIG_PATH
 //   2. $HOME/.circonus/unified-agent/circonus-unified-agent.conf
-//   3. /opt/circonus/unified-agent/etc/circonus-unified-agent.conf
+//   3. os specific:
+//      default: /opt/circonus/unified-agent/etc/circonus-unified-agent.conf
+//      windows: "C:\Program Files\Circonus\Circonus-Unified-Agent\etc\circonus-unified-agent.conf"
 //
 func getDefaultConfigPath() (string, error) {
 	envfile := os.Getenv("CUA_CONFIG_PATH")
@@ -773,7 +775,7 @@ func getDefaultConfigPath() (string, error) {
 		if programFiles == "" { // Should never happen
 			programFiles = `C:\Program Files`
 		}
-		etcfile = programFiles + `\Circonus-unified-agent\circonus-unified-agent.conf`
+		etcfile = programFiles + `\Circonus\Circonus-Unified-Agent\etc\circonus-unified-agent.conf`
 	}
 	for _, path := range []string{envfile, homefile, etcfile} {
 		if _, err := os.Stat(path); err == nil {

--- a/docs/WINDOWS_SERVICE.md
+++ b/docs/WINDOWS_SERVICE.md
@@ -4,22 +4,22 @@ The agent natively supports running as a Windows Service. Outlined below is are
 the general steps to set it up.
 
 1. Obtain the agent windows distribution
-2. Create the directory `C:\Program Files\Circonus Unified Agent` (if you install in a different
+2. Create the directory `C:\Program Files\Circonus\Circonus-Unified-Agent` (if you install in a different
    location simply specify the `--config` parameter with the desired location)
-3. Unzip the windows release into `C:\Program Files\Circonus Unified Agent`
+3. Unzip the windows release into `C:\Program Files\Circonus\Circonus-Unified-Agent`
 4. Rename `etc\example-circonus-unified-agent_windows.conf` to `etc\circonus-unified-agent.conf`
 5. Edit `etc\circonus-unified-agent.conf` - at a minimum add a valid Circonus API Token to `api_token` under the `[agent.circonus]` section
 6. To install the service into the Windows Service Manager, run the following in PowerShell as an administrator (If necessary, you can wrap any spaces in the file paths in double quotes ""):
 
    ```
-   > "C:\Program Files\Circonus Unified Agent\circonus-unified-agentd.exe" --service install
+   > "C:\Program Files\Circonus\Circonus-Unified-Agent\circonus-unified-agentd.exe" --service install
    ```
 
 5. Edit the configuration file to meet your needs
 6. To check that it works, run:
 
    ```
-   > "C:\Program Files\Circonus Unified Agent\circonus-unified-agentd.exe" --config="C:\Program Files\Circonus Unified Agent\etc\circonus-unified-agent.conf" --test
+   > "C:\Program Files\Circonus\Circonus-Unified-Agent\circonus-unified-agentd.exe" --config="C:\Program Files\Circonus\Circonus-Unified-Agent\etc\circonus-unified-agent.conf" --test
    ```
 
 7. To start collecting data, run:
@@ -31,10 +31,12 @@ the general steps to set it up.
 ## Config Directory
 
 You can also specify a `--config-directory` for the service to use:
-1. Create a directory for config snippets: `C:\Program Files\Circonus Unified Agent\etc\config.d`
+
+1. Create a directory for config snippets: `C:\Program Files\Circonus\Circonus-Unified-Agent\etc\config.d`
 2. Include the `--config-directory` option when registering the service:
+
    ```
-   > "C:\Program Files\Circonus Unified Agent\circonus-unified-agentd.exe" --service install --config="C:\Program Files\Circonus Unified Agent\circonus-unified-agent.conf" --config-directory="C:\Program Files\Circonus Unified Agent\etc\config.d"
+   > "C:\Program Files\Circonus\Circonus-Unified-Agent\circonus-unified-agentd.exe" --service install --config="C:\Program Files\Circonus\Circonus-Unified-Agent\circonus-unified-agent.conf" --config-directory="C:\Program Files\Circonus\Circonus-Unified-Agent\etc\config.d"
    ```
 
 ## Other supported operations
@@ -57,8 +59,8 @@ on a single system, you can install the service with the `--service-name` and
 `--service-display-name` flags to give the services unique names:
 
 ```
-> "C:\Program Files\Circonus Unified Agent\circonus-unified-agentd.exe" --service install --service-name circonus-unified-agent-1 --service-display-name "Circonus Unified Agent 1"
-> "C:\Program Files\Circonus Unified Agent\circonus-unified-agentd.exe" --service install --service-name circonus-unified-agent-2 --service-display-name "Circonus Unified Agent 2"
+> "C:\Program Files\Circonus\Circonus-Unified-Agent\circonus-unified-agentd.exe" --service install --service-name circonus-unified-agent-1 --service-display-name "Circonus Unified Agent 1"
+> "C:\Program Files\Circonus\Circonus-Unified-Agent\circonus-unified-agentd.exe" --service install --service-name circonus-unified-agent-2 --service-display-name "Circonus Unified Agent 2"
 ```
 
 ## Troubleshooting
@@ -70,4 +72,4 @@ Check event log for an error reported by `circonus-unified-agent` service in cas
 
 When installing as service in Windows, always double check to specify full path of the config file, otherwise windows service will fail to start
 
- `--config "C:\Program Files\Circonus Unified Agent\etc\circonus-unified-agent.conf"`
+ `--config "C:\Program Files\Circonus\Circonus-Unified-Agent\etc\circonus-unified-agent.conf"`

--- a/etc/example-circonus-unified-agent.conf
+++ b/etc/example-circonus-unified-agent.conf
@@ -111,6 +111,7 @@
     ## Circonus API URL
     ## Optional
     # api_url = "https://api.circonus.com/"
+    api_url = "https://api.circonus.com/"
 
     ## Circonus API TLS CA file
     ## Optional


### PR DESCRIPTION
* add: --apiurl argument to installer [CIRC-7756]
* add: processor support (`amd64`, `x86_64`, `aarch64`, `arm64`) [CIRC-7877]
* fix: handle booleans as numerics [CIRC-7781]
* upd: on windows, check for config in `"C:\Program Files\Circonus\Circonus-Unified-Agent\etc\circonus-unified-agent.conf"` [CIRC-7980]
* doc: update `doc/WINDOWS_SERVICE.md` to reflect where installer is actually putting the files [CIRC-7980]
