### PR TITLE
return nil if no err in tail init

### DIFF
--- a/plugins/inputs/tail/tail.go
+++ b/plugins/inputs/tail/tail.go
@@ -156,7 +156,10 @@ func (t *Tail) Init() error {
 
 	var err error
 	t.decoder, err = encoding.NewDecoder(t.CharacterEncoding)
-	return fmt.Errorf("new decoder: %w", err)
+	if err != nil {
+		return fmt.Errorf("new decoder: %w", err)
+	}
+	return nil
 }
 
 func (t *Tail) Gather(ctx context.Context, acc cua.Accumulator) error {


### PR DESCRIPTION
fixes the initialization issue with the tail input plugin