### PR TITLE
allow for user supplied config

### DIFF
--- a/install/install_windows.psm1
+++ b/install/install_windows.psm1
@@ -1,0 +1,169 @@
+New-Module -name circonus-install -ScriptBlock {
+  $usage = "Circonus Unified Agent Install Help
+
+Usage
+
+  install --key <apikey>
+
+Options
+
+  [--key]         Circonus API key/token
+  [--config]      Absolute path to a configuration file
+  [--ver]         CUA version number
+  [--help]        This message
+
+Note: Provide an authorized app for the key or ensure api 
+      key/token has adequate privileges (default app state:allow)"
+  $installpath = "${env:systemdrive}\Program Files\Circonus\Circonus-Unified-Agent"
+  $name = "circonus-unified-agent"
+  $repo = "circonus-labs/${name}"
+  $releases = "https://api.github.com/repos/${repo}/releases"
+  $zip = "${name}.zip"
+
+  function New-Location {
+    if (!(Test-Path $installpath)) {
+      New-Item -ItemType Directory -Force -Path $installpath
+    }
+    else {
+      return
+    }
+  }
+
+  function Get-Latest-Release {
+    Write-Host "Determining latest release..."
+    $tag = (Invoke-WebRequest $releases -UseBasicParsing | ConvertFrom-Json)[0].tag_name
+    $tagrawv = $tag.substring(1)
+    $download = "https://github.com/${repo}/releases/download/${tag}/circonus-unified-agent_${tagrawv}_windows_x86_64.zip"
+    return $download
+  }
+
+  function Get-Release {
+    param ($tag)
+    Write-Host "Generating URL for release $tag"
+    $tagrawv = $tag.substring(1)
+    $download = "https://github.com/${repo}/releases/download/${tag}/circonus-unified-agent_${tagrawv}_windows_x86_64.zip"
+    return $download
+  }
+
+  function Get-Package {
+    param ($downloadpath)
+    Write-Host "Downloading Package..."
+    Invoke-WebRequest $downloadpath -Out "${env:temp}\${zip}"
+  }
+
+  function Expand-Package {
+    Write-Host "Expanding archive and installing..."
+    Expand-Archive -Path "${env:temp}\${zip}" -DestinationPath "${env:systemdrive}\Program Files\Circonus\Circonus-Unified-Agent"
+  }
+
+  function Enable-Service {
+    Write-Host ".........."
+    & "${installpath}\sbin\${name}d.exe" --service install --config "${installpath}\etc\circonus-unified-agent.conf"
+    Set-Service -Name circonus-unified-agent -StartupType Automatic
+  }
+
+  function Set-Config-Key {
+    param ($token)
+    $file = "${installpath}\etc\circonus-unified-agent.conf"
+  (Get-Content $file) -replace '  api_token = ""', "  api_token = `"${token}`"" | Set-Content $file
+  }
+
+
+  function Set-Config-Default {
+    Write-Host "Copying config..."
+    Move-Item -Path "${installpath}\etc\example-circonus-unified-agent_windows.conf" -Destination "${installpath}\etc\circonus-unified-agent.conf"
+  }
+
+  function Set-Config-With-Config {
+    param ($configfile)
+    Write-Host "Copying config..."
+    Copy-Item -Path "${configfile}" -Destination "${installpath}\etc\circonus-unified-agent.conf"
+  }
+
+  function Cleanup {
+    Write-Host "Cleaning up..."
+    Remove-Item -Path "${env:temp}\${zip}" -Force
+  }
+
+  function Start-Service {
+    Write-Host "Starting service..."
+    Set-Service -Name circonus-unified-agent -Status Running -PassThru
+  }
+
+  function Install-Project {
+    <#
+  .SYNOPSIS
+  Install Circonus Unified Agent for Windows
+  .DESCRIPTION
+  Install Circonus Unified Agent for Windows
+  .EXAMPLE
+  iex; install -key <your key here>
+#>
+    param (
+      # Circonus API Key
+      [Parameter()]
+      [string]$key,
+      [string]$config,
+      [string]$ver,
+      # display help
+      [bool]$help
+    )
+    if ($help) {
+      Write-Host $usage
+      return
+    }
+    if ($key -eq "" -And $config -eq "" ) {
+      Write-Host "Circonus API Key or Config file path is required."
+      Write-Host $usage
+      return
+    }
+    if ((Test-Path -Path "${installpath}\sbin\circonus-unified-agentd.exe" -PathType Leaf)) {
+      Write-Host "Circonus-Unified-Agent is already installed."
+      return
+    }
+    if ([Environment]::Is64BitProcess -ne [Environment]::Is64BitOperatingSystem) {
+      Write-Host "Circonus-Unified-Agent is only supported on 64-Bit Windows releases."
+      return
+    }
+
+    # Create the install directory
+    New-Location
+    # Determine the latest release
+
+    $release = ""
+    if ($ver -ne "") {
+      $release = Get-Release($ver)
+    }
+    else {
+      $release = Get-Latest-Release
+    }
+
+      
+    # Fetch the latest CUA version zip file
+    Get-Package($release)
+    # Unarchive the zip file into their proper location
+    Expand-Package
+    # Set the service up
+    Enable-Service
+
+    # Setup the configuration file
+    if ($config -ne "" ) {
+      Set-Config-With-Config($config)
+    }
+    else {
+      Set-Config-Default
+    }
+
+    if ($key -ne "") {
+      # Replace the api key if not set
+      Set-Config-Key($key)
+    }
+
+    # Cleanup tmp dir
+    Cleanup
+    # Start the service
+    Start-Service
+  }
+  Set-Alias install -value Install-Project
+  Export-ModuleMember -function 'Install-Project' -alias 'install'
+}


### PR DESCRIPTION
When first installing an agent using the original install script for osx, the user has no control over the global tags. This means when the agent automatically starts at the end of the install process, it sends data with the default conical name.

After the user updates their configs with a new global tag, there will be two sets of metrics, one for the old and one for the new conical name. This creates a poor experience when using the metrics explorer.

To address this, the install script now accepts a --config flag for the user to supply their own config to use for the install.

Similar updates to the windows and linux scripts are in progress. I will finish/submit those in a separate PR if we decide that this design for the install script makes sense. 