### PR TITLE
feat(install): Install scripts replace API token in supplied config

### DIFF
--- a/install/install_freebsd.sh
+++ b/install/install_freebsd.sh
@@ -152,7 +152,7 @@ __configure_agent() {
     [[ -f $cua_conf_file ]] || fail "config file (${cua_conf_file}) not found"
 
     log "\tSetting Circonus API key in configuration"
-    \sed -i -e "s/  api_token = \"\"/  api_token = \"${cua_api_key}\"/" $cua_conf_file
+    \sed -i -e "s/  api_token = \".*\"/  api_token = \"${cua_api_key}\"/" $cua_conf_file
     [[ $? -eq 0 ]] || fail "updating ${cua_conf_file} with api key"
 
     if [[ -n "${cua_api_app}" ]]; then

--- a/install/install_linux.sh
+++ b/install/install_linux.sh
@@ -206,7 +206,7 @@ __configure_agent() {
     [[ -f $cua_conf_file ]] || fail "config file (${cua_conf_file}) not found"
 
     log "\tSetting Circonus API key in configuration"
-    \sed -i -e "s/    api_token = \"\"/    api_token = \"${cua_api_key}\"/" $cua_conf_file
+    \sed -i -e "s/    api_token = \".*\"/    api_token = \"${cua_api_key}\"/" $cua_conf_file
     [[ $? -eq 0 ]] || fail "updating ${cua_conf_file} with api key"
 
     if [[ -n "${cua_api_app}" ]]; then

--- a/install/install_macos.sh
+++ b/install/install_macos.sh
@@ -140,7 +140,7 @@ __configure_agent() {
     [[ -f $cua_conf_file ]] || fail "config file (${cua_conf_file}) not found"
 
     log "\tSetting Circonus API key in configuration"
-    \sed -i -e "s/  api_token = \"\"/  api_token = \"${cua_api_key}\"/" $cua_conf_file
+    \sed -i -e "s/  api_token = \".*\"/  api_token = \"${cua_api_key}\"/" $cua_conf_file
     [[ $? -eq 0 ]] || fail "updating ${cua_conf_file} with api key"
 
     if [[ -n "${cua_api_app}" ]]; then

--- a/install/install_windows.ps1
+++ b/install/install_windows.ps1
@@ -56,7 +56,7 @@ New-Module -name circonus-install -ScriptBlock {
     Write-Host "Copying config..."
     Move-Item -Path "${installpath}\etc\example-circonus-unified-agent_windows.conf" -Destination "${installpath}\etc\circonus-unified-agent.conf"
     $file = "${installpath}\etc\circonus-unified-agent.conf"
-    (Get-Content $file) -replace '  api_token = ""', "  api_token = `"${token}`"" | Set-Content $file
+    (Get-Content $file) -replace '  api_token = \".*\"', "  api_token = `"${token}`"" | Set-Content $file
   }
 
   function Cleanup {


### PR DESCRIPTION
Modify regex to include API tokens in user supplied config, when
  replacing config api_token value with the argument provided,
  in the installer scripts.

issue #CIRC-8723

This will replace the existing api_token in the config with the one
passed to the installer, and gives a better user experience when using
the installer. If a customer were to pass around an existing config for
usage on different systems, this gives more predictable behavior, which
is defaulting to the api token that is passed as an argument at runtime.

* Tags: installer macos linux windows freebsd