### PR TITLE
fix: linux installer not recognizing x86_64 arch as valid [CIRC-9001]

### DIFF
--- a/install/install_linux.sh
+++ b/install/install_linux.sh
@@ -19,7 +19,7 @@ pass() { printf "${GREEN}"; log "$*"; printf "${NORMAL}"; }
 
 hw=$(uname -m | tr '[:upper:]' '[:lower:]')
 case "$hw" in
-    amd64)
+    x86_64|amd64)
         hw="x86_64"
         ;;
     aarch64|arm64)


### PR DESCRIPTION
add `x86_64` as a valid architecture, was omitted from case.