### PR TITLE
Upgrade golangci-lint to v1.49 [CIRC-9033]

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,6 +19,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.2.0
         with:
-          version: v1.42
+          version: v1.49
           skip-go-installation: true
           args: --timeout=5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,25 +15,27 @@ linters:
     - staticcheck
     - unused
     - gosimple
-    - structcheck
-    - varcheck
     - ineffassign
-    - deadcode
     - typecheck
     # - revive
-    # - golint -- deprecated, owner archived repo, replaced by 'revive'
     - gosec
-    # - interfacer -- deprecated, owner archived repo
     - misspell
     - unparam
     - prealloc
-    # - scopelint -- deprecated
     - exportloopref
     - gocritic
     - asciicheck
     - errorlint
     - unconvert
-    # - wrapcheck
-    # - goconst
-    # - nolintlint # different linters with different GOOS fire issues GOOS=linux 'structcheck' unused, under GOOS=darwin it's required
-    # - ifshort # doesn't really work... (x := someFunc(); if x ... then x used later, linter complains var isn't used)
+  disable:
+    ## deprecated linters
+    - deadcode
+    - exhaustivestruct
+    - golint
+    - ifshort
+    - interfacer
+    - maligned
+    - nosnakecase
+    - scopelint
+    - structcheck
+    - varcheck

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -46,9 +46,11 @@ type inputUnit struct {
 	inputs []*models.RunningInput
 }
 
-//  ______     ┌───────────┐     ______
+//	______     ┌───────────┐     ______
+//
 // ()_____)──▶ │ Processor │──▶ ()_____)
-//             └───────────┘
+//
+//	└───────────┘
 type processorUnit struct {
 	src       <-chan cua.Metric
 	dst       chan<- cua.Metric
@@ -59,17 +61,19 @@ type processorUnit struct {
 // Typically the aggregators write to a processor channel and pass the original
 // metrics to the output channel.  The sink channels may be the same channel.
 //
-//                 ┌────────────┐
-//            ┌──▶ │ Aggregator │───┐
-//            │    └────────────┘   │
-//  ______    │    ┌────────────┐   │     ______
+//	               ┌────────────┐
+//	          ┌──▶ │ Aggregator │───┐
+//	          │    └────────────┘   │
+//	______    │    ┌────────────┐   │     ______
+//
 // ()_____)───┼──▶ │ Aggregator │───┼──▶ ()_____)
-//            │    └────────────┘   │
-//            │    ┌────────────┐   │
-//            ├──▶ │ Aggregator │───┘
-//            │    └────────────┘
-//            │                           ______
-//            └────────────────────────▶ ()_____)
+//
+//	│    └────────────┘   │
+//	│    ┌────────────┐   │
+//	├──▶ │ Aggregator │───┘
+//	│    └────────────┘
+//	│                           ______
+//	└────────────────────────▶ ()_____)
 type aggregatorUnit struct {
 	src         <-chan cua.Metric
 	aggC        chan<- cua.Metric
@@ -80,15 +84,17 @@ type aggregatorUnit struct {
 // outputUnit is a group of Outputs and their source channel.  Metrics on the
 // channel are written to all outputs.
 //
-//                            ┌────────┐
-//                       ┌──▶ │ Output │
-//                       │    └────────┘
-//  ______     ┌─────┐   │    ┌────────┐
+//	                          ┌────────┐
+//	                     ┌──▶ │ Output │
+//	                     │    └────────┘
+//	______     ┌─────┐   │    ┌────────┐
+//
 // ()_____)──▶ │ Fan │───┼──▶ │ Output │
-//             └─────┘   │    └────────┘
-//                       │    ┌────────┐
-//                       └──▶ │ Output │
-//                            └────────┘
+//
+//	└─────┘   │    └────────┘
+//	          │    ┌────────┐
+//	          └──▶ │ Output │
+//	               └────────┘
 type outputUnit struct {
 	src     <-chan cua.Metric
 	outputs []*models.RunningOutput

--- a/cmd/circonus-unified-agent/circonus-unified-agent.go
+++ b/cmd/circonus-unified-agent/circonus-unified-agent.go
@@ -230,7 +230,7 @@ func runAgent(ctx context.Context,
 }
 
 func usageExit(rc int) {
-	fmt.Println(internal.Usage) //nolint
+	fmt.Println(internal.Usage) //nolint:govet
 	os.Exit(rc)
 }
 
@@ -321,7 +321,8 @@ func main() {
 
 			log.Printf("I! Starting pprof HTTP server at: %s", pprofHostPort)
 
-			if err := http.ListenAndServe(*pprofAddr, nil); err != nil {
+			err := http.ListenAndServe(*pprofAddr, nil) // #nosec G114 // G114: Use of net/http serve function that has no support for setting timeouts
+			if err != nil {
 				log.Fatal("E! " + err.Error())
 			}
 		}()

--- a/config/config.go
+++ b/config/config.go
@@ -772,12 +772,11 @@ func (c *Config) LoadDirectory(path string) error {
 }
 
 // Try to find a default config file at these locations (in order):
-//   1. $CUA_CONFIG_PATH
-//   2. $HOME/.circonus/unified-agent/circonus-unified-agent.conf
-//   3. os specific:
-//      default: /opt/circonus/unified-agent/etc/circonus-unified-agent.conf
-//      windows: "C:\Program Files\Circonus\Circonus-Unified-Agent\etc\circonus-unified-agent.conf"
-//
+//  1. $CUA_CONFIG_PATH
+//  2. $HOME/.circonus/unified-agent/circonus-unified-agent.conf
+//  3. os specific:
+//     default: /opt/circonus/unified-agent/etc/circonus-unified-agent.conf
+//     windows: "C:\Program Files\Circonus\Circonus-Unified-Agent\etc\circonus-unified-agent.conf"
 func getDefaultConfigPath() (string, error) {
 	envfile := os.Getenv("CUA_CONFIG_PATH")
 	homefile := os.ExpandEnv("${HOME}/.circonus/unified-agent/circonus-unified-agent.conf")
@@ -1800,11 +1799,10 @@ type unwrappable interface {
 	Unwrap() cua.Processor
 }
 
-//
 // Circonus plugins
-//   agent   - which are always enabled
-//   default - which are enabled for "hosts" (disabled in docker containers)
 //
+//	agent   - which are always enabled
+//	default - which are enabled for "hosts" (disabled in docker containers)
 type circonusPlugin struct {
 	Data    []byte
 	Enabled bool

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -14,11 +14,10 @@ type Filter interface {
 // for matching a given string against the filter list. The filter list
 // supports glob matching too, ie:
 //
-//   f, _ := Compile([]string{"cpu", "mem", "net*"})
-//   f.Match("cpu")     // true
-//   f.Match("network") // true
-//   f.Match("memory")  // false
-//
+//	f, _ := Compile([]string{"cpu", "mem", "net*"})
+//	f.Match("cpu")     // true
+//	f.Match("network") // true
+//	f.Match("memory")  // false
 func Compile(filters []string) (Filter, error) {
 	// return if there is nothing to compile
 	if len(filters) == 0 {

--- a/internal/circonus/circonus.go
+++ b/internal/circonus/circonus.go
@@ -246,11 +246,12 @@ func createMetrics(cfg *trapmetrics.Config) (*trapmetrics.TrapMetrics, error) {
 
 // NewMetricDestination will find/retrieve/create a new circonus check bundle and add it to a trap metrics instance to be
 // used as a metric destination.
-//  pluginID = id/name (e.g. inputs.cpu would be cpu, inputs.snmp would be snmp)
-//  instanceID = instance_id setting from the config
-//  metricGroupID = group of metrics from the plugin (some offer multiple)
-//  hostname = used in the display name and target of the check
-//  logger = an instance of cua logger (already configured for the plugin requesting the metric destination)
+//
+//	pluginID = id/name (e.g. inputs.cpu would be cpu, inputs.snmp would be snmp)
+//	instanceID = instance_id setting from the config
+//	metricGroupID = group of metrics from the plugin (some offer multiple)
+//	hostname = used in the display name and target of the check
+//	logger = an instance of cua logger (already configured for the plugin requesting the metric destination)
 func NewMetricDestination(opts *MetricDestConfig, logger cua.Logger) (*trapmetrics.TrapMetrics, error) {
 	if ch == nil {
 		return nil, fmt.Errorf("circonus metric destination management module: module not initialized")

--- a/internal/circonus/config_cache.go
+++ b/internal/circonus/config_cache.go
@@ -10,9 +10,7 @@ import (
 	apiclicfg "github.com/circonus-labs/go-apiclient/config"
 )
 
-//
 // Check bundle config caching
-//
 func loadCheckConfig(id string) *apiclient.CheckBundle {
 	if !ch.circCfg.CacheConfigs {
 		return nil

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -150,8 +150,9 @@ func ReadLines(filename string) ([]string, error) {
 // ReadLines reads contents from file and splits them by new line.
 // The offset tells at which line number to start.
 // The count determines the number of lines to read (starting from offset):
-//   n >= 0: at most n lines
-//   n < 0: whole file
+//
+//	n >= 0: at most n lines
+//	n < 0: whole file
 func ReadLinesOffsetN(filename string, offset uint, n int) ([]string, error) {
 	f, err := os.Open(filename)
 	if err != nil {
@@ -316,9 +317,10 @@ func CompressWithGzip(data io.Reader) (io.ReadCloser, error) {
 
 // ParseTimestamp parses a Time according to the standard agent options.
 // These are generally displayed in the toml similar to:
-//   json_time_key= "timestamp"
-//   json_time_format = "2006-01-02T15:04:05Z07:00"
-//   json_timezone = "America/Los_Angeles"
+//
+//	json_time_key= "timestamp"
+//	json_time_format = "2006-01-02T15:04:05Z07:00"
+//	json_timezone = "America/Los_Angeles"
 //
 // The format can be one of "unix", "unix_ms", "unix_us", "unix_ns", or a Go
 // time layout suitable for time.Parse.
@@ -367,7 +369,8 @@ func parseUnix(format string, timestamp interface{}) (time.Time, error) {
 // Returns the integers before and after an optional decimal point.  Both '.'
 // and ',' are supported for the decimal point.  The timestamp can be an int64,
 // float64, or string.
-//   ex: "42.5" -> (42, 5, nil)
+//
+//	ex: "42.5" -> (42, 5, nil)
 func parseComponents(timestamp interface{}) (int64, int64, error) {
 	switch ts := timestamp.(type) {
 	case string:

--- a/internal/templating/engine.go
+++ b/internal/templating/engine.go
@@ -13,8 +13,8 @@ const (
 // Engine uses a Matcher to retrieve the appropriate template and applies the template
 // to the input string
 type Engine struct {
-	joiner  string
 	matcher *matcher
+	joiner  string
 }
 
 // Apply extracts the template fields from the given line and returns the measurement

--- a/internal/templating/engine_test.go
+++ b/internal/templating/engine_test.go
@@ -36,10 +36,10 @@ func TestEngineWithWildcardTemplate(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, testCase := range []struct {
+		tags        map[string]string
 		line        string
 		measurement string
 		field       string
-		tags        map[string]string
 	}{
 		{
 			line:        "taskmanagerTask.alarm-detector.Assign.alarmDefinitionId.timeout_errors.duration.p75",

--- a/internal/templating/node.go
+++ b/internal/templating/node.go
@@ -8,10 +8,10 @@ import (
 // node is an item in a sorted k-ary tree of filter parts. Each child is sorted by its part value.
 // The special value of "*", is always sorted last.
 type node struct {
+	template  *Template
 	separator string
 	value     string
 	children  nodes
-	template  *Template
 }
 
 // insert inserts the given string template into the tree.  The filter string is separated
@@ -105,16 +105,18 @@ type nodes []*node
 // less than a non-wildcard value.
 //
 // For example, the filters:
-//             "*.*"
-//             "servers.*"
-//             "servers.localhost"
-//             "*.localhost"
+//
+//	"*.*"
+//	"servers.*"
+//	"servers.localhost"
+//	"*.localhost"
 //
 // Would be sorted as:
-//             "servers.localhost"
-//             "servers.*"
-//             "*.localhost"
-//             "*.*"
+//
+//	"servers.localhost"
+//	"servers.*"
+//	"*.localhost"
+//	"*.*"
 func (n *nodes) Less(j, k int) bool {
 	if (*n)[j].value == "*" && (*n)[k].value != "*" {
 		return false

--- a/internal/templating/template.go
+++ b/internal/templating/template.go
@@ -7,9 +7,9 @@ import (
 
 // Template represents a pattern and tags to map a metric string to a influxdb Point
 type Template struct {
+	defaultTags       map[string]string
 	separator         string
 	parts             []string
-	defaultTags       map[string]string
 	greedyField       bool
 	greedyMeasurement bool
 }

--- a/plugins/common/shim/example/cmd/main.go
+++ b/plugins/common/shim/example/cmd/main.go
@@ -23,16 +23,16 @@ var err error
 // However, if you want to do all your config in code, you can like so:
 //
 // // initialize your plugin with any settngs you want
-// myInput := &mypluginname.MyPlugin{
-// 	DefaultSettingHere: 3,
-// }
+//
+//	myInput := &mypluginname.MyPlugin{
+//		DefaultSettingHere: 3,
+//	}
 //
 // shim := shim.New()
 //
 // shim.AddInput(myInput)
 //
 // // now the shim.Run() call as below.
-//
 func main() {
 	// parse command line options
 	flag.Parse()

--- a/plugins/common/tls/config.go
+++ b/plugins/common/tls/config.go
@@ -146,6 +146,6 @@ func loadCertificate(config *tls.Config, certFile, keyFile string) error {
 	}
 
 	config.Certificates = []tls.Certificate{cert}
-	config.BuildNameToCertificate()
+	// config.BuildNameToCertificate() // SA1019: config.BuildNameToCertificate has been deprecated since Go 1.14: NameToCertificate only allows associating a single certificate with a given name. Leave that field nil to let the library select the first compatible chain from Certificates.
 	return nil
 }

--- a/plugins/inputs/aerospike/aerospike.go
+++ b/plugins/inputs/aerospike/aerospike.go
@@ -18,28 +18,20 @@ import (
 )
 
 type Aerospike struct {
-	Servers []string `toml:"servers"`
-
-	Username string `toml:"username"`
-	Password string `toml:"password"`
-
-	EnableTLS bool `toml:"enable_tls"`
-	EnableSSL bool `toml:"enable_ssl"` // deprecated in 1.7; use enable_tls
+	tlsConfig *tls.Config
+	Username  string `toml:"username"`
+	Password  string `toml:"password"`
 	tlsint.ClientConfig
-
-	initialized bool
-	tlsConfig   *tls.Config
-
-	DisableQueryNamespaces bool     `toml:"disable_query_namespaces"`
-	Namespaces             []string `toml:"namespaces"`
-
-	QuerySets bool     `toml:"query_sets"`
-	Sets      []string `toml:"sets"`
-
-	EnableTTLHistogram              bool `toml:"enable_ttl_histogram"`
-	EnableObjectSizeLinearHistogram bool `toml:"enable_object_size_linear_histogram"`
-
-	NumberHistogramBuckets int `toml:"num_histogram_buckets"`
+	Namespaces                      []string `toml:"namespaces"`
+	Servers                         []string `toml:"servers"`
+	Sets                            []string `toml:"sets"`
+	NumberHistogramBuckets          int      `toml:"num_histogram_buckets"`
+	EnableTLS                       bool     `toml:"enable_tls"`
+	QuerySets                       bool     `toml:"query_sets"`
+	DisableQueryNamespaces          bool     `toml:"disable_query_namespaces"`
+	EnableTTLHistogram              bool     `toml:"enable_ttl_histogram"`
+	EnableObjectSizeLinearHistogram bool     `toml:"enable_object_size_linear_histogram"`
+	initialized                     bool
 }
 
 var sampleConfig = `
@@ -97,8 +89,8 @@ func (a *Aerospike) Gather(ctx context.Context, acc cua.Accumulator) error {
 		if err != nil {
 			return fmt.Errorf("TLSConfig: %w", err)
 		}
-		if tlsConfig == nil && (a.EnableTLS || a.EnableSSL) {
-			tlsConfig = &tls.Config{MinVersion: tls.VersionTLS12}
+		if tlsConfig == nil && a.EnableTLS {
+			tlsConfig = &tls.Config{MinVersion: tls.VersionTLS12} // #nosec G402 // G402: TLS MinVersion too low.
 		}
 		a.tlsConfig = tlsConfig
 		a.initialized = true

--- a/plugins/inputs/chrony/chrony.go
+++ b/plugins/inputs/chrony/chrony.go
@@ -19,8 +19,8 @@ var (
 )
 
 type Chrony struct {
-	DNSLookup bool `toml:"dns_lookup"`
 	path      string
+	DNSLookup bool `toml:"dns_lookup"`
 }
 
 func (*Chrony) Description() string {
@@ -67,19 +67,19 @@ func (c *Chrony) Gather(ctx context.Context, acc cua.Accumulator) error {
 
 // processChronycOutput takes in a string output from the chronyc command, like:
 //
-//     Reference ID    : 192.168.1.22 (ntp.example.com)
-//     Stratum         : 3
-//     Ref time (UTC)  : Thu May 12 14:27:07 2016
-//     System time     : 0.000020390 seconds fast of NTP time
-//     Last offset     : +0.000012651 seconds
-//     RMS offset      : 0.000025577 seconds
-//     Frequency       : 16.001 ppm slow
-//     Residual freq   : -0.000 ppm
-//     Skew            : 0.006 ppm
-//     Root delay      : 0.001655 seconds
-//     Root dispersion : 0.003307 seconds
-//     Update interval : 507.2 seconds
-//     Leap status     : Normal
+//	Reference ID    : 192.168.1.22 (ntp.example.com)
+//	Stratum         : 3
+//	Ref time (UTC)  : Thu May 12 14:27:07 2016
+//	System time     : 0.000020390 seconds fast of NTP time
+//	Last offset     : +0.000012651 seconds
+//	RMS offset      : 0.000025577 seconds
+//	Frequency       : 16.001 ppm slow
+//	Residual freq   : -0.000 ppm
+//	Skew            : 0.006 ppm
+//	Root delay      : 0.001655 seconds
+//	Root dispersion : 0.003307 seconds
+//	Update interval : 507.2 seconds
+//	Leap status     : Normal
 //
 // The value on the left side of the colon is used as field name, if the first field on
 // the right side is a float. If it cannot be parsed as float, it is a tag name.

--- a/plugins/inputs/circ_http_json/circ_http_json.go
+++ b/plugins/inputs/circ_http_json/circ_http_json.go
@@ -6,7 +6,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -183,7 +183,7 @@ func (chj *CHJ) getURL(ctx context.Context) ([]byte, error) {
 		return nil, fmt.Errorf("response status: %d", resp.StatusCode)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("reading response body: %w", err)
 	}

--- a/plugins/inputs/cpu/cpu_test.go
+++ b/plugins/inputs/cpu/cpu_test.go
@@ -108,16 +108,17 @@ func TestCPUStats(t *testing.T) {
 // if the measurement is of the wrong type, or if no matching measurements are found
 //
 // Parameters:
-//     t *testing.T            : Testing object to use
-//     acc testutil.Accumulator: Accumulator to examine
-//     measurement string      : Name of the measurement to examine
-//     expectedValue float64   : Value to search for within the measurement
-//     delta float64           : Maximum acceptable distance of an accumulated value
-//                               from the expectedValue parameter. Useful when
-//                               floating-point arithmetic imprecision makes looking
-//                               for an exact match impractical
-//     tags map[string]string  : Tag set the found measurement must have. Set to nil to
-//                               ignore the tag set.
+//
+//	t *testing.T            : Testing object to use
+//	acc testutil.Accumulator: Accumulator to examine
+//	measurement string      : Name of the measurement to examine
+//	expectedValue float64   : Value to search for within the measurement
+//	delta float64           : Maximum acceptable distance of an accumulated value
+//	                          from the expectedValue parameter. Useful when
+//	                          floating-point arithmetic imprecision makes looking
+//	                          for an exact match impractical
+//	tags map[string]string  : Tag set the found measurement must have. Set to nil to
+//	                          ignore the tag set.
 func assertContainsTaggedFloat(
 	t *testing.T,
 	acc *testutil.Accumulator,

--- a/plugins/inputs/filecount/filesystem_helpers.go
+++ b/plugins/inputs/filecount/filesystem_helpers.go
@@ -43,6 +43,7 @@ func (osFS) Stat(name string) (os.FileInfo, error) { return os.Stat(name) }
 */
 
 // When tests can be done on windows, remove these nolint:unused comments - see filesystem_helpers_test.go
+//
 //nolint:unused
 type fakeFileSystem struct {
 	files map[string]fakeFileInfo

--- a/plugins/inputs/fluentd/fluentd.go
+++ b/plugins/inputs/fluentd/fluentd.go
@@ -36,9 +36,9 @@ const (
 
 // Fluentd - plugin main structure
 type Fluentd struct {
+	client   *http.Client
 	Endpoint string
 	Exclude  []string
-	client   *http.Client
 }
 
 type endpointInfo struct {
@@ -46,21 +46,23 @@ type endpointInfo struct {
 }
 
 type pluginData struct {
-	PluginID              string   `json:"plugin_id"`
-	PluginType            string   `json:"type"`
-	PluginCategory        string   `json:"plugin_category"`
 	RetryCount            *float64 `json:"retry_count"`
 	BufferQueueLength     *float64 `json:"buffer_queue_length"`
 	BufferTotalQueuedSize *float64 `json:"buffer_total_queued_size"`
+	PluginID              string   `json:"plugin_id"`
+	PluginType            string   `json:"type"`
+	PluginCategory        string   `json:"plugin_category"`
 }
 
 // parse JSON from fluentd Endpoint
 // Parameters:
-// 		data: unprocessed json received from endpoint
+//
+//	data: unprocessed json received from endpoint
 //
 // Returns:
-//		pluginData:		slice that contains parsed plugins
-//		error:			error that may have occurred
+//
+//	pluginData:		slice that contains parsed plugins
+//	error:			error that may have occurred
 func parse(data []byte) (datapointArray []pluginData, err error) {
 	var endpointData endpointInfo
 

--- a/plugins/inputs/fluentd/fluentd_test.go
+++ b/plugins/inputs/fluentd/fluentd_test.go
@@ -103,8 +103,22 @@ var (
 		// 		{"object:f48698", "dummy", "input", nil, nil, nil},
 		// 		{"object:e27138", "dummy", "input", nil, nil, nil},
 		// 		{"object:d74060", "monitor_agent", "input", nil, nil, nil},
-		{"object:11a5e2c", "stdout", "output", &zero, nil, nil},
-		{"object:11237ec", "s3", "output", &zero, &zero, &zero},
+		{
+			PluginID:              "object:11a5e2c",
+			PluginType:            "stdout",
+			PluginCategory:        "output",
+			RetryCount:            &zero,
+			BufferQueueLength:     nil,
+			BufferTotalQueuedSize: nil,
+		},
+		{
+			PluginID:              "object:11237ec",
+			PluginType:            "s3",
+			PluginCategory:        "output",
+			RetryCount:            &zero,
+			BufferQueueLength:     &zero,
+			BufferTotalQueuedSize: &zero,
+		},
 	}
 	fluentdTest = &Fluentd{
 		Endpoint: "http://localhost:8081",

--- a/plugins/inputs/graylog/graylog.go
+++ b/plugins/inputs/graylog/graylog.go
@@ -25,20 +25,19 @@ type ResponseMetrics struct {
 }
 
 type Metric struct {
+	Fields   map[string]interface{} `json:"metric"`
 	FullName string                 `json:"full_name"`
 	Name     string                 `json:"name"`
 	Type     string                 `json:"type"`
-	Fields   map[string]interface{} `json:"metric"`
 }
 
 type GrayLog struct {
-	Servers  []string
-	Metrics  []string
+	client   HTTPClient
 	Username string
 	Password string
 	tls.ClientConfig
-
-	client HTTPClient
+	Servers []string
+	Metrics []string
 }
 
 type HTTPClient interface {
@@ -157,12 +156,14 @@ func (h *GrayLog) Gather(ctx context.Context, acc cua.Accumulator) error {
 
 // Gathers data from a particular server
 // Parameters:
-//     acc      : The cua Accumulator to use
-//     serverURL: endpoint to send request to
-//     service  : the service being queried
+//
+//	acc      : The cua Accumulator to use
+//	serverURL: endpoint to send request to
+//	service  : the service being queried
 //
 // Returns:
-//     error: Any error that may have occurred
+//
+//	error: Any error that may have occurred
 func (h *GrayLog) gatherServer(
 	acc cua.Accumulator,
 	serverURL string,
@@ -197,11 +198,14 @@ func (h *GrayLog) gatherServer(
 
 // Flatten JSON hierarchy to produce field name and field value
 // Parameters:
-//    item: Item map to flatten
-//    fields: Map to store generated fields.
-//    id: Prefix for top level metric (empty string "")
+//
+//	item: Item map to flatten
+//	fields: Map to store generated fields.
+//	id: Prefix for top level metric (empty string "")
+//
 // Returns:
-//    void
+//
+//	void
 func (h *GrayLog) flatten(item map[string]interface{}, fields map[string]interface{}, id string) {
 	if id != "" {
 		id += "_"
@@ -221,11 +225,13 @@ func (h *GrayLog) flatten(item map[string]interface{}, fields map[string]interfa
 
 // Sends an HTTP request to the server using the GrayLog object's HTTPClient.
 // Parameters:
-//     serverURL: endpoint to send request to
+//
+//	serverURL: endpoint to send request to
 //
 // Returns:
-//     string: body of the response
-//     error : Any error that may have occurred
+//
+//	string: body of the response
+//	error : Any error that may have occurred
 func (h *GrayLog) sendRequest(serverURL string) (string, float64, error) {
 	headers := map[string]string{
 		"Content-Type": "application/json",

--- a/plugins/inputs/graylog/graylog_test.go
+++ b/plugins/inputs/graylog/graylog_test.go
@@ -128,11 +128,13 @@ func (c *mockHTTPClient) HTTPClient() *http.Client {
 
 // Generates a pointer to an HttpJson object that uses a mock HTTP client.
 // Parameters:
-//     response  : Body of the response that the mock HTTP client should return
-//     statusCode: HTTP status code the mock HTTP client should return
+//
+//	response  : Body of the response that the mock HTTP client should return
+//	statusCode: HTTP status code the mock HTTP client should return
 //
 // Returns:
-//     *HttpJson: Pointer to an HttpJson object that uses the generated mock HTTP client
+//
+//	*HttpJson: Pointer to an HttpJson object that uses the generated mock HTTP client
 func genMockGrayLog(response string, statusCode int) []*GrayLog {
 	return []*GrayLog{
 		{

--- a/plugins/inputs/http/http.go
+++ b/plugins/inputs/http/http.go
@@ -19,32 +19,29 @@ import (
 )
 
 type HTTP struct {
-	URLs            []string `toml:"urls"`
-	Method          string   `toml:"method"`
-	Body            string   `toml:"body"`
-	ContentEncoding string   `toml:"content_encoding"`
+	// The parser will automatically be set by cua core code because
+	// this plugin implements the ParserInput interface (i.e. the SetParser method)
+	parser parsers.Parser
 
 	Headers map[string]string `toml:"headers"`
+	client  *http.Client
 
 	// HTTP Basic Auth Credentials
 	Username string `toml:"username"`
 	Password string `toml:"password"`
-	tls.ClientConfig
 
+	ContentEncoding string `toml:"content_encoding"`
 	proxy.HTTPProxy
 
 	// Absolute path to file with Bearer token
 	BearerToken string `toml:"bearer_token"`
 
-	SuccessStatusCodes []int `toml:"success_status_codes"`
-
-	Timeout internal.Duration `toml:"timeout"`
-
-	client *http.Client
-
-	// The parser will automatically be set by cua core code because
-	// this plugin implements the ParserInput interface (i.e. the SetParser method)
-	parser parsers.Parser
+	Body   string `toml:"body"`
+	Method string `toml:"method"`
+	tls.ClientConfig
+	URLs               []string          `toml:"urls"`
+	SuccessStatusCodes []int             `toml:"success_status_codes"`
+	Timeout            internal.Duration `toml:"timeout"`
 }
 
 var sampleConfig = `
@@ -163,11 +160,13 @@ func (h *HTTP) SetParser(parser parsers.Parser) {
 
 // Gathers data from a particular URL
 // Parameters:
-//     acc    : The cua Accumulator to use
-//     url    : endpoint to send request to
+//
+//	acc    : The cua Accumulator to use
+//	url    : endpoint to send request to
 //
 // Returns:
-//     error: Any error that may have occurred
+//
+//	error: Any error that may have occurred
 func (h *HTTP) gatherURL(
 	acc cua.Accumulator,
 	url string,

--- a/plugins/inputs/influxdb/influxdb.go
+++ b/plugins/inputs/influxdb/influxdb.go
@@ -22,9 +22,9 @@ const (
 )
 
 type APIError struct {
-	StatusCode  int
 	Reason      string
 	Description string `json:"error"`
+	StatusCode  int
 }
 
 func (e *APIError) Error() string {
@@ -35,13 +35,12 @@ func (e *APIError) Error() string {
 }
 
 type InfluxDB struct {
-	URLs     []string          `toml:"urls"`
-	Username string            `toml:"username"`
-	Password string            `toml:"password"`
-	Timeout  internal.Duration `toml:"timeout"`
+	client   *http.Client
+	Username string `toml:"username"`
+	Password string `toml:"password"`
 	tls.ClientConfig
-
-	client *http.Client
+	URLs    []string          `toml:"urls"`
+	Timeout internal.Duration `toml:"timeout"`
 }
 
 func (*InfluxDB) Description() string {
@@ -114,9 +113,9 @@ func (i *InfluxDB) Gather(ctx context.Context, acc cua.Accumulator) error {
 }
 
 type point struct {
-	Name   string                 `json:"name"`
 	Tags   map[string]string      `json:"tags"`
 	Values map[string]interface{} `json:"values"`
+	Name   string                 `json:"name"`
 }
 
 type memstats struct {
@@ -151,11 +150,13 @@ type memstats struct {
 
 // Gathers data from a particular URL
 // Parameters:
-//     acc    : The cua Accumulator to use
-//     url    : endpoint to send request to
+//
+//	acc    : The cua Accumulator to use
+//	url    : endpoint to send request to
 //
 // Returns:
-//     error: Any error that may have occurred
+//
+//	error: Any error that may have occurred
 func (i *InfluxDB) gatherURL(
 	acc cua.Accumulator,
 	url string,

--- a/plugins/inputs/jolokia2/client.go
+++ b/plugins/inputs/jolokia2/client.go
@@ -14,17 +14,17 @@ import (
 )
 
 type Client struct {
-	URL    string
 	client *http.Client
 	config *ClientConfig
+	URL    string
 }
 
 type ClientConfig struct {
-	ResponseTimeout time.Duration
-	Username        string
-	Password        string
-	ProxyConfig     *ProxyConfig
+	ProxyConfig *ProxyConfig
+	Username    string
+	Password    string
 	tls.ClientConfig
+	ResponseTimeout time.Duration
 }
 
 type ProxyConfig struct {
@@ -41,33 +41,33 @@ type ProxyTargetConfig struct {
 
 type ReadRequest struct {
 	Mbean      string
-	Attributes []string
 	Path       string
+	Attributes []string
 }
 
 type ReadResponse struct {
-	Status            int
 	Value             interface{}
 	RequestMbean      string
-	RequestAttributes []string
 	RequestPath       string
 	RequestTarget     string
+	RequestAttributes []string
+	Status            int
 }
 
-// Jolokia JSON request object. Example: {
-//   "type": "read",
-//   "mbean: "java.lang:type="Runtime",
-//   "attribute": "Uptime",
-//   "target": {
-//     "url: "service:jmx:rmi:///jndi/rmi://target:9010/jmxrmi"
-//   }
-// }
+//	Jolokia JSON request object. Example: {
+//	  "type": "read",
+//	  "mbean: "java.lang:type="Runtime",
+//	  "attribute": "Uptime",
+//	  "target": {
+//	    "url: "service:jmx:rmi:///jndi/rmi://target:9010/jmxrmi"
+//	  }
+//	}
 type jolokiaRequest struct {
+	Attribute interface{}    `json:"attribute,omitempty"`
+	Target    *jolokiaTarget `json:"target,omitempty"`
 	Type      string         `json:"type"`
 	Mbean     string         `json:"mbean"`
-	Attribute interface{}    `json:"attribute,omitempty"`
 	Path      string         `json:"path,omitempty"`
-	Target    *jolokiaTarget `json:"target,omitempty"`
 }
 
 type jolokiaTarget struct {
@@ -76,22 +76,22 @@ type jolokiaTarget struct {
 	Password string `json:"password,omitempty"`
 }
 
-// Jolokia JSON response object. Example: {
-//   "request": {
-//     "type": "read"
-//     "mbean": "java.lang:type=Runtime",
-//     "attribute": "Uptime",
-//     "target": {
-//       "url": "service:jmx:rmi:///jndi/rmi://target:9010/jmxrmi"
-//     }
-//   },
-//   "value": 1214083,
-//   "timestamp": 1488059309,
-//   "status": 200
-// }
+//	Jolokia JSON response object. Example: {
+//	  "request": {
+//	    "type": "read"
+//	    "mbean": "java.lang:type=Runtime",
+//	    "attribute": "Uptime",
+//	    "target": {
+//	      "url": "service:jmx:rmi:///jndi/rmi://target:9010/jmxrmi"
+//	    }
+//	  },
+//	  "value": 1214083,
+//	  "timestamp": 1488059309,
+//	  "status": 200
+//	}
 type jolokiaResponse struct {
-	Request jolokiaRequest `json:"request"`
 	Value   interface{}    `json:"value"`
+	Request jolokiaRequest `json:"request"`
 	Status  int            `json:"status"`
 }
 

--- a/plugins/inputs/jolokia2/jolokia_agent.go
+++ b/plugins/inputs/jolokia2/jolokia_agent.go
@@ -11,20 +11,17 @@ import (
 )
 
 type JolokiaAgent struct {
+	gatherer              *Gatherer
 	DefaultFieldPrefix    string
 	DefaultFieldSeparator string
 	DefaultTagPrefix      string
-
-	URLs            []string `toml:"urls"`
-	Username        string
-	Password        string
-	ResponseTimeout internal.Duration `toml:"response_timeout"`
-
+	Username              string
+	Password              string
 	tls.ClientConfig
-
-	Metrics  []MetricConfig `toml:"metric"`
-	gatherer *Gatherer
-	clients  []*Client
+	URLs            []string       `toml:"urls"`
+	Metrics         []MetricConfig `toml:"metric"`
+	clients         []*Client
+	ResponseTimeout internal.Duration `toml:"response_timeout"`
 }
 
 func (ja *JolokiaAgent) SampleConfig() string {

--- a/plugins/inputs/jolokia2/jolokia_proxy.go
+++ b/plugins/inputs/jolokia2/jolokia_proxy.go
@@ -9,23 +9,20 @@ import (
 )
 
 type JolokiaProxy struct {
-	DefaultFieldPrefix    string
+	client                *Client
+	gatherer              *Gatherer
 	DefaultFieldSeparator string
 	DefaultTagPrefix      string
-
 	URL                   string `toml:"url"`
 	DefaultTargetPassword string
 	DefaultTargetUsername string
-	Targets               []JolokiaProxyTargetConfig `toml:"target"`
-
-	Username        string
-	Password        string
-	ResponseTimeout internal.Duration `toml:"response_timeout"`
+	DefaultFieldPrefix    string
+	Username              string
+	Password              string
 	tls.ClientConfig
-
-	Metrics  []MetricConfig `toml:"metric"`
-	client   *Client
-	gatherer *Gatherer
+	Targets         []JolokiaProxyTargetConfig `toml:"target"`
+	Metrics         []MetricConfig             `toml:"metric"`
+	ResponseTimeout internal.Duration          `toml:"response_timeout"`
 }
 
 type JolokiaProxyTargetConfig struct {

--- a/plugins/inputs/kapacitor/kapacitor.go
+++ b/plugins/inputs/kapacitor/kapacitor.go
@@ -19,11 +19,10 @@ const (
 )
 
 type Kapacitor struct {
+	client *http.Client
+	tls.ClientConfig
 	URLs    []string `toml:"urls"`
 	Timeout internal.Duration
-	tls.ClientConfig
-
-	client *http.Client
 }
 
 func (*Kapacitor) Description() string {
@@ -93,9 +92,9 @@ func (k *Kapacitor) createHTTPClient() (*http.Client, error) {
 }
 
 type object struct {
-	Name   string                 `json:"name"`
 	Values map[string]interface{} `json:"values"`
 	Tags   map[string]string      `json:"tags"`
+	Name   string                 `json:"name"`
 }
 
 type memstats struct {
@@ -128,26 +127,28 @@ type memstats struct {
 }
 
 type stats struct {
-	CmdLine          []string           `json:"cmdline"`
-	ClusterID        string             `json:"cluster_id"`
-	Host             string             `json:"host"`
 	Kapacitor        *map[string]object `json:"kapacitor"`
 	MemStats         *memstats          `json:"memstats"`
-	NumEnabledTasks  int                `json:"num_enabled_tasks"`
-	NumSubscriptions int                `json:"num_subscriptions"`
-	NumTasks         int                `json:"num_tasks"`
+	ClusterID        string             `json:"cluster_id"`
+	Host             string             `json:"host"`
 	Product          string             `json:"product"`
 	ServerID         string             `json:"server_id"`
 	Version          string             `json:"version"`
+	CmdLine          []string           `json:"cmdline"`
+	NumEnabledTasks  int                `json:"num_enabled_tasks"`
+	NumSubscriptions int                `json:"num_subscriptions"`
+	NumTasks         int                `json:"num_tasks"`
 }
 
 // Gathers data from a particular URL
 // Parameters:
-//     acc    : The cua Accumulator to use
-//     url    : endpoint to send request to
+//
+//	acc    : The cua Accumulator to use
+//	url    : endpoint to send request to
 //
 // Returns:
-//     error: Any error that may have occurred
+//
+//	error: Any error that may have occurred
 func (k *Kapacitor) gatherURL(
 	acc cua.Accumulator,
 	rurl string,

--- a/plugins/inputs/lustre2/lustre2.go
+++ b/plugins/inputs/lustre2/lustre2.go
@@ -7,7 +7,6 @@ Lustre 2.x plugin
 Lustre (http://lustre.org/) is an open-source, parallel file system
 for HPC environments. It stores statistics about its activity in
 /proc
-
 */
 package lustre2
 
@@ -52,12 +51,13 @@ var sampleConfig = `
   # ]
 `
 
-/* The wanted fields would be a []string if not for the
-   lines that start with read_bytes/write_bytes and contain
-   both the byte count and the function call count
-	inProc   string // What to look for at the start of a line in /proc/fs/lustre/*
-	field    uint32 // which field to extract from that line
-	reportAs string // What measurement name to use
+/*
+	 The wanted fields would be a []string if not for the
+	   lines that start with read_bytes/write_bytes and contain
+	   both the byte count and the function call count
+		inProc   string // What to look for at the start of a line in /proc/fs/lustre/*
+		field    uint32 // which field to extract from that line
+		reportAs string // What measurement name to use
 */
 type mapping struct {
 	inProc   string

--- a/plugins/inputs/mongodb/mongodb.go
+++ b/plugins/inputs/mongodb/mongodb.go
@@ -18,21 +18,20 @@ import (
 )
 
 type MongoDB struct {
+	Log    cua.Logger
+	mongos map[string]*Server
+	tlsint.ClientConfig
 	Servers             []string
+	ColStatsDbs         []string
 	Ssl                 Ssl
-	mongos              map[string]*Server
 	GatherClusterStatus bool
 	GatherPerdbStats    bool
 	GatherColStats      bool
-	ColStatsDbs         []string
-	tlsint.ClientConfig
-
-	Log cua.Logger
 }
 
 type Ssl struct {
-	Enabled bool
 	CaCerts []string `toml:"cacerts"`
+	Enabled bool
 }
 
 var sampleConfig = `
@@ -149,7 +148,7 @@ func (m *MongoDB) gatherServer(server *Server, acc cua.Accumulator) error {
 
 		if m.Ssl.Enabled {
 			// Deprecated TLS config
-			tlsConfig = &tls.Config{MinVersion: tls.VersionTLS12}
+			tlsConfig = &tls.Config{MinVersion: tls.VersionTLS12} // #nosec G402 // G402: TLS MinVersion too low.
 			if len(m.Ssl.CaCerts) > 0 {
 				roots := x509.NewCertPool()
 				for _, caCert := range m.Ssl.CaCerts {

--- a/plugins/inputs/mongodb/mongodb_data.go
+++ b/plugins/inputs/mongodb/mongodb_data.go
@@ -18,14 +18,14 @@ type MDBData struct {
 }
 
 type DbData struct {
-	Name   string
 	Fields map[string]interface{}
+	Name   string
 }
 
 type ColData struct {
+	Fields map[string]interface{}
 	Name   string
 	DbName string
-	Fields map[string]interface{}
 }
 
 func NewMongodbData(statLine *StatLine, tags map[string]string) *MDBData {

--- a/plugins/inputs/mongodb/mongostat.go
+++ b/plugins/inputs/mongodb/mongostat.go
@@ -40,33 +40,33 @@ type MongoStatus struct {
 }
 
 type ServerStatus struct {
-	Host               string                 `bson:"host"`
-	Version            string                 `bson:"version"`
-	Process            string                 `bson:"process"`
-	Pid                int64                  `bson:"pid"`
-	Uptime             int64                  `bson:"uptime"`
-	UptimeMillis       int64                  `bson:"uptimeMillis"`
-	UptimeEstimate     int64                  `bson:"uptimeEstimate"`
 	LocalTime          time.Time              `bson:"localTime"`
+	OpLatencies        *OpLatenciesStats      `bson:"opLatencies"`
+	Mem                *MemStats              `bson:"mem"`
+	Locks              map[string]LockStats   `bson:"locks,omitempty"`
+	Network            *NetworkStats          `bson:"network"`
+	GlobalLock         *GlobalLockStats       `bson:"globalLock"`
+	Metrics            *MetricsStats          `bson:"metrics"`
+	WiredTiger         *WiredTiger            `bson:"wiredTiger"`
 	Asserts            *AssertsStats          `bson:"asserts"`
 	BackgroundFlushing *FlushStats            `bson:"backgroundFlushing"`
 	ExtraInfo          *ExtraInfo             `bson:"extra_info"`
 	Connections        *ConnectionStats       `bson:"connections"`
 	Dur                *DurStats              `bson:"dur"`
-	GlobalLock         *GlobalLockStats       `bson:"globalLock"`
-	Locks              map[string]LockStats   `bson:"locks,omitempty"`
-	Network            *NetworkStats          `bson:"network"`
+	TCMallocStats      *TCMallocStats         `bson:"tcmalloc"`
+	StorageEngine      map[string]string      `bson:"storageEngine"`
+	ShardCursorType    map[string]interface{} `bson:"shardCursorType"`
 	Opcounters         *OpcountStats          `bson:"opcounters"`
 	OpcountersRepl     *OpcountStats          `bson:"opcountersRepl"`
-	OpLatencies        *OpLatenciesStats      `bson:"opLatencies"`
-	RecordStats        *DBRecordStats         `bson:"recordStats"`
-	Mem                *MemStats              `bson:"mem"`
 	Repl               *ReplStatus            `bson:"repl"`
-	ShardCursorType    map[string]interface{} `bson:"shardCursorType"`
-	StorageEngine      map[string]string      `bson:"storageEngine"`
-	WiredTiger         *WiredTiger            `bson:"wiredTiger"`
-	Metrics            *MetricsStats          `bson:"metrics"`
-	TCMallocStats      *TCMallocStats         `bson:"tcmalloc"`
+	RecordStats        *DBRecordStats         `bson:"recordStats"`
+	Process            string                 `bson:"process"`
+	Host               string                 `bson:"host"`
+	Version            string                 `bson:"version"`
+	Uptime             int64                  `bson:"uptime"`
+	Pid                int64                  `bson:"pid"`
+	UptimeEstimate     int64                  `bson:"uptimeEstimate"`
+	UptimeMillis       int64                  `bson:"uptimeMillis"`
 }
 
 // DbStats stores stats from all dbs
@@ -76,12 +76,13 @@ type DbStats struct {
 
 // Db represent a single DB
 type Db struct {
-	Name        string
 	DbStatsData *DbStatsData
+	Name        string
 }
 
 // DbStatsData stores stats from a db
 type DbStatsData struct {
+	GleStats    interface{} `bson:"gleStats"`
 	Db          string      `bson:"db"`
 	Collections int64       `bson:"collections"`
 	Objects     int64       `bson:"objects"`
@@ -92,7 +93,6 @@ type DbStatsData struct {
 	Indexes     int64       `bson:"indexes"`
 	IndexSize   int64       `bson:"indexSize"`
 	Ok          int64       `bson:"ok"`
-	GleStats    interface{} `bson:"gleStats"`
 }
 
 type ColStats struct {
@@ -100,9 +100,9 @@ type ColStats struct {
 }
 
 type Collection struct {
+	ColStatsData *ColStatsData
 	Name         string
 	DbName       string
-	ColStatsData *ColStatsData
 }
 
 type ColStatsData struct {
@@ -133,10 +133,10 @@ type OplogStats struct {
 
 // ReplSetMember stores information related to a replica set member
 type ReplSetMember struct {
-	Name       string    `bson:"name"`
-	State      int64     `bson:"state"`
-	StateStr   string    `bson:"stateStr"`
 	OptimeDate time.Time `bson:"optimeDate"`
+	Name       string    `bson:"name"`
+	StateStr   string    `bson:"stateStr"`
+	State      int64     `bson:"state"`
 }
 
 // WiredTiger stores information related to the WiredTiger storage engine.
@@ -148,8 +148,8 @@ type WiredTiger struct {
 
 // ShardStats stores information from shardConnPoolStats.
 type ShardStats struct {
-	ShardStatsData `bson:",inline"`
 	Hosts          map[string]ShardHostStatsData `bson:"hosts"`
+	ShardStatsData `bson:",inline"`
 }
 
 // ShardStatsData is the total Shard Stats from shardConnPoolStats database command.
@@ -225,16 +225,16 @@ type ReplStatus struct {
 	Secondary    interface{} `bson:"secondary"`
 	IsReplicaSet interface{} `bson:"isreplicaset"`
 	ArbiterOnly  interface{} `bson:"arbiterOnly"`
+	Me           string      `bson:"me"`
 	Hosts        []string    `bson:"hosts"`
 	Passives     []string    `bson:"passives"`
-	Me           string      `bson:"me"`
 }
 
 // DBRecordStats stores data related to memory operations across databases.
 type DBRecordStats struct {
+	DBRecordAccesses          map[string]RecordAccesses `bson:",inline"`
 	AccessesNotInMemory       int64                     `bson:"accessesNotInMemory"`
 	PageFaultExceptionsThrown int64                     `bson:"pageFaultExceptionsThrown"`
-	DBRecordAccesses          map[string]RecordAccesses `bson:",inline"`
 }
 
 // RecordAccesses stores data related to memory operations scoped to a database.
@@ -245,21 +245,21 @@ type RecordAccesses struct {
 
 // MemStats stores data related to memory statistics.
 type MemStats struct {
+	Supported         interface{} `bson:"supported"`
 	Bits              int64       `bson:"bits"`
 	Resident          int64       `bson:"resident"`
 	Virtual           int64       `bson:"virtual"`
-	Supported         interface{} `bson:"supported"`
 	Mapped            int64       `bson:"mapped"`
 	MappedWithJournal int64       `bson:"mappedWithJournal"`
 }
 
 // FlushStats stores information about memory flushes.
 type FlushStats struct {
+	LastFinished time.Time `bson:"last_finished"`
 	Flushes      int64     `bson:"flushes"`
 	TotalMs      int64     `bson:"total_ms"`
 	AverageMs    float64   `bson:"average_ms"`
 	LastMs       int64     `bson:"last_ms"`
-	LastFinished time.Time `bson:"last_finished"`
 }
 
 // ConnectionStats stores information related to incoming database connections.
@@ -305,10 +305,10 @@ type ClientStats struct {
 
 // GlobalLockStats stores information related locks in the MMAP storage engine.
 type GlobalLockStats struct {
-	TotalTime     int64        `bson:"totalTime"`
-	LockTime      int64        `bson:"lockTime"`
 	CurrentQueue  *QueueStats  `bson:"currentQueue"`
 	ActiveClients *ClientStats `bson:"activeClients"`
+	TotalTime     int64        `bson:"totalTime"`
+	LockTime      int64        `bson:"lockTime"`
 }
 
 // NetworkStats stores information related to network traffic.
@@ -361,8 +361,8 @@ type TTLStats struct {
 
 // CursorStats stores information related to cursor metrics.
 type CursorStats struct {
-	TimedOut int64            `bson:"timedOut"`
 	Open     *OpenCursorStats `bson:"open"`
+	TimedOut int64            `bson:"timedOut"`
 }
 
 // DocumentStats stores information related to document metrics.
@@ -440,8 +440,8 @@ type ReplExecutorStats struct {
 
 // ReplNetworkStats stores information related to network usage by replication process
 type ReplNetworkStats struct {
-	Bytes    int64       `bson:"bytes"`
 	GetMores *BasicStats `bson:"getmores"`
+	Bytes    int64       `bson:"bytes"`
 	Ops      int64       `bson:"ops"`
 }
 
@@ -461,15 +461,15 @@ type ReadWriteLockTimes struct {
 
 // LockStats stores information related to time spent acquiring/holding locks
 // for a given database.
+//
+// AcquireCount and AcquireWaitCount are new fields of the lock stats only populated on 3.0 or newer.
+// Typed as a pointer so that if it is nil, mongostat can assume the field is not populated
+// with real namespace data.
 type LockStats struct {
-	TimeLockedMicros    ReadWriteLockTimes `bson:"timeLockedMicros"`
-	TimeAcquiringMicros ReadWriteLockTimes `bson:"timeAcquiringMicros"`
-
-	// AcquireCount and AcquireWaitCount are new fields of the lock stats only populated on 3.0 or newer.
-	// Typed as a pointer so that if it is nil, mongostat can assume the field is not populated
-	// with real namespace data.
-	AcquireCount     *ReadWriteLockTimes `bson:"acquireCount,omitempty"`
-	AcquireWaitCount *ReadWriteLockTimes `bson:"acquireWaitCount,omitempty"`
+	AcquireCount        *ReadWriteLockTimes `bson:"acquireCount,omitempty"`
+	AcquireWaitCount    *ReadWriteLockTimes `bson:"acquireWaitCount,omitempty"`
+	TimeLockedMicros    ReadWriteLockTimes  `bson:"timeLockedMicros"`
+	TimeAcquiringMicros ReadWriteLockTimes  `bson:"timeAcquiringMicros"`
 }
 
 // ExtraInfo stores additional platform specific information.
@@ -610,165 +610,352 @@ type LockStatus struct {
 	Global     bool
 }
 
+// // StatLine is a wrapper for all metrics reported by mongostat for monitored hosts.
+// type StatLine struct {
+// 	Key string
+// 	// What storage engine is being used for the node with this stat line
+// 	StorageEngine string
+
+// 	Error    error
+// 	IsMongos bool
+// 	Host     string
+// 	Version  string
+
+// 	UptimeNanos int64
+
+// 	// The time at which this StatLine was generated.
+// 	Time time.Time
+
+// 	// The last time at which this StatLine was printed to output.
+// 	LastPrinted time.Time
+
+// 	// Opcounter fields
+// 	Insert, InsertCnt   int64
+// 	Query, QueryCnt     int64
+// 	Update, UpdateCnt   int64
+// 	Delete, DeleteCnt   int64
+// 	GetMore, GetMoreCnt int64
+// 	Command, CommandCnt int64
+
+// 	// Asserts fields
+// 	Regular   int64
+// 	Warning   int64
+// 	Msg       int64
+// 	User      int64
+// 	Rollovers int64
+
+// 	// OpLatency fields
+// 	WriteOpsCnt    int64
+// 	WriteLatency   int64
+// 	ReadOpsCnt     int64
+// 	ReadLatency    int64
+// 	CommandOpsCnt  int64
+// 	CommandLatency int64
+
+// 	// TTL fields
+// 	Passes, PassesCnt                     int64
+// 	DeletedDocuments, DeletedDocumentsCnt int64
+
+// 	// Cursor fields
+// 	TimedOutC, TimedOutCCnt   int64
+// 	NoTimeoutC, NoTimeoutCCnt int64
+// 	PinnedC, PinnedCCnt       int64
+// 	TotalC, TotalCCnt         int64
+
+// 	// Document fields
+// 	DeletedD, InsertedD, ReturnedD, UpdatedD int64
+
+// 	// Commands fields
+// 	AggregateCommandTotal, AggregateCommandFailed         int64
+// 	CountCommandTotal, CountCommandFailed                 int64
+// 	DeleteCommandTotal, DeleteCommandFailed               int64
+// 	DistinctCommandTotal, DistinctCommandFailed           int64
+// 	FindCommandTotal, FindCommandFailed                   int64
+// 	FindAndModifyCommandTotal, FindAndModifyCommandFailed int64
+// 	GetMoreCommandTotal, GetMoreCommandFailed             int64
+// 	InsertCommandTotal, InsertCommandFailed               int64
+// 	UpdateCommandTotal, UpdateCommandFailed               int64
+
+// 	// Operation fields
+// 	ScanAndOrderOp, WriteConflictsOp int64
+
+// 	// Query Executor fields
+// 	TotalKeysScanned, TotalObjectsScanned int64
+
+// 	// Connection fields
+// 	CurrentC, AvailableC, TotalCreatedC int64
+
+// 	// Collection locks (3.0 mmap only)
+// 	CollectionLocks *CollectionLockStatus
+
+// 	// Cache utilization (wiredtiger only)
+// 	CacheDirtyPercent float64
+// 	CacheUsedPercent  float64
+
+// 	// Cache utilization extended (wiredtiger only)
+// 	TrackedDirtyBytes         int64
+// 	CurrentCachedBytes        int64
+// 	MaxBytesConfigured        int64
+// 	AppThreadsPageReadCount   int64
+// 	AppThreadsPageReadTime    int64
+// 	AppThreadsPageWriteCount  int64
+// 	BytesWrittenFrom          int64
+// 	BytesReadInto             int64
+// 	PagesEvictedByAppThread   int64
+// 	PagesQueuedForEviction    int64
+// 	PagesReadIntoCache        int64
+// 	PagesWrittenFromCache     int64
+// 	PagesRequestedFromCache   int64
+// 	ServerEvictingPages       int64
+// 	WorkerThreadEvictingPages int64
+// 	InternalPagesEvicted      int64
+// 	ModifiedPagesEvicted      int64
+// 	UnmodifiedPagesEvicted    int64
+
+// 	// Replicated Opcounter fields
+// 	InsertR, InsertRCnt                      int64
+// 	QueryR, QueryRCnt                        int64
+// 	UpdateR, UpdateRCnt                      int64
+// 	DeleteR, DeleteRCnt                      int64
+// 	GetMoreR, GetMoreRCnt                    int64
+// 	CommandR, CommandRCnt                    int64
+// 	ReplLag                                  int64
+// 	OplogStats                               *OplogStats
+// 	Flushes, FlushesCnt                      int64
+// 	FlushesTotalTime                         int64
+// 	Mapped, Virtual, Resident, NonMapped     int64
+// 	Faults, FaultsCnt                        int64
+// 	HighestLocked                            *LockStatus
+// 	QueuedReaders, QueuedWriters             int64
+// 	ActiveReaders, ActiveWriters             int64
+// 	AvailableReaders, AvailableWriters       int64
+// 	TotalTicketsReaders, TotalTicketsWriters int64
+// 	NetIn, NetInCnt                          int64
+// 	NetOut, NetOutCnt                        int64
+// 	NumConnections                           int64
+// 	ReplSetName                              string
+// 	NodeType                                 string
+// 	NodeState                                string
+// 	NodeStateInt                             int64
+
+// 	// Replicated Metrics fields
+// 	ReplNetworkBytes                    int64
+// 	ReplNetworkGetmoresNum              int64
+// 	ReplNetworkGetmoresTotalMillis      int64
+// 	ReplNetworkOps                      int64
+// 	ReplBufferCount                     int64
+// 	ReplBufferSizeBytes                 int64
+// 	ReplApplyBatchesNum                 int64
+// 	ReplApplyBatchesTotalMillis         int64
+// 	ReplApplyOps                        int64
+// 	ReplExecutorPoolInProgressCount     int64
+// 	ReplExecutorQueuesNetworkInProgress int64
+// 	ReplExecutorQueuesSleepers          int64
+// 	ReplExecutorUnsignaledEvents        int64
+
+// 	// Cluster fields
+// 	JumboChunksCount int64
+
+// 	// DB stats field
+// 	DbStatsLines []DbStatLine
+
+// 	// Col Stats field
+// 	ColStatsLines []ColStatLine
+
+// 	// Shard stats
+// 	TotalInUse, TotalAvailable, TotalCreated, TotalRefreshing int64
+
+// 	// Shard Hosts stats field
+// 	ShardHostStatsLines map[string]ShardHostStatLine
+
+// 	// TCMalloc stats field
+// 	TCMallocCurrentAllocatedBytes        int64
+// 	TCMallocHeapSize                     int64
+// 	TCMallocCentralCacheFreeBytes        int64
+// 	TCMallocCurrentTotalThreadCacheBytes int64
+// 	TCMallocMaxTotalThreadCacheBytes     int64
+// 	TCMallocTotalFreeBytes               int64
+// 	TCMallocTransferCacheFreeBytes       int64
+// 	TCMallocThreadCacheFreeBytes         int64
+// 	TCMallocSpinLockTotalDelayNanos      int64
+// 	TCMallocPageheapFreeBytes            int64
+// 	TCMallocPageheapUnmappedBytes        int64
+// 	TCMallocPageheapComittedBytes        int64
+// 	TCMallocPageheapScavengeCount        int64
+// 	TCMallocPageheapCommitCount          int64
+// 	TCMallocPageheapTotalCommitBytes     int64
+// 	TCMallocPageheapDecommitCount        int64
+// 	TCMallocPageheapTotalDecommitBytes   int64
+// 	TCMallocPageheapReserveCount         int64
+// 	TCMallocPageheapTotalReserveBytes    int64
+
+// 	// Storage stats field
+// 	StorageFreelistSearchBucketExhausted int64
+// 	StorageFreelistSearchRequests        int64
+// 	StorageFreelistSearchScanned         int64
+// }
+
+// below is an aligned struct of the above (192 pointer bytes instead of 1328)
+// the above is maintained for the comments and organization of the members
+
 // StatLine is a wrapper for all metrics reported by mongostat for monitored hosts.
 type StatLine struct {
-	Key string
-	// What storage engine is being used for the node with this stat line
-	StorageEngine string
-
-	Error    error
-	IsMongos bool
-	Host     string
-	Version  string
-
-	UptimeNanos int64
-
-	// The time at which this StatLine was generated.
-	Time time.Time
-
-	// The last time at which this StatLine was printed to output.
-	LastPrinted time.Time
-
-	// Opcounter fields
-	Insert, InsertCnt   int64
-	Query, QueryCnt     int64
-	Update, UpdateCnt   int64
-	Delete, DeleteCnt   int64
-	GetMore, GetMoreCnt int64
-	Command, CommandCnt int64
-
-	// Asserts fields
-	Regular   int64
-	Warning   int64
-	Msg       int64
-	User      int64
-	Rollovers int64
-
-	// OpLatency fields
-	WriteOpsCnt    int64
-	WriteLatency   int64
-	ReadOpsCnt     int64
-	ReadLatency    int64
-	CommandOpsCnt  int64
-	CommandLatency int64
-
-	// TTL fields
-	Passes, PassesCnt                     int64
-	DeletedDocuments, DeletedDocumentsCnt int64
-
-	// Cursor fields
-	TimedOutC, TimedOutCCnt   int64
-	NoTimeoutC, NoTimeoutCCnt int64
-	PinnedC, PinnedCCnt       int64
-	TotalC, TotalCCnt         int64
-
-	// Document fields
-	DeletedD, InsertedD, ReturnedD, UpdatedD int64
-
-	// Commands fields
-	AggregateCommandTotal, AggregateCommandFailed         int64
-	CountCommandTotal, CountCommandFailed                 int64
-	DeleteCommandTotal, DeleteCommandFailed               int64
-	DistinctCommandTotal, DistinctCommandFailed           int64
-	FindCommandTotal, FindCommandFailed                   int64
-	FindAndModifyCommandTotal, FindAndModifyCommandFailed int64
-	GetMoreCommandTotal, GetMoreCommandFailed             int64
-	InsertCommandTotal, InsertCommandFailed               int64
-	UpdateCommandTotal, UpdateCommandFailed               int64
-
-	// Operation fields
-	ScanAndOrderOp, WriteConflictsOp int64
-
-	// Query Executor fields
-	TotalKeysScanned, TotalObjectsScanned int64
-
-	// Connection fields
-	CurrentC, AvailableC, TotalCreatedC int64
-
-	// Collection locks (3.0 mmap only)
-	CollectionLocks *CollectionLockStatus
-
-	// Cache utilization (wiredtiger only)
-	CacheDirtyPercent float64
-	CacheUsedPercent  float64
-
-	// Cache utilization extended (wiredtiger only)
-	TrackedDirtyBytes         int64
-	CurrentCachedBytes        int64
-	MaxBytesConfigured        int64
-	AppThreadsPageReadCount   int64
-	AppThreadsPageReadTime    int64
-	AppThreadsPageWriteCount  int64
-	BytesWrittenFrom          int64
-	BytesReadInto             int64
-	PagesEvictedByAppThread   int64
-	PagesQueuedForEviction    int64
-	PagesReadIntoCache        int64
-	PagesWrittenFromCache     int64
-	PagesRequestedFromCache   int64
-	ServerEvictingPages       int64
-	WorkerThreadEvictingPages int64
-	InternalPagesEvicted      int64
-	ModifiedPagesEvicted      int64
-	UnmodifiedPagesEvicted    int64
-
-	// Replicated Opcounter fields
-	InsertR, InsertRCnt                      int64
-	QueryR, QueryRCnt                        int64
-	UpdateR, UpdateRCnt                      int64
-	DeleteR, DeleteRCnt                      int64
-	GetMoreR, GetMoreRCnt                    int64
-	CommandR, CommandRCnt                    int64
-	ReplLag                                  int64
-	OplogStats                               *OplogStats
-	Flushes, FlushesCnt                      int64
-	FlushesTotalTime                         int64
-	Mapped, Virtual, Resident, NonMapped     int64
-	Faults, FaultsCnt                        int64
-	HighestLocked                            *LockStatus
-	QueuedReaders, QueuedWriters             int64
-	ActiveReaders, ActiveWriters             int64
-	AvailableReaders, AvailableWriters       int64
-	TotalTicketsReaders, TotalTicketsWriters int64
-	NetIn, NetInCnt                          int64
-	NetOut, NetOutCnt                        int64
-	NumConnections                           int64
-	ReplSetName                              string
-	NodeType                                 string
-	NodeState                                string
-	NodeStateInt                             int64
-
-	// Replicated Metrics fields
-	ReplNetworkBytes                    int64
-	ReplNetworkGetmoresNum              int64
-	ReplNetworkGetmoresTotalMillis      int64
-	ReplNetworkOps                      int64
-	ReplBufferCount                     int64
-	ReplBufferSizeBytes                 int64
-	ReplApplyBatchesNum                 int64
-	ReplApplyBatchesTotalMillis         int64
-	ReplApplyOps                        int64
-	ReplExecutorPoolInProgressCount     int64
-	ReplExecutorQueuesNetworkInProgress int64
-	ReplExecutorQueuesSleepers          int64
-	ReplExecutorUnsignaledEvents        int64
-
-	// Cluster fields
-	JumboChunksCount int64
-
-	// DB stats field
-	DbStatsLines []DbStatLine
-
-	// Col Stats field
-	ColStatsLines []ColStatLine
-
-	// Shard stats
-	TotalInUse, TotalAvailable, TotalCreated, TotalRefreshing int64
-
-	// Shard Hosts stats field
-	ShardHostStatsLines map[string]ShardHostStatLine
-
-	// TCMalloc stats field
+	Time                                 time.Time
+	LastPrinted                          time.Time
+	Error                                error
+	CollectionLocks                      *CollectionLockStatus
+	ShardHostStatsLines                  map[string]ShardHostStatLine
+	OplogStats                           *OplogStats
+	HighestLocked                        *LockStatus
+	Host                                 string
+	NodeState                            string
+	NodeType                             string
+	ReplSetName                          string
+	Version                              string
+	Key                                  string
+	StorageEngine                        string
+	ColStatsLines                        []ColStatLine
+	DbStatsLines                         []DbStatLine
+	DeletedD                             int64
+	AppThreadsPageReadTime               int64
+	GetMoreCnt                           int64
+	Command                              int64
+	CommandCnt                           int64
+	Regular                              int64
+	Warning                              int64
+	Msg                                  int64
+	User                                 int64
+	Rollovers                            int64
+	WriteOpsCnt                          int64
+	WriteLatency                         int64
+	ReadOpsCnt                           int64
+	ReadLatency                          int64
+	CommandOpsCnt                        int64
+	CommandLatency                       int64
+	Passes                               int64
+	PassesCnt                            int64
+	DeletedDocuments                     int64
+	DeletedDocumentsCnt                  int64
+	TimedOutC                            int64
+	TimedOutCCnt                         int64
+	NoTimeoutC                           int64
+	NoTimeoutCCnt                        int64
+	PinnedC                              int64
+	PinnedCCnt                           int64
+	TotalC                               int64
+	TotalCCnt                            int64
+	DeleteCnt                            int64
+	InsertedD                            int64
+	ReturnedD                            int64
+	UpdatedD                             int64
+	AggregateCommandTotal                int64
+	AggregateCommandFailed               int64
+	CountCommandTotal                    int64
+	CountCommandFailed                   int64
+	DeleteCommandTotal                   int64
+	DeleteCommandFailed                  int64
+	DistinctCommandTotal                 int64
+	DistinctCommandFailed                int64
+	FindCommandTotal                     int64
+	FindCommandFailed                    int64
+	FindAndModifyCommandTotal            int64
+	QueryR                               int64
+	GetMoreCommandTotal                  int64
+	GetMoreCommandFailed                 int64
+	InsertCommandTotal                   int64
+	InsertCommandFailed                  int64
+	UpdateCommandTotal                   int64
+	UpdateCommandFailed                  int64
+	ScanAndOrderOp                       int64
+	WriteConflictsOp                     int64
+	TotalKeysScanned                     int64
+	TotalObjectsScanned                  int64
+	CurrentC                             int64
+	AvailableC                           int64
+	TotalCreatedC                        int64
+	UpdateR                              int64
+	CacheDirtyPercent                    float64
+	CacheUsedPercent                     float64
+	TrackedDirtyBytes                    int64
+	CurrentCachedBytes                   int64
+	MaxBytesConfigured                   int64
+	AppThreadsPageReadCount              int64
+	QueryRCnt                            int64
+	AppThreadsPageWriteCount             int64
+	BytesWrittenFrom                     int64
+	BytesReadInto                        int64
+	PagesEvictedByAppThread              int64
+	PagesQueuedForEviction               int64
+	PagesReadIntoCache                   int64
+	PagesWrittenFromCache                int64
+	PagesRequestedFromCache              int64
+	ServerEvictingPages                  int64
+	WorkerThreadEvictingPages            int64
+	InternalPagesEvicted                 int64
+	ModifiedPagesEvicted                 int64
+	UnmodifiedPagesEvicted               int64
+	InsertR                              int64
+	InsertRCnt                           int64
+	FindAndModifyCommandFailed           int64
+	GetMore                              int64
+	Delete                               int64
+	UpdateRCnt                           int64
+	DeleteR                              int64
+	DeleteRCnt                           int64
+	GetMoreR                             int64
+	GetMoreRCnt                          int64
+	CommandR                             int64
+	CommandRCnt                          int64
+	ReplLag                              int64
+	UpdateCnt                            int64
+	Flushes                              int64
+	FlushesCnt                           int64
+	FlushesTotalTime                     int64
+	Mapped                               int64
+	Virtual                              int64
+	Resident                             int64
+	NonMapped                            int64
+	Faults                               int64
+	FaultsCnt                            int64
+	Update                               int64
+	QueuedReaders                        int64
+	QueuedWriters                        int64
+	ActiveReaders                        int64
+	ActiveWriters                        int64
+	AvailableReaders                     int64
+	AvailableWriters                     int64
+	TotalTicketsReaders                  int64
+	TotalTicketsWriters                  int64
+	NetIn                                int64
+	NetInCnt                             int64
+	NetOut                               int64
+	NetOutCnt                            int64
+	NumConnections                       int64
+	QueryCnt                             int64
+	Query                                int64
+	InsertCnt                            int64
+	NodeStateInt                         int64
+	ReplNetworkBytes                     int64
+	ReplNetworkGetmoresNum               int64
+	ReplNetworkGetmoresTotalMillis       int64
+	ReplNetworkOps                       int64
+	ReplBufferCount                      int64
+	ReplBufferSizeBytes                  int64
+	ReplApplyBatchesNum                  int64
+	ReplApplyBatchesTotalMillis          int64
+	ReplApplyOps                         int64
+	ReplExecutorPoolInProgressCount      int64
+	ReplExecutorQueuesNetworkInProgress  int64
+	ReplExecutorQueuesSleepers           int64
+	ReplExecutorUnsignaledEvents         int64
+	JumboChunksCount                     int64
+	Insert                               int64
+	UptimeNanos                          int64
+	TotalInUse                           int64
+	TotalAvailable                       int64
+	TotalCreated                         int64
+	TotalRefreshing                      int64
+	StorageFreelistSearchScanned         int64
 	TCMallocCurrentAllocatedBytes        int64
 	TCMallocHeapSize                     int64
 	TCMallocCentralCacheFreeBytes        int64
@@ -788,11 +975,9 @@ type StatLine struct {
 	TCMallocPageheapTotalDecommitBytes   int64
 	TCMallocPageheapReserveCount         int64
 	TCMallocPageheapTotalReserveBytes    int64
-
-	// Storage stats field
 	StorageFreelistSearchBucketExhausted int64
 	StorageFreelistSearchRequests        int64
-	StorageFreelistSearchScanned         int64
+	IsMongos                             bool
 }
 
 type DbStatLine struct {

--- a/plugins/inputs/ping/ping_notwindows.go
+++ b/plugins/inputs/ping/ping_notwindows.go
@@ -162,13 +162,13 @@ func (p *Ping) args(url string, system string) []string {
 
 // processPingOutput takes in a string output from the ping command, like:
 //
-//     ping www.google.com (173.194.115.84): 56 data bytes
-//     64 bytes from 173.194.115.84: icmp_seq=0 ttl=54 time=52.172 ms
-//     64 bytes from 173.194.115.84: icmp_seq=1 ttl=54 time=34.843 ms
+//	ping www.google.com (173.194.115.84): 56 data bytes
+//	64 bytes from 173.194.115.84: icmp_seq=0 ttl=54 time=52.172 ms
+//	64 bytes from 173.194.115.84: icmp_seq=1 ttl=54 time=34.843 ms
 //
-//     --- www.google.com ping statistics ---
-//     2 packets transmitted, 2 packets received, 0.0% packet loss
-//     round-trip min/avg/max/stddev = 34.843/43.508/52.172/8.664 ms
+//	--- www.google.com ping statistics ---
+//	2 packets transmitted, 2 packets received, 0.0% packet loss
+//	round-trip min/avg/max/stddev = 34.843/43.508/52.172/8.664 ms
 //
 // It returns (<transmitted packets>, <received packets>, <average response>)
 func processPingOutput(out string) (int, int, int, float64, float64, float64, float64, []float64, error) {

--- a/plugins/inputs/processes/processes_test.go
+++ b/plugins/inputs/processes/processes_test.go
@@ -19,8 +19,8 @@ import (
 func TestProcesses(t *testing.T) {
 	tester := tester{}
 	processes := &Processes{
-		Log: testutil.Logger{},
-		execPS: testExecPS("STAT\n		Ss  \n		S   \n		Z   \n		R   \n		S<  \n		SNs \n		Ss+ \n		\n		\n"),
+		Log:          testutil.Logger{},
+		execPS:       testExecPS("STAT\n		Ss  \n		S   \n		Z   \n		R   \n		S<  \n		SNs \n		Ss+ \n		\n		\n"),
 		readProcFile: tester.testProcFile,
 	}
 	var acc testutil.Accumulator

--- a/plugins/inputs/redis/redis.go
+++ b/plugins/inputs/redis/redis.go
@@ -19,9 +19,9 @@ import (
 )
 
 type command struct {
-	Command []interface{}
 	Field   string
 	Type    string
+	Command []interface{}
 }
 
 type Redis struct {
@@ -361,7 +361,9 @@ func gatherInfoOutput(
 
 // Parse the special Keyspace line at end of redis stats
 // This is a special line that looks something like:
-//     db0:keys=2,expires=0,avg_ttl=0
+//
+//	db0:keys=2,expires=0,avg_ttl=0
+//
 // And there is one for each db on the redis instance
 func gatherKeyspaceLine(
 	name string,
@@ -390,7 +392,9 @@ func gatherKeyspaceLine(
 
 // Parse the special cmdstat lines.
 // Example:
-//     cmdstat_publish:calls=33791,usec=208789,usec_per_call=6.18
+//
+//	cmdstat_publish:calls=33791,usec=208789,usec_per_call=6.18
+//
 // Tag: cmdstat=publish; Fields: calls=33791i,usec=208789i,usec_per_call=6.18
 func gatherCommandstateLine(
 	name string,
@@ -435,7 +439,9 @@ func gatherCommandstateLine(
 
 // Parse the special Replication line
 // Example:
-//     slave0:ip=127.0.0.1,port=7379,state=online,offset=4556468,lag=0
+//
+//	slave0:ip=127.0.0.1,port=7379,state=online,offset=4556468,lag=0
+//
 // This line will only be visible when a node has a replica attached.
 func gatherReplicationLine(
 	name string,

--- a/plugins/inputs/sensors/sensors.go
+++ b/plugins/inputs/sensors/sensors.go
@@ -57,7 +57,9 @@ func (s *Sensors) Gather(ctx context.Context, acc cua.Accumulator) error {
 }
 
 // parse forks the command:
-//     sensors -u -A
+//
+//	sensors -u -A
+//
 // and parses the output to add it to the cua.Accumulator.
 func (s *Sensors) parse(acc cua.Accumulator) error {
 	tags := map[string]string{}

--- a/plugins/inputs/snmp/snmp.go
+++ b/plugins/inputs/snmp/snmp.go
@@ -792,18 +792,19 @@ func (s *Snmp) getConnection(idx int) (snmpConnection, error) {
 }
 
 // fieldConvert converts from any type according to the conv specification
-//  "float"/"float(0)" will convert the value into a float.
-//  "float(X)" will convert the value into a float, and then move the decimal before Xth right-most digit.
-//  "int" will convert the value into an integer.
-//  "hwaddr" will convert the value into a MAC address.
-//  "ipaddr" will convert the value into into an IP address.
-//  "string" will force convert a byte slice into a string, nonprintable characters will be converted to '_'
-//           if the value is not a byte slice, it is returned as-is
-//  ""       will convert a byte slice into a string (if all runes are printable, otherwise it will return a hex string)
-//           if the value is not a byte slice, it is returned as-is
-//  "regex" will extract a value from the input
-//  "timestamp" convert string to unix epoch based on timestamp_layout
-//              see: https://pkg.go.dev/time#pkg-constants and https://pkg.go.dev/time#Parse
+//
+//	"float"/"float(0)" will convert the value into a float.
+//	"float(X)" will convert the value into a float, and then move the decimal before Xth right-most digit.
+//	"int" will convert the value into an integer.
+//	"hwaddr" will convert the value into a MAC address.
+//	"ipaddr" will convert the value into into an IP address.
+//	"string" will force convert a byte slice into a string, nonprintable characters will be converted to '_'
+//	         if the value is not a byte slice, it is returned as-is
+//	""       will convert a byte slice into a string (if all runes are printable, otherwise it will return a hex string)
+//	         if the value is not a byte slice, it is returned as-is
+//	"regex" will extract a value from the input
+//	"timestamp" convert string to unix epoch based on timestamp_layout
+//	            see: https://pkg.go.dev/time#pkg-constants and https://pkg.go.dev/time#Parse
 func fieldConvert(f Field, sv gosnmp.SnmpPDU) (interface{}, error) {
 
 	v := sv.Value

--- a/plugins/inputs/snmp_deprecated/snmp_test.go
+++ b/plugins/inputs/snmp_deprecated/snmp_test.go
@@ -22,8 +22,8 @@ import (
 )
 
 type testSNMPConnection struct {
-	host   string
 	values map[string]interface{}
+	host   string
 }
 
 func (tsc *testSNMPConnection) Host() string {
@@ -698,48 +698,200 @@ func TestGather_host(t *testing.T) {
 
 func TestFieldConvert(t *testing.T) {
 	testTable := []struct {
-		input    gosnmp.SnmpPDU
-		conv     string
 		expected interface{}
+		conv     string
+		input    gosnmp.SnmpPDU
 	}{
-		{gosnmp.SnmpPDU{Value: []byte("foo")}, "", string("foo")},
-		{gosnmp.SnmpPDU{Value: "0.123"}, "float", float64(0.123)},
-		{gosnmp.SnmpPDU{Value: []byte("0.123")}, "float", float64(0.123)},
-		{gosnmp.SnmpPDU{Value: float32(0.123)}, "float", float64(float32(0.123))},
-		{gosnmp.SnmpPDU{Value: float64(0.123)}, "float", float64(0.123)},
-		{gosnmp.SnmpPDU{Value: 123}, "float", float64(123)},
-		{gosnmp.SnmpPDU{Value: 123}, "float(0)", float64(123)},
-		{gosnmp.SnmpPDU{Value: 123}, "float(4)", float64(0.0123)},
-		{gosnmp.SnmpPDU{Value: int8(123)}, "float(3)", float64(0.123)},
-		{gosnmp.SnmpPDU{Value: int16(123)}, "float(3)", float64(0.123)},
-		{gosnmp.SnmpPDU{Value: int32(123)}, "float(3)", float64(0.123)},
-		{gosnmp.SnmpPDU{Value: int64(123)}, "float(3)", float64(0.123)},
-		{gosnmp.SnmpPDU{Value: uint(123)}, "float(3)", float64(0.123)},
-		{gosnmp.SnmpPDU{Value: uint8(123)}, "float(3)", float64(0.123)},
-		{gosnmp.SnmpPDU{Value: uint16(123)}, "float(3)", float64(0.123)},
-		{gosnmp.SnmpPDU{Value: uint32(123)}, "float(3)", float64(0.123)},
-		{gosnmp.SnmpPDU{Value: uint64(123)}, "float(3)", float64(0.123)},
-		{gosnmp.SnmpPDU{Value: "123"}, "int", int64(123)},
-		{gosnmp.SnmpPDU{Value: []byte("123")}, "int", int64(123)},
-		{gosnmp.SnmpPDU{Value: "123123123123"}, "int", int64(123123123123)},
-		{gosnmp.SnmpPDU{Value: []byte("123123123123")}, "int", int64(123123123123)},
-		{gosnmp.SnmpPDU{Value: float32(12.3)}, "int", int64(12)},
-		{gosnmp.SnmpPDU{Value: float64(12.3)}, "int", int64(12)},
-		{gosnmp.SnmpPDU{Value: int(123)}, "int", int64(123)},
-		{gosnmp.SnmpPDU{Value: int8(123)}, "int", int64(123)},
-		{gosnmp.SnmpPDU{Value: int16(123)}, "int", int64(123)},
-		{gosnmp.SnmpPDU{Value: int32(123)}, "int", int64(123)},
-		{gosnmp.SnmpPDU{Value: int64(123)}, "int", int64(123)},
-		{gosnmp.SnmpPDU{Value: uint(123)}, "int", int64(123)},
-		{gosnmp.SnmpPDU{Value: uint8(123)}, "int", int64(123)},
-		{gosnmp.SnmpPDU{Value: uint16(123)}, "int", int64(123)},
-		{gosnmp.SnmpPDU{Value: uint32(123)}, "int", int64(123)},
-		{gosnmp.SnmpPDU{Value: uint64(123)}, "int", int64(123)},
-		{gosnmp.SnmpPDU{Value: []byte("abcdef")}, "hwaddr", "61:62:63:64:65:66"},
-		{gosnmp.SnmpPDU{Value: "abcdef"}, "hwaddr", "61:62:63:64:65:66"},
-		{gosnmp.SnmpPDU{Value: []byte("abcd")}, "ipaddr", "97.98.99.100"},
-		{gosnmp.SnmpPDU{Value: "abcd"}, "ipaddr", "97.98.99.100"},
-		{gosnmp.SnmpPDU{Value: []byte("abcdefghijklmnop")}, "ipaddr", "6162:6364:6566:6768:696a:6b6c:6d6e:6f70"},
+		{
+			input:    gosnmp.SnmpPDU{Value: []byte("foo")},
+			conv:     "",
+			expected: string("foo"),
+		},
+		{
+			input:    gosnmp.SnmpPDU{Value: "0.123"},
+			conv:     "float",
+			expected: float64(0.123),
+		},
+		{
+			input:    gosnmp.SnmpPDU{Value: []byte("0.123")},
+			conv:     "float",
+			expected: float64(0.123),
+		},
+		{
+			input:    gosnmp.SnmpPDU{Value: float32(0.123)},
+			conv:     "float",
+			expected: float64(float32(0.123)),
+		},
+		{
+			input:    gosnmp.SnmpPDU{Value: float64(0.123)},
+			conv:     "float",
+			expected: float64(0.123),
+		},
+		{
+			input:    gosnmp.SnmpPDU{Value: 123},
+			conv:     "float",
+			expected: float64(123),
+		},
+		{
+			input:    gosnmp.SnmpPDU{Value: 123},
+			conv:     "float(0)",
+			expected: float64(123),
+		},
+		{
+			input:    gosnmp.SnmpPDU{Value: 123},
+			conv:     "float(4)",
+			expected: float64(0.0123),
+		},
+		{
+			input:    gosnmp.SnmpPDU{Value: int8(123)},
+			conv:     "float(3)",
+			expected: float64(0.123),
+		},
+		{
+			input:    gosnmp.SnmpPDU{Value: int16(123)},
+			conv:     "float(3)",
+			expected: float64(0.123),
+		},
+		{
+			input:    gosnmp.SnmpPDU{Value: int32(123)},
+			conv:     "float(3)",
+			expected: float64(0.123),
+		},
+		{
+			input:    gosnmp.SnmpPDU{Value: int64(123)},
+			conv:     "float(3)",
+			expected: float64(0.123),
+		},
+		{
+			input:    gosnmp.SnmpPDU{Value: uint(123)},
+			conv:     "float(3)",
+			expected: float64(0.123),
+		},
+		{
+			input:    gosnmp.SnmpPDU{Value: uint8(123)},
+			conv:     "float(3)",
+			expected: float64(0.123),
+		},
+		{
+			input:    gosnmp.SnmpPDU{Value: uint16(123)},
+			conv:     "float(3)",
+			expected: float64(0.123),
+		},
+		{
+			input:    gosnmp.SnmpPDU{Value: uint32(123)},
+			conv:     "float(3)",
+			expected: float64(0.123),
+		},
+		{
+			input:    gosnmp.SnmpPDU{Value: uint64(123)},
+			conv:     "float(3)",
+			expected: float64(0.123),
+		},
+		{
+			input:    gosnmp.SnmpPDU{Value: "123"},
+			conv:     "int",
+			expected: int64(123),
+		},
+		{
+			input:    gosnmp.SnmpPDU{Value: []byte("123")},
+			conv:     "int",
+			expected: int64(123),
+		},
+		{
+			input:    gosnmp.SnmpPDU{Value: "123123123123"},
+			conv:     "int",
+			expected: int64(123123123123),
+		},
+		{
+			input:    gosnmp.SnmpPDU{Value: []byte("123123123123")},
+			conv:     "int",
+			expected: int64(123123123123),
+		},
+		{
+			input:    gosnmp.SnmpPDU{Value: float32(12.3)},
+			conv:     "int",
+			expected: int64(12),
+		},
+		{
+			input:    gosnmp.SnmpPDU{Value: float64(12.3)},
+			conv:     "int",
+			expected: int64(12),
+		},
+		{
+			input:    gosnmp.SnmpPDU{Value: int(123)},
+			conv:     "int",
+			expected: int64(123),
+		},
+		{
+			input:    gosnmp.SnmpPDU{Value: int8(123)},
+			conv:     "int",
+			expected: int64(123),
+		},
+		{
+			input:    gosnmp.SnmpPDU{Value: int16(123)},
+			conv:     "int",
+			expected: int64(123),
+		},
+		{
+			input:    gosnmp.SnmpPDU{Value: int32(123)},
+			conv:     "int",
+			expected: int64(123),
+		},
+		{
+			input:    gosnmp.SnmpPDU{Value: int64(123)},
+			conv:     "int",
+			expected: int64(123),
+		},
+		{
+			input:    gosnmp.SnmpPDU{Value: uint(123)},
+			conv:     "int",
+			expected: int64(123),
+		},
+		{
+			input:    gosnmp.SnmpPDU{Value: uint8(123)},
+			conv:     "int",
+			expected: int64(123),
+		},
+		{
+			input:    gosnmp.SnmpPDU{Value: uint16(123)},
+			conv:     "int",
+			expected: int64(123),
+		},
+		{
+			input:    gosnmp.SnmpPDU{Value: uint32(123)},
+			conv:     "int",
+			expected: int64(123),
+		},
+		{
+			input:    gosnmp.SnmpPDU{Value: uint64(123)},
+			conv:     "int",
+			expected: int64(123),
+		},
+		{
+			input:    gosnmp.SnmpPDU{Value: []byte("abcdef")},
+			conv:     "hwaddr",
+			expected: "61:62:63:64:65:66",
+		},
+		{
+			input:    gosnmp.SnmpPDU{Value: "abcdef"},
+			conv:     "hwaddr",
+			expected: "61:62:63:64:65:66",
+		},
+		{
+			input:    gosnmp.SnmpPDU{Value: []byte("abcd")},
+			conv:     "ipaddr",
+			expected: "97.98.99.100",
+		},
+		{
+			input:    gosnmp.SnmpPDU{Value: "abcd"},
+			conv:     "ipaddr",
+			expected: "97.98.99.100",
+		},
+		{
+			input:    gosnmp.SnmpPDU{Value: []byte("abcdefghijklmnop")},
+			conv:     "ipaddr",
+			expected: "6162:6364:6566:6768:696a:6b6c:6d6e:6f70",
+		},
 	}
 
 	for _, tc := range testTable {

--- a/plugins/inputs/sqlserver/azuresqlqueries.go
+++ b/plugins/inputs/sqlserver/azuresqlqueries.go
@@ -4,9 +4,9 @@ import (
 	_ "github.com/denisenkom/go-mssqldb" // go-mssqldb initialization
 )
 
-//------------------------------------------------------------------------------------------------
-//------------------ Azure SQL Database ------------------------------------------------------
-//------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
+// ------------------ Azure SQL Database ------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Only executed if AzureDB flag is set
 const sqlAzureDBResourceStats string = `
 IF SERVERPROPERTY('EngineEdition') <> 5 BEGIN /*not Azure SQL DB*/
@@ -655,9 +655,9 @@ SELECT
 FROM sys.dm_os_schedulers AS s
 `
 
-//------------------------------------------------------------------------------------------------
-//------------------ Azure Managed Instance ------------------------------------------------------
-//------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
+// ------------------ Azure Managed Instance ------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 const sqlAzureMIProperties = `
 IF SERVERPROPERTY('EngineEdition') <> 8 BEGIN /*not Azure Managed Instance*/
 	DECLARE @ErrorMessage AS nvarchar(500) = 'Circonus Unified Agent - Connection string Server:'+ @@SERVERNAME + ',Database:' + DB_NAME() +' is not an Azure Managed Instance. Check the database_type parameter in the configuration.';

--- a/plugins/inputs/sqlserver/sqlqueriesV2.go
+++ b/plugins/inputs/sqlserver/sqlqueriesV2.go
@@ -388,8 +388,11 @@ EXEC sp_executesql @SqlStatement
 
 /*
 This string defines a SQL statements to retrieve Performance Counters as documented here -
+
 	SQL Server Performance Objects - https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/use-sql-server-objects?view=sql-server-ver15#SQLServerPOs
+
 Some of the specific objects used are -
+
 	MSSQL$*:Access Methods - https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/sql-server-access-methods-object?view=sql-server-ver15
 	MSSQL$*:Buffer Manager - https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/sql-server-buffer-manager-object?view=sql-server-ver15
 	MSSQL$*:Databases - https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/sql-server-databases-object?view=sql-server-ver15

--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -16,13 +16,13 @@ import (
 
 // SQLServer struct
 type SQLServer struct {
-	Servers       []string `toml:"servers"`
-	QueryVersion  int      `toml:"query_version"`
-	AzureDB       bool     `toml:"azuredb"`
+	queries       MapQuery
 	DatabaseType  string   `toml:"database_type"`
+	Servers       []string `toml:"servers"`
 	IncludeQuery  []string `toml:"include_query"`
 	ExcludeQuery  []string `toml:"exclude_query"`
-	queries       MapQuery
+	QueryVersion  int      `toml:"query_version"`
+	AzureDB       bool     `toml:"azuredb"`
 	isInitialized bool
 }
 
@@ -30,8 +30,8 @@ type SQLServer struct {
 type Query struct {
 	ScriptName     string
 	Script         string
-	ResultByRow    bool
 	OrderedColumns []string
+	ResultByRow    bool
 }
 
 // MapQuery type

--- a/plugins/inputs/statsd/running_stats.go
+++ b/plugins/inputs/statsd/running_stats.go
@@ -37,7 +37,8 @@ const defaultPercentileLimit = 1000
 // RunningStats calculates a running mean, variance, standard deviation,
 // lower bound, upper bound, count, and can calculate estimated percentiles.
 // It is based on the incremental algorithm described here:
-//    https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
+//
+//	https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
 type RunningStats struct {
 	perc      []float64
 	k         float64

--- a/plugins/inputs/statsd_deprecated/datadog_test.go
+++ b/plugins/inputs/statsd_deprecated/datadog_test.go
@@ -11,17 +11,17 @@ import (
 func TestEventGather(t *testing.T) {
 	now := time.Now()
 	type expected struct {
-		title  string
 		tags   map[string]string
 		fields map[string]interface{}
+		title  string
 	}
 	tests := []struct {
+		now      time.Time
+		expected expected
 		name     string
 		message  string
 		hostname string
-		now      time.Time
 		err      bool
-		expected expected
 	}{{
 		name:     "basic",
 		message:  "_e{10,9}:test title|test text",
@@ -108,16 +108,16 @@ func TestEvents(t *testing.T) {
 		hostname string
 	}
 	type expected struct {
-		title          string
-		text           interface{}
 		now            time.Time
+		text           interface{}
 		ts             interface{}
-		priority       string
-		source         string
 		alertType      interface{}
-		aggregationKey string
 		sourceTypeName interface{}
 		checkTags      map[string]string
+		title          string
+		priority       string
+		source         string
+		aggregationKey string
 	}
 
 	tests := []struct {

--- a/plugins/inputs/statsd_deprecated/running_stats.go
+++ b/plugins/inputs/statsd_deprecated/running_stats.go
@@ -11,23 +11,22 @@ const defaultPercentileLimit = 1000
 // RunningStats calculates a running mean, variance, standard deviation,
 // lower bound, upper bound, count, and can calculate estimated percentiles.
 // It is based on the incremental algorithm described here:
-//    https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
+//
+//	https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
 type RunningStats struct {
-	k   float64
-	n   int64
-	ex  float64
-	ex2 float64
-
 	// Array used to calculate estimated percentiles
 	// We will store a maximum of PercLimit values, at which point we will start
 	// randomly replacing old values, hence it is an estimated percentile.
-	perc      []float64
+	perc []float64
+
+	k         float64
+	n         int64
+	ex        float64
+	ex2       float64
 	PercLimit int
-
-	sum float64
-
-	lower float64
-	upper float64
+	sum       float64
+	lower     float64
+	upper     float64
 
 	// cache if we have sorted the list so that we never re-sort a sorted list,
 	// which can have very bad performance.

--- a/plugins/inputs/statsd_deprecated/statsd_test.go
+++ b/plugins/inputs/statsd_deprecated/statsd_test.go
@@ -518,19 +518,19 @@ func TestParse_InvalidSampleRate(t *testing.T) {
 	}
 
 	counterValidations := []struct {
+		cache map[string]cachedcounter
 		name  string
 		value int64
-		cache map[string]cachedcounter
 	}{
 		{
-			"invalid_sample_rate",
-			45,
-			s.counters,
+			name:  "invalid_sample_rate",
+			value: 45,
+			cache: s.counters,
 		},
 		{
-			"invalid_sample_rate_2",
-			45,
-			s.counters,
+			name:  "invalid_sample_rate_2",
+			value: 45,
+			cache: s.counters,
 		},
 	}
 
@@ -742,23 +742,23 @@ func TestParse_TemplateFields(t *testing.T) {
 
 	counterTests := []struct {
 		name  string
-		value int64
 		field string
+		value int64
 	}{
 		{
-			"my_counter",
-			2,
-			"f1",
+			name:  "my_counter",
+			value: 2,
+			field: "f1",
 		},
 		{
-			"my_counter",
-			1,
-			"f2",
+			name:  "my_counter",
+			value: 1,
+			field: "f2",
 		},
 		{
-			"my_counter",
-			110,
-			"f3",
+			name:  "my_counter",
+			value: 110,
+			field: "f3",
 		},
 	}
 	// Validate counters
@@ -771,18 +771,18 @@ func TestParse_TemplateFields(t *testing.T) {
 
 	gaugeTests := []struct {
 		name  string
-		value float64
 		field string
+		value float64
 	}{
 		{
-			"my_gauge",
-			0.9,
-			"f1",
+			name:  "my_gauge",
+			value: 0.9,
+			field: "f1",
 		},
 		{
-			"my_gauge",
-			10.1,
-			"f2",
+			name:  "my_gauge",
+			value: 10.1,
+			field: "f2",
 		},
 	}
 	// Validate gauges
@@ -795,18 +795,18 @@ func TestParse_TemplateFields(t *testing.T) {
 
 	setTests := []struct {
 		name  string
-		value int64
 		field string
+		value int64
 	}{
 		{
-			"my_set",
-			2,
-			"f1",
+			name:  "my_set",
+			value: 2,
+			field: "f1",
 		},
 		{
-			"my_set",
-			1,
-			"f2",
+			name:  "my_set",
+			value: 1,
+			field: "f2",
 		},
 	}
 	// Validate sets
@@ -830,29 +830,29 @@ func TestParse_Tags(t *testing.T) {
 	s := NewTestStatsd()
 
 	tests := []struct {
+		tags   map[string]string
 		bucket string
 		name   string
-		tags   map[string]string
 	}{
 		{
-			"cpu.idle,host=localhost",
-			"cpu_idle",
-			map[string]string{
+			bucket: "cpu.idle,host=localhost",
+			name:   "cpu_idle",
+			tags: map[string]string{
 				"host": "localhost",
 			},
 		},
 		{
-			"cpu.idle,host=localhost,region=west",
-			"cpu_idle",
-			map[string]string{
+			bucket: "cpu.idle,host=localhost,region=west",
+			name:   "cpu_idle",
+			tags: map[string]string{
 				"host":   "localhost",
 				"region": "west",
 			},
 		},
 		{
-			"cpu.idle,host=localhost,color=red,region=west",
-			"cpu_idle",
-			map[string]string{
+			bucket: "cpu.idle,host=localhost,color=red,region=west",
+			name:   "cpu_idle",
+			tags: map[string]string{
 				"host":   "localhost",
 				"region": "west",
 				"color":  "red",

--- a/plugins/inputs/sysstat/sysstat.go
+++ b/plugins/inputs/sysstat/sysstat.go
@@ -175,7 +175,9 @@ func (s *Sysstat) Gather(ctx context.Context, acc cua.Accumulator) error {
 
 // collect collects sysstat data with the collector utility sadc.
 // It runs the following command:
-//     Sadc -S <Activity1> -S <Activity2> ... <collectInterval> 2 tmpFile
+//
+//	Sadc -S <Activity1> -S <Activity2> ... <collectInterval> 2 tmpFile
+//
 // The above command collects system metrics during <collectInterval> and
 // saves it in binary form to tmpFile.
 func (s *Sysstat) collect() error {
@@ -230,7 +232,9 @@ func withCLocale(cmd *exec.Cmd) *exec.Cmd {
 }
 
 // parse runs Sadf on the previously saved tmpFile:
-//    Sadf -p -- -p <option> tmpFile
+//
+//	Sadf -p -- -p <option> tmpFile
+//
 // and parses the output to add it to the cua.Accumulator acc.
 func (s *Sysstat) parse(acc cua.Accumulator, option string, ts time.Time) error {
 	cmd := execCommand(s.Sadf, s.sadfOptions(option)...)

--- a/plugins/inputs/win_eventlog/event.go
+++ b/plugins/inputs/win_eventlog/event.go
@@ -1,8 +1,9 @@
 //go:build windows
 // +build windows
 
-//revive:disable-next-line:var-naming
 // Package win_eventlog Input plugin to collect Windows Event Log messages
+//
+//revive:disable-next-line:var-naming
 package wineventlog
 
 // Event is the event entry representation

--- a/plugins/inputs/win_eventlog/syscall_windows.go
+++ b/plugins/inputs/win_eventlog/syscall_windows.go
@@ -1,8 +1,9 @@
 //go:build windows
 // +build windows
 
-//revive:disable-next-line:var-naming
 // Package win_eventlog Input plugin to collect Windows Event Log messages
+//
+//revive:disable-next-line:var-naming
 package wineventlog
 
 import "syscall"

--- a/plugins/inputs/win_eventlog/util.go
+++ b/plugins/inputs/win_eventlog/util.go
@@ -1,8 +1,9 @@
 //go:build windows
 // +build windows
 
-//revive:disable-next-line:var-naming
 // Package win_eventlog Input plugin to collect Windows Event Log messages
+//
+//revive:disable-next-line:var-naming
 package wineventlog
 
 import (

--- a/plugins/inputs/win_eventlog/util_test.go
+++ b/plugins/inputs/win_eventlog/util_test.go
@@ -1,8 +1,9 @@
 //go:build windows
 // +build windows
 
-//revive:disable-next-line:var-naming
 // Package win_eventlog Input plugin to collect Windows Event Log messages
+//
+//revive:disable-next-line:var-naming
 package wineventlog
 
 import (

--- a/plugins/inputs/win_eventlog/win_eventlog.go
+++ b/plugins/inputs/win_eventlog/win_eventlog.go
@@ -1,8 +1,9 @@
 //go:build windows
 // +build windows
 
-//revive:disable-next-line:var-naming
 // Package win_eventlog Input plugin to collect Windows Event Log messages
+//
+//revive:disable-next-line:var-naming
 package wineventlog
 
 import (

--- a/plugins/inputs/win_eventlog/win_eventlog_notwindows.go
+++ b/plugins/inputs/win_eventlog/win_eventlog_notwindows.go
@@ -1,6 +1,7 @@
 //go:build !windows
 // +build !windows
 
-//revive:disable-next-line:var-naming
 // Package win_eventlog Input plugin to collect Windows Event Log messages
+//
+//revive:disable-next-line:var-naming
 package wineventlog

--- a/plugins/inputs/win_eventlog/win_eventlog_test.go
+++ b/plugins/inputs/win_eventlog/win_eventlog_test.go
@@ -1,8 +1,9 @@
 //go:build windows
 // +build windows
 
-//revive:disable-next-line:var-naming
 // Package win_eventlog Input plugin to collect Windows Event Log messages
+//
+//revive:disable-next-line:var-naming
 package wineventlog
 
 import (

--- a/plugins/inputs/win_eventlog/zsyscall_windows.go
+++ b/plugins/inputs/win_eventlog/zsyscall_windows.go
@@ -1,8 +1,9 @@
 //go:build windows
 // +build windows
 
-//revive:disable-next-line:var-naming
 // Package win_eventlog Input plugin to collect Windows Event Log messages
+//
+//revive:disable-next-line:var-naming
 package wineventlog
 
 import (

--- a/plugins/inputs/win_perf_counters/pdh.go
+++ b/plugins/inputs/win_perf_counters/pdh.go
@@ -218,7 +218,7 @@ func init() {
 // full implementation of the pdh.dll API, except with a GUI and all that. The registry setting also provides an
 // interface to the available counters, and can be found at the following key:
 //
-// 	HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Perflib\CurrentLanguage
+//	HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Perflib\CurrentLanguage
 //
 // This registry key contains several values as follows:
 //
@@ -287,9 +287,9 @@ func PdhCloseQuery(hQuery PdhHQuery) uint32 {
 // of the counter can be extracted with PdhGetFormattedCounterValue(). For example, the following code
 // requires at least two calls:
 //
-// 	var handle win.PDH_HQUERY
-// 	var counterHandle win.PDH_HCOUNTER
-// 	ret := win.PdhOpenQuery(0, 0, &handle)
+//	var handle win.PDH_HQUERY
+//	var counterHandle win.PDH_HCOUNTER
+//	ret := win.PdhOpenQuery(0, 0, &handle)
 //	ret = win.PdhAddEnglishCounter(handle, "\\Processor(_Total)\\% Idle Time", 0, &counterHandle)
 //	var derp win.PDH_FMT_COUNTERVALUE_DOUBLE
 //
@@ -311,7 +311,6 @@ func PdhCollectQueryData(hQuery PdhHQuery) uint32 {
 
 // PdhCollectQueryDataWithTime queries data from perfmon, retrieving the device/windows timestamp from the node it was collected on.
 // Converts the filetime structure to a GO time class and returns the native time.
-//
 func PdhCollectQueryDataWithTime(hQuery PdhHQuery) (uint32, time.Time) {
 	var localFileTime FILETIME
 	ret, _, _ := pdhCollectQueryDataWithTime.Call(uintptr(hQuery), uintptr(unsafe.Pointer(&localFileTime)))

--- a/plugins/inputs/x509_cert/x509_cert.go
+++ b/plugins/inputs/x509_cert/x509_cert.go
@@ -43,11 +43,11 @@ const description = "Reads metrics from a SSL certificate"
 
 // X509Cert holds the configuration of the plugin.
 type X509Cert struct {
-	Sources    []string          `toml:"sources"`
-	Timeout    internal.Duration `toml:"timeout"`
-	ServerName string            `toml:"server_name"`
 	tlsCfg     *tls.Config
+	ServerName string `toml:"server_name"`
 	_tls.ClientConfig
+	Sources []string          `toml:"sources"`
+	Timeout internal.Duration `toml:"timeout"`
 }
 
 // Description returns description of the plugin.
@@ -259,7 +259,7 @@ func (c *X509Cert) Init() error {
 		return fmt.Errorf("TLSConfig: %w", err)
 	}
 	if tlsCfg == nil {
-		tlsCfg = &tls.Config{MinVersion: tls.VersionTLS12}
+		tlsCfg = &tls.Config{MinVersion: tls.VersionTLS12} // #nosec G402 // G402: TLS MinVersion too low.
 	}
 
 	c.tlsCfg = tlsCfg

--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -136,8 +136,8 @@ func TestGatherLocal(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		mode    os.FileMode
 		content string
+		mode    os.FileMode
 		error   bool
 	}{
 		{name: "permission denied", mode: 0001, error: true},

--- a/plugins/inputs/zipkin/cmd/thrift_serialize/thrift_serialize.go
+++ b/plugins/inputs/zipkin/cmd/thrift_serialize/thrift_serialize.go
@@ -18,8 +18,6 @@ Usage:
 If `deserialize` is set to true (false by default), the tool will interpret the input file as
 thrift, and write it as json to the output file.
 Otherwise, the input file will be interpreted as json, and the output will be encoded as thrift.
-
-
 */
 package main
 

--- a/plugins/inputs/zipkin/convert_test.go
+++ b/plugins/inputs/zipkin/convert_test.go
@@ -19,11 +19,11 @@ func TestLineProtocolConverter_Record(t *testing.T) {
 		t trace.Trace
 	}
 	tests := []struct {
-		name    string
 		fields  fields
+		name    string
 		args    args
-		wantErr bool
 		want    []testutil.Metric
+		wantErr bool
 	}{
 		{
 			name: "threespan",

--- a/plugins/inputs/zipkin/handler.go
+++ b/plugins/inputs/zipkin/handler.go
@@ -17,8 +17,8 @@ import (
 // SpanHandler is an implementation of a Handler which accepts zipkin thrift
 // span data and sends it to the recorder
 type SpanHandler struct {
-	Path     string
 	recorder Recorder
+	Path     string
 }
 
 // NewSpanHandler returns a new server instance given path to handle

--- a/plugins/inputs/zipkin/handler_test.go
+++ b/plugins/inputs/zipkin/handler_test.go
@@ -15,8 +15,8 @@ import (
 )
 
 type MockRecorder struct {
-	Data trace.Trace
 	Err  error
+	Data trace.Trace
 }
 
 func (m *MockRecorder) Record(t trace.Trace) error {

--- a/plugins/inputs/zipkin/zipkin_test.go
+++ b/plugins/inputs/zipkin/zipkin_test.go
@@ -19,10 +19,10 @@ func TestZipkinPlugin(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		datafile    string // data file which contains test data
+		datafile    string
 		contentType string
-		wantErr     bool
 		want        []testutil.Metric
+		wantErr     bool
 	}{
 		{
 			name:        "threespan",

--- a/plugins/outputs/circonus/metrics.go
+++ b/plugins/outputs/circonus/metrics.go
@@ -106,7 +106,8 @@ func (c *Circonus) metricProcessor(id int, metrics []cua.Metric, buf bytes.Buffe
 
 // handleGeneric constructs text and numeric metrics from a cua metric
 // Note: for certain cua metric types the actual fields may be either text OR numeric...
-//       and now potentially boolean as well as text and numeric.
+//
+//	and now potentially boolean as well as text and numeric.
 func (c *Circonus) handleGeneric(m cua.Metric) int64 {
 	dest := c.getMetricDestination(m)
 	if dest == nil {

--- a/plugins/parsers/grok/parser_test.go
+++ b/plugins/parsers/grok/parser_test.go
@@ -345,13 +345,13 @@ func TestParseEpoch(t *testing.T) {
 
 func TestParseEpochDecimal(t *testing.T) {
 	var tests = []struct {
-		name    string
-		line    string
-		noMatch bool
+		time    time.Time
 		err     error
 		tags    map[string]string
 		fields  map[string]interface{}
-		time    time.Time
+		name    string
+		line    string
+		noMatch bool
 	}{
 		{
 			name: "ns precision",
@@ -978,9 +978,9 @@ func TestNewlineInPatterns(t *testing.T) {
 func TestSyslogTimestamp(t *testing.T) {
 	currentYear := time.Now().Year()
 	tests := []struct {
+		expected time.Time
 		name     string
 		line     string
-		expected time.Time
 	}{
 		{
 			name:     "two digit day of month",

--- a/plugins/parsers/json_v2/parser_test.go
+++ b/plugins/parsers/json_v2/parser_test.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -21,7 +20,7 @@ import (
 
 func TestMultipleConfigs(t *testing.T) {
 	// Get all directories in testdata
-	folders, err := ioutil.ReadDir("testdata")
+	folders, err := os.ReadDir("testdata")
 	require.NoError(t, err)
 	// Make sure testdata contains data
 	require.Greater(t, len(folders), 0)

--- a/plugins/processors/topk/topk.go
+++ b/plugins/processors/topk/topk.go
@@ -22,21 +22,20 @@ const (
 )
 
 type TopK struct {
-	Period             internal.Duration
-	K                  int
-	GroupBy            []string `toml:"group_by"`
-	Fields             []string
+	lastAggregation    time.Time
+	tagsGlobs          filter.Filter
+	cache              map[string][]cua.Metric
+	aggFieldSet        map[string]bool
+	rankFieldSet       map[string]bool
+	AddGroupByTag      string `toml:"add_groupby_tag"`
 	Aggregation        string
-	Bottomk            bool
-	AddGroupByTag      string   `toml:"add_groupby_tag"`
 	AddRankFields      []string `toml:"add_rank_fields"`
 	AddAggregateFields []string `toml:"add_aggregate_fields"`
-
-	cache           map[string][]cua.Metric
-	tagsGlobs       filter.Filter
-	rankFieldSet    map[string]bool
-	aggFieldSet     map[string]bool
-	lastAggregation time.Time
+	Fields             []string
+	GroupBy            []string `toml:"group_by"`
+	Period             internal.Duration
+	K                  int
+	Bottomk            bool
 }
 
 func New() *TopK {
@@ -109,8 +108,8 @@ var sampleConfig = `
 `
 
 type MetricAggregation struct {
-	groupbykey string
 	values     map[string]float64
+	groupbykey string
 }
 
 func sortMetrics(metrics []MetricAggregation, field string, reverse bool) {

--- a/plugins/processors/topk/topk_test.go
+++ b/plugins/processors/topk/topk_test.go
@@ -11,8 +11,8 @@ import (
 
 // Key, value pair that represents a cua.Metric Field
 type field struct {
-	key string
 	val interface{}
+	key string
 }
 
 func fieldList(fields ...field) []field {
@@ -42,11 +42,12 @@ type metricChange struct {
 // Generate a new set of metrics from a set of changes. This is used to generate an answer which will be
 // compare against the output of the processor
 // NOTE: A `changeSet` is a map where the keys are the indices of the metrics to keep, and the values
-//       are list of new tags and fields to be added to the metric in that index.
-//       THE ORDERING OF THE NEW TAGS AND FIELDS MATTERS. When using reflect.DeepEqual to compare metrics,
-//       comparing metrics that have the same fields/tags added in different orders will return false, although
-//       they are semantically equal.
-//       Therefore the fields and tags must be in the same order that the processor would add them
+//
+//	are list of new tags and fields to be added to the metric in that index.
+//	THE ORDERING OF THE NEW TAGS AND FIELDS MATTERS. When using reflect.DeepEqual to compare metrics,
+//	comparing metrics that have the same fields/tags added in different orders will return false, although
+//	they are semantically equal.
+//	Therefore the fields and tags must be in the same order that the processor would add them
 func generateAns(input []cua.Metric, changeSet map[int]metricChange) []cua.Metric {
 	answer := []cua.Metric{}
 
@@ -174,7 +175,7 @@ func TestTopkMeanAddAggregateFields(t *testing.T) {
 	input := deepCopy(MetricsSet1)
 
 	// Generate the answer
-	chng := fieldList(field{"a_topk_aggregate", float64(28.044)})
+	chng := fieldList(field{key: "a_topk_aggregate", val: float64(28.044)})
 	changeSet := map[int]metricChange{
 		0: {newFields: chng},
 		1: {newFields: chng},
@@ -203,7 +204,7 @@ func TestTopkSumAddAggregateFields(t *testing.T) {
 	input := deepCopy(MetricsSet1)
 
 	// Generate the answer
-	chng := fieldList(field{"a_topk_aggregate", float64(140.22)})
+	chng := fieldList(field{key: "a_topk_aggregate", val: float64(140.22)})
 	changeSet := map[int]metricChange{
 		0: {newFields: chng},
 		1: {newFields: chng},
@@ -232,7 +233,7 @@ func TestTopkMaxAddAggregateFields(t *testing.T) {
 	input := deepCopy(MetricsSet1)
 
 	// Generate the answer
-	chng := fieldList(field{"a_topk_aggregate", float64(50.5)})
+	chng := fieldList(field{key: "a_topk_aggregate", val: float64(50.5)})
 	changeSet := map[int]metricChange{
 		0: {newFields: chng},
 		1: {newFields: chng},
@@ -261,7 +262,7 @@ func TestTopkMinAddAggregateFields(t *testing.T) {
 	input := deepCopy(MetricsSet1)
 
 	// Generate the answer
-	chng := fieldList(field{"a_topk_aggregate", float64(0.3)})
+	chng := fieldList(field{key: "a_topk_aggregate", val: float64(0.3)})
 	changeSet := map[int]metricChange{
 		0: {newFields: chng},
 		1: {newFields: chng},
@@ -291,10 +292,10 @@ func TestTopkGroupby1(t *testing.T) {
 
 	// Generate the answer
 	changeSet := map[int]metricChange{
-		2: {newFields: fieldList(field{"value_topk_aggregate", float64(74.18)})},
-		3: {newFields: fieldList(field{"value_topk_aggregate", float64(72)})},
-		4: {newFields: fieldList(field{"value_topk_aggregate", float64(163.22)})},
-		5: {newFields: fieldList(field{"value_topk_aggregate", float64(163.22)})},
+		2: {newFields: fieldList(field{key: "value_topk_aggregate", val: float64(74.18)})},
+		3: {newFields: fieldList(field{key: "value_topk_aggregate", val: float64(72)})},
+		4: {newFields: fieldList(field{key: "value_topk_aggregate", val: float64(163.22)})},
+		5: {newFields: fieldList(field{key: "value_topk_aggregate", val: float64(163.22)})},
 	}
 	answer := generateAns(input, changeSet)
 
@@ -315,9 +316,9 @@ func TestTopkGroupby2(t *testing.T) {
 	input := deepCopy(MetricsSet2)
 
 	// Generate the answer
-	chng1 := fieldList(field{"value_topk_aggregate", float64(66.805)})
-	chng2 := fieldList(field{"value_topk_aggregate", float64(72)})
-	chng3 := fieldList(field{"value_topk_aggregate", float64(81.61)})
+	chng1 := fieldList(field{key: "value_topk_aggregate", val: float64(66.805)})
+	chng2 := fieldList(field{key: "value_topk_aggregate", val: float64(72)})
+	chng3 := fieldList(field{key: "value_topk_aggregate", val: float64(81.61)})
 	changeSet := map[int]metricChange{
 		1: {newFields: chng1},
 		2: {newFields: chng1},
@@ -344,7 +345,7 @@ func TestTopkGroupby3(t *testing.T) {
 	input := deepCopy(MetricsSet2)
 
 	// Generate the answer
-	chng := fieldList(field{"value_topk_aggregate", float64(75.3)})
+	chng := fieldList(field{key: "value_topk_aggregate", val: float64(75.3)})
 	changeSet := map[int]metricChange{
 		4: {newFields: chng},
 		5: {newFields: chng},
@@ -372,10 +373,10 @@ func TestTopkGroupbyFields1(t *testing.T) {
 
 	// Generate the answer
 	changeSet := map[int]metricChange{
-		0: {newFields: fieldList(field{"A_topk_aggregate", float64(95.36)})},
-		1: {newFields: fieldList(field{"A_topk_aggregate", float64(39.01)})},
-		2: {newFields: fieldList(field{"A_topk_aggregate", float64(39.01)})},
-		5: {newFields: fieldList(field{"A_topk_aggregate", float64(29.45)})},
+		0: {newFields: fieldList(field{key: "A_topk_aggregate", val: float64(95.36)})},
+		1: {newFields: fieldList(field{key: "A_topk_aggregate", val: float64(39.01)})},
+		2: {newFields: fieldList(field{key: "A_topk_aggregate", val: float64(39.01)})},
+		5: {newFields: fieldList(field{key: "A_topk_aggregate", val: float64(29.45)})},
 	}
 	answer := generateAns(input, changeSet)
 
@@ -399,10 +400,10 @@ func TestTopkGroupbyFields2(t *testing.T) {
 
 	// Generate the answer
 	changeSet := map[int]metricChange{
-		0: {newFields: fieldList(field{"C_topk_aggregate", float64(72.41)})},
-		2: {newFields: fieldList(field{"B_topk_aggregate", float64(60.96)})},
-		4: {newFields: fieldList(field{"B_topk_aggregate", float64(81.55)}, field{"C_topk_aggregate", float64(49.96)})},
-		5: {newFields: fieldList(field{"C_topk_aggregate", float64(49.96)})},
+		0: {newFields: fieldList(field{key: "C_topk_aggregate", val: float64(72.41)})},
+		2: {newFields: fieldList(field{key: "B_topk_aggregate", val: float64(60.96)})},
+		4: {newFields: fieldList(field{key: "B_topk_aggregate", val: float64(81.55)}, field{key: "C_topk_aggregate", val: float64(49.96)})},
+		5: {newFields: fieldList(field{key: "C_topk_aggregate", val: float64(49.96)})},
 	}
 	answer := generateAns(input, changeSet)
 
@@ -425,7 +426,7 @@ func TestTopkGroupbyMetricName1(t *testing.T) {
 	input := deepCopy(MetricsSet2)
 
 	// Generate the answer
-	chng := fieldList(field{"value_topk_aggregate", float64(235.22000000000003)})
+	chng := fieldList(field{key: "value_topk_aggregate", val: float64(235.22000000000003)})
 	changeSet := map[int]metricChange{
 		3: {newFields: chng},
 		4: {newFields: chng},
@@ -453,10 +454,10 @@ func TestTopkGroupbyMetricName2(t *testing.T) {
 
 	// Generate the answer
 	changeSet := map[int]metricChange{
-		0: {newFields: fieldList(field{"A_topk_aggregate", float64(95.36)})},
-		1: {newFields: fieldList(field{"A_topk_aggregate", float64(78.02)}, field{"value_topk_aggregate", float64(133.61)})},
-		2: {newFields: fieldList(field{"A_topk_aggregate", float64(78.02)}, field{"value_topk_aggregate", float64(133.61)})},
-		4: {newFields: fieldList(field{"value_topk_aggregate", float64(87.92)})},
+		0: {newFields: fieldList(field{key: "A_topk_aggregate", val: float64(95.36)})},
+		1: {newFields: fieldList(field{key: "A_topk_aggregate", val: float64(78.02)}, field{key: "value_topk_aggregate", val: float64(133.61)})},
+		2: {newFields: fieldList(field{key: "A_topk_aggregate", val: float64(78.02)}, field{key: "value_topk_aggregate", val: float64(133.61)})},
+		4: {newFields: fieldList(field{key: "value_topk_aggregate", val: float64(87.92)})},
 	}
 	answer := generateAns(input, changeSet)
 

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -45,10 +45,11 @@ func MockMetrics() []cua.Metric {
 }
 
 // TestMetric Returns a simple test point:
-//     measurement -> "test1" or name
-//     tags -> "tag1":"value1"
-//     value -> value
-//     time -> time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+//
+//	measurement -> "test1" or name
+//	tags -> "tag1":"value1"
+//	value -> value
+//	time -> time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
 func TestMetric(value interface{}, name ...string) cua.Metric {
 	if value == nil {
 		panic("Cannot use a nil value")


### PR DESCRIPTION
This PR is just housekeeping...

* feat(lint): update golangci-lint to 1.49
* fix(lint): structcheck, deadcode, varcheck deprecated
* fix(lint): G114: Use of net/http serve function that has no support for setting timeouts
* fix(lint): SA1019: config.BuildNameToCertificate has been deprecated since Go 1.14: NameToCertificate only allows associating a single certificate with a given name. Leave that field nil to let the library select the first compatible chain from Certificates.
* fix(lint): G402: TLS MinVersion too low.
* fix(lint): G112: Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server
* fix(lint): ioutil deprecation
* fix(gopls): struct alignment
* fix(lint): File is not `gofmt`-ed with `-s`