### PR TITLE
Add optional credentials_file to stackdriver input plugin

### DIFF
--- a/plugins/inputs/stackdriver/README.md
+++ b/plugins/inputs/stackdriver/README.md
@@ -15,6 +15,11 @@ costs.
   ## GCP Project
   project = "erudite-bloom-151019"
 
+  ## Optional. Filepath for GCP credentials JSON file to authorize calls to
+  ## monitoring APIs. If not set explicitly, the agent will attempt to use
+  ## Application Default Credentials, which is preferred.
+  # credentials_file = "path/to/my/creds.json"
+
   ## Include timeseries that start with the given metric type.
   metric_type_prefix_include = [
     "compute.googleapis.com/",

--- a/plugins/inputs/stackdriver_circonus/README.md
+++ b/plugins/inputs/stackdriver_circonus/README.md
@@ -17,6 +17,11 @@ costs.
   ## GCP Project
   project = "erudite-bloom-151019"
 
+  ## Optional. Filepath for GCP credentials JSON file to authorize calls to
+  ## monitoring APIs. If not set explicitly, the agent will attempt to use
+  ## Application Default Credentials, which is preferred.
+  # credentials_file = "path/to/my/creds.json"
+  
   ## Most metrics are updated no more than once per minute; it is recommended
   ## to override the agent level interval with a value of 1m or greater.
   interval = "1m"

--- a/plugins/inputs/stackdriver_circonus/stackdriver.go
+++ b/plugins/inputs/stackdriver_circonus/stackdriver.go
@@ -19,12 +19,12 @@ import (
 	"github.com/circonus-labs/circonus-unified-agent/selfstat"
 	googlepbduration "github.com/golang/protobuf/ptypes/duration"
 	googlepbts "github.com/golang/protobuf/ptypes/timestamp"
+	"golang.org/x/oauth2/google"
 	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
 	distributionpb "google.golang.org/genproto/googleapis/api/distribution"
 	metricpb "google.golang.org/genproto/googleapis/api/metric"
 	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
-	"google.golang.org/api/option"
-	"golang.org/x/oauth2/google"
 )
 
 const (
@@ -462,9 +462,9 @@ func (s *Stackdriver) initializeStackdriverClient(ctx context.Context) error {
 	if s.CredentialsFile != "" {
 		credsOpt = option.WithCredentialsFile(s.CredentialsFile)
 	} else {
-		creds, err := google.FindDefaultCredentials(context.Background(), monitoring.DefaultAuthScopes())
+		creds, err := google.FindDefaultCredentials(context.Background())
 		if err != nil {
-			return nil, fmt.Errorf(
+			return fmt.Errorf(
 				"unable to find GCP Application Default Credentials: %w."+
 					"Either set ADC or provide CredentialsFile config", err)
 		}

--- a/plugins/inputs/stackdriver_circonus/stackdriver.go
+++ b/plugins/inputs/stackdriver_circonus/stackdriver.go
@@ -23,6 +23,8 @@ import (
 	distributionpb "google.golang.org/genproto/googleapis/api/distribution"
 	metricpb "google.golang.org/genproto/googleapis/api/metric"
 	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
+	"google.golang.org/api/option"
+	"golang.org/x/oauth2/google"
 )
 
 const (
@@ -30,6 +32,11 @@ const (
 	description      = "Gather timeseries from Google Cloud Platform v3 monitoring API"
 	sampleConfig     = `
   instance_id = "" # unique instance identifier (REQUIRED)
+
+	## Optional. Filepath for GCP credentials JSON file to authorize calls to
+  ## Stackdriver APIs. If not set explicitly, the agent will attempt to use
+  ## Application Default Credentials, which is preferred.
+  # credentials_file = "path/to/my/creds.json"
 
   ## GCP Project
   project = "erudite-bloom-151019"
@@ -115,6 +122,7 @@ type Stackdriver struct {
 	Log                             cua.Logger
 	timeSeriesConfCache             *timeSeriesConfCache
 	Filter                          *ListTimeSeriesFilter `toml:"filter"`
+	CredentialsFile                 string                `toml:"credentials_file"`
 	Project                         string                `toml:"project"`
 	MetricTypePrefixExclude         []string
 	MetricTypePrefixInclude         []string
@@ -450,8 +458,20 @@ func (c *timeSeriesConfCache) IsValid() bool {
 }
 
 func (s *Stackdriver) initializeStackdriverClient(ctx context.Context) error {
+	var credsOpt option.ClientOption
+	if s.CredentialsFile != "" {
+		credsOpt = option.WithCredentialsFile(s.CredentialsFile)
+	} else {
+		creds, err := google.FindDefaultCredentials(context.Background(), monitoring.DefaultAuthScopes())
+		if err != nil {
+			return nil, fmt.Errorf(
+				"unable to find GCP Application Default Credentials: %w."+
+					"Either set ADC or provide CredentialsFile config", err)
+		}
+		credsOpt = option.WithCredentials(creds)
+	}
 	if s.client == nil {
-		client, err := monitoring.NewMetricClient(ctx)
+		client, err := monitoring.NewMetricClient(ctx, credsOpt)
 		if err != nil {
 			return fmt.Errorf("failed to create stackdriver monitoring client: %w", err)
 		}


### PR DESCRIPTION
# Summary 

- Adds an optional `credentials_file` configuration field to the stackdriver input plugin. If no file is provided, uses the default credentials like it was previously doing.
- Also updates the stackdriver input plugin readme

Thanks for making cua open source. 