### PR TITLE
v0.0.48

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.0.48
+
+* feat: add `check_target` to generic input plugin config to allow creating configs that can be migrated to different CUA instances [CIRC-9205]
+* feat: (stackdriver) Add optional `credentials_file` config setting
+
 # v0.0.47
 
 * feat: (snmp) Add CUA post-processing for a subset of SNMP metrics in the most efficient way to derive error and discard rate metrics. [CIRC-9100]

--- a/config/config.go
+++ b/config/config.go
@@ -1347,6 +1347,7 @@ func (c *Config) buildInput(name string, tbl *ast.Table) (*models.InputConfig, e
 	}
 	// mgm:add `check_tags` - add to check bundle on creation ONLY
 	c.getFieldStringMap(tbl, "check_tags", &cp.CheckTags)
+	c.getFieldString(tbl, "check_target", &cp.CheckTarget)
 
 	cp.Tags = make(map[string]string)
 	if node, ok := tbl.Fields["tags"]; ok {

--- a/cua/metric.go
+++ b/cua/metric.go
@@ -146,4 +146,8 @@ type Metric interface {
 	OriginCheckTags() map[string]string
 	// SetOriginCheckTags sets the origin check tags
 	SetOriginCheckTags(map[string]string)
+	// OriginCheckTarget gets the origin check target
+	OriginCheckTarget() string
+	// SetOriginCheckTarget sets the origin check target
+	SetOriginCheckTarget(string)
 }

--- a/internal/circonus/circonus.go
+++ b/internal/circonus/circonus.go
@@ -45,6 +45,7 @@ type MetricMeta struct {
 type MetricDestConfig struct {
 	DebugAPI     *bool             // allow override of api debugging per output
 	TraceMetrics *string           // allow override of metric tracing per output
+	CheckTarget  string            // check target
 	CheckTags    map[string]string // tags for a specific instance of a check
 	APIToken     string            // allow override of api token for a specific plugin (dm input or circonus output)
 	Broker       string            // allow override of broker for a specific plugin (dm input or circonus output)
@@ -373,6 +374,9 @@ func NewMetricDestination(opts *MetricDestConfig, logger cua.Logger) (*trapmetri
 	}
 
 	checkTarget := hostname
+	if opts.CheckTarget != "" {
+		checkTarget = opts.CheckTarget
+	}
 
 	instanceLogger := &Logshim{
 		logh:     logger,

--- a/metric/metric.go
+++ b/metric/metric.go
@@ -10,15 +10,16 @@ import (
 )
 
 type metric struct {
-	tm              time.Time
-	name            string
-	originInstance  string
-	origin          string
-	originCheckTags map[string]string
-	fields          []*cua.Field
-	tags            []*cua.Tag
-	tp              cua.ValueType
-	aggregate       bool
+	tm                time.Time
+	name              string
+	originInstance    string
+	origin            string
+	originCheckTarget string
+	originCheckTags   map[string]string
+	fields            []*cua.Field
+	tags              []*cua.Tag
+	tp                cua.ValueType
+	aggregate         bool
 }
 
 func New(
@@ -70,15 +71,16 @@ func New(
 // removed.
 func FromMetric(other cua.Metric) cua.Metric {
 	m := &metric{
-		name:            other.Name(),
-		tags:            make([]*cua.Tag, len(other.TagList())),
-		fields:          make([]*cua.Field, len(other.FieldList())),
-		tm:              other.Time(),
-		tp:              other.Type(),
-		aggregate:       other.IsAggregate(),
-		origin:          other.Origin(),
-		originInstance:  other.OriginInstance(),
-		originCheckTags: make(map[string]string),
+		name:              other.Name(),
+		tags:              make([]*cua.Tag, len(other.TagList())),
+		fields:            make([]*cua.Field, len(other.FieldList())),
+		tm:                other.Time(),
+		tp:                other.Type(),
+		aggregate:         other.IsAggregate(),
+		origin:            other.Origin(),
+		originInstance:    other.OriginInstance(),
+		originCheckTags:   make(map[string]string),
+		originCheckTarget: other.OriginCheckTarget(),
 	}
 
 	for i, tag := range other.TagList() {
@@ -243,15 +245,16 @@ func (m *metric) SetTime(t time.Time) {
 
 func (m *metric) Copy() cua.Metric {
 	m2 := &metric{
-		name:            m.name,
-		tags:            make([]*cua.Tag, len(m.tags)),
-		fields:          make([]*cua.Field, len(m.fields)),
-		tm:              m.tm,
-		tp:              m.tp,
-		aggregate:       m.aggregate,
-		origin:          m.origin,
-		originInstance:  m.originInstance,
-		originCheckTags: make(map[string]string),
+		name:              m.name,
+		tags:              make([]*cua.Tag, len(m.tags)),
+		fields:            make([]*cua.Field, len(m.fields)),
+		tm:                m.tm,
+		tp:                m.tp,
+		aggregate:         m.aggregate,
+		origin:            m.origin,
+		originInstance:    m.originInstance,
+		originCheckTags:   make(map[string]string),
+		originCheckTarget: m.originCheckTarget,
 	}
 
 	for i, tag := range m.tags {
@@ -424,4 +427,11 @@ func (m *metric) SetOriginCheckTags(checkTags map[string]string) {
 	for k, v := range checkTags {
 		m.originCheckTags[k] = v
 	}
+}
+
+func (m *metric) OriginCheckTarget() string {
+	return m.originCheckTarget
+}
+func (m *metric) SetOriginCheckTarget(checkTarget string) {
+	m.originCheckTarget = checkTarget
 }

--- a/models/running_input.go
+++ b/models/running_input.go
@@ -74,6 +74,7 @@ type InputConfig struct {
 	NameOverride      string
 	MeasurementPrefix string
 	MeasurementSuffix string
+	CheckTarget       string
 	CheckTags         map[string]string
 	Filter            Filter
 	Precision         time.Duration
@@ -115,6 +116,8 @@ func (r *RunningInput) MakeMetric(metric cua.Metric) cua.Metric {
 
 	m.SetOrigin(r.Config.Name)
 	m.SetOriginInstance(r.Config.InstanceID)
+	m.SetOriginCheckTags(r.Config.CheckTags)
+	m.SetOriginCheckTarget(r.Config.CheckTarget)
 
 	r.Config.Filter.Modify(metric)
 	if len(metric.FieldList()) == 0 {

--- a/plugins/inputs/ping/ping.go
+++ b/plugins/inputs/ping/ping.go
@@ -46,7 +46,8 @@ type Ping struct {
 	Method            string            // Method defines how to ping (native or exec)
 	Interface         string            // Interface or source address to send ping from (ping -I/-S <INTERFACE/SRC_ADDR>)
 	InstanceID        string            `toml:"instance_id"`
-	CheckTags         map[string]string `toml:"check_tags"` // direct metrics mode - list of tags to add to check when created
+	CheckTarget       string            `toml:"check_target"` // direct metrics mode - check target
+	CheckTags         map[string]string `toml:"check_tags"`   // direct metrics mode - list of tags to add to check when created
 	Tags              map[string]string // need static inpupt tags for direct metrics
 	Urls              []string          // URLs to ping
 	Percentiles       []int             // Calculate the given percentiles when using native method
@@ -396,6 +397,7 @@ func (p *Ping) Init() error {
 			DebugAPI:     p.DebugAPI,
 			TraceMetrics: p.TraceMetrics,
 			CheckTags:    p.CheckTags,
+			CheckTarget:  p.CheckTarget,
 		}
 		dest, err := circmgr.NewMetricDestination(opts, p.Log)
 		if err != nil {

--- a/plugins/inputs/snmp/snmp.go
+++ b/plugins/inputs/snmp/snmp.go
@@ -121,6 +121,7 @@ type Snmp struct {
 	Name              string                   // Name & Fields are the elements of a Table.
 	AgentHostTag      string                   `toml:"agent_host_tag"` // The tag used to name the agent host
 	InstanceID        string                   `toml:"instance_id"`    // direct metrics mode - send directly to circonus (bypassing output)
+	CheckTarget       string                   `toml:"check_target"`   // direct metrics mode - check target setting
 	Tables            []Table                  `toml:"table"`
 	Fields            []Field                  `toml:"field"` // Name & Fields are the elements of a Table. agent chokes if we try to embed a Table. So instead we have to embed the fields of a Table, and construct a Table during runtime.
 	connectionCache   []snmpConnection
@@ -157,6 +158,7 @@ func (s *Snmp) init() error {
 			DebugAPI:     s.DebugAPI,
 			TraceMetrics: s.TraceMetrics,
 			CheckTags:    s.CheckTags,
+			CheckTarget:  s.CheckTarget,
 		}
 		dest, err := circmgr.NewMetricDestination(opts, s.Log)
 		if err != nil {

--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -178,7 +178,8 @@ type Statsd struct {
 	metricDestination      *trapmetrics.TrapMetrics
 	TCPKeepAlivePeriod     *internal.Duration `toml:"tcp_keep_alive_period"`
 	bufPool                sync.Pool
-	Broker                 string `toml:"broker"` // direct metrics
+	CheckTarget            string `toml:"check_target"` // direct metrics - check target
+	Broker                 string `toml:"broker"`       // direct metrics
 	MetricSeparator        string
 	ServiceAddress         string
 	Protocol               string `toml:"protocol"`
@@ -365,6 +366,7 @@ func (s *Statsd) Start(ctx context.Context, ac cua.Accumulator) error {
 		DebugAPI:     s.DebugAPI,
 		TraceMetrics: s.TraceMetrics,
 		CheckTags:    s.CheckTags,
+		CheckTarget:  s.CheckTarget,
 	}
 
 	dest, err := circmgr.NewMetricDestination(opts, s.Log)

--- a/plugins/outputs/circonus/circonus.go
+++ b/plugins/outputs/circonus/circonus.go
@@ -149,7 +149,7 @@ func (c *Circonus) Connect() error {
 			PluginID:   "agent",
 			InstanceID: config.DefaultInstanceID(),
 		}
-		if err := c.initMetricDestination(meta); err != nil {
+		if err := c.initMetricDestination(meta, map[string]string{}, ""); err != nil {
 			c.Log.Errorf("unable to initialize circonus metric destination (%s)", err)
 			return err
 		}
@@ -166,7 +166,7 @@ func (c *Circonus) Connect() error {
 					PluginID:   "host",
 					InstanceID: config.DefaultInstanceID(),
 				}
-				if err := c.initMetricDestination(meta); err != nil {
+				if err := c.initMetricDestination(meta, map[string]string{}, ""); err != nil {
 					c.Log.Errorf("unable to initialize circonus metric destination (%s)", err)
 					return err
 				}

--- a/plugins/outputs/circonus/metric_destination.go
+++ b/plugins/outputs/circonus/metric_destination.go
@@ -72,7 +72,7 @@ func (c *Circonus) getMetricDestination(m cua.Metric) *metricDestination {
 		return d
 	}
 
-	if err := c.initMetricDestination(metricMeta); err != nil {
+	if err := c.initMetricDestination(metricMeta, m.OriginCheckTags(), m.OriginCheckTarget()); err != nil {
 		c.Log.Errorf("error initializing metric destination: %s", err)
 		os.Exit(1) //nolint:gocritic
 	}
@@ -87,7 +87,7 @@ func (c *Circonus) getMetricDestination(m cua.Metric) *metricDestination {
 	return nil
 }
 
-func (c *Circonus) initMetricDestination(metricMeta circmgr.MetricMeta) error {
+func (c *Circonus) initMetricDestination(metricMeta circmgr.MetricMeta, checkTags map[string]string, checkTarget string) error {
 	c.Lock()
 	defer c.Unlock()
 
@@ -97,6 +97,8 @@ func (c *Circonus) initMetricDestination(metricMeta circmgr.MetricMeta) error {
 		Broker:       c.Broker,
 		DebugAPI:     c.DebugAPI,
 		TraceMetrics: c.TraceMetrics,
+		CheckTarget:  checkTarget,
+		CheckTags:    checkTags,
 	}
 
 	dest, err := circmgr.NewMetricDestination(&opts, c.Log)


### PR DESCRIPTION
* feat: add `check_target` to generic input plugin config to allow creating configs that can be migrated to different CUA instances [CIRC-9205]
* feat: (stackdriver) Add optional `credentials_file` config setting


[CIRC-9205]: https://circonus.atlassian.net/browse/CIRC-9205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ