### PR TITLE
Stackdriver circonus

### DIFF
--- a/etc/config.d/README.md
+++ b/etc/config.d/README.md
@@ -1,0 +1,1 @@
+Add additional individual plugin configurations in separate files to this directory. Ensure service is started with `--config-directory=/opt/circonus/unified-agent/etc/config.d`.

--- a/plugins/inputs/stackdriver/stackdriver_test.go
+++ b/plugins/inputs/stackdriver/stackdriver_test.go
@@ -23,12 +23,11 @@ type Call struct {
 }
 
 type MockStackdriverClient struct {
+	sync.Mutex
 	ListMetricDescriptorsF func(ctx context.Context, req *monitoringpb.ListMetricDescriptorsRequest) (<-chan *metricpb.MetricDescriptor, error)
 	ListTimeSeriesF        func(ctx context.Context, req *monitoringpb.ListTimeSeriesRequest) (<-chan *monitoringpb.TimeSeries, error)
 	CloseF                 func() error
-
-	calls []*Call
-	sync.Mutex
+	calls                  []*Call
 }
 
 func (m *MockStackdriverClient) ListMetricDescriptors(

--- a/plugins/inputs/stackdriver_circonus/README.md
+++ b/plugins/inputs/stackdriver_circonus/README.md
@@ -11,7 +11,7 @@ costs.
 ## Configuration
 
 ```toml
-[[inputs.stackdriver]]
+[[inputs.stackdriver_circonus]]
   instance_id = "" # unique instance identifier (REQUIRED)
 
   ## GCP Project
@@ -21,7 +21,15 @@ costs.
   ## monitoring APIs. If not set explicitly, the agent will attempt to use
   ## Application Default Credentials, which is preferred.
   # credentials_file = "path/to/my/creds.json"
-  
+
+  ## Include timeseries that start with the given metric type.
+  metric_type_prefix_include = [
+    "compute.googleapis.com/",
+  ]
+
+  ## Exclude timeseries that start with the given metric type.
+  # metric_type_prefix_exclude = []
+
   ## Most metrics are updated no more than once per minute; it is recommended
   ## to override the agent level interval with a value of 1m or greater.
   interval = "1m"


### PR DESCRIPTION
This is a fix to the Circonus stack driver input plugin to re-enable `metric_type_prefix_include` option that was removed initially for fancy check display names and automated dashboards.