### PR TITLE
CIRC-9378

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/cenkalti/backoff v2.0.0+incompatible // indirect
 	github.com/circonus-labs/go-apiclient v0.7.18
 	github.com/circonus-labs/go-trapcheck v0.0.9
-	github.com/circonus-labs/go-trapmetrics v0.0.9
+	github.com/circonus-labs/go-trapmetrics v0.0.10
 	github.com/cisco-ie/nx-telemetry-proto v0.0.0-20220628142927-f4160bcb943c
 	github.com/cockroachdb/apd v1.1.0 // indirect
 	github.com/couchbase/go-couchbase v0.0.0-20180501122049-16db1f1fe037

--- a/go.sum
+++ b/go.sum
@@ -237,8 +237,8 @@ github.com/circonus-labs/go-apiclient v0.7.18 h1:OrRHUwoFroEUN+3KylQkdQOaTN1s3SC
 github.com/circonus-labs/go-apiclient v0.7.18/go.mod h1:NCu3kJ282ZGzr7vxzFH/S28y1nW9DZ37f8L7veDENFc=
 github.com/circonus-labs/go-trapcheck v0.0.9 h1:avgxD4QyB44sNl8IkjeA68/L8Yanl0YdwrCJdME0Qfg=
 github.com/circonus-labs/go-trapcheck v0.0.9/go.mod h1:xZpt1/2XJTmhcvW/OOGrv4zW4SHNzj4twr6tY9IkXeQ=
-github.com/circonus-labs/go-trapmetrics v0.0.9 h1:LOkjSuR4Hv3wIz6kPUbfrg0BWr5fpX4MBUbE34Q5pD8=
-github.com/circonus-labs/go-trapmetrics v0.0.9/go.mod h1:ojDq1/l0z+CYgrnOjvU2xKejBHjn0wHGLLjxfxCHCr8=
+github.com/circonus-labs/go-trapmetrics v0.0.10 h1:G0qTlbkrTShAG5tRBX61KwBLGsjfFZGMdklRspaFW8I=
+github.com/circonus-labs/go-trapmetrics v0.0.10/go.mod h1:ojDq1/l0z+CYgrnOjvU2xKejBHjn0wHGLLjxfxCHCr8=
 github.com/cisco-ie/nx-telemetry-proto v0.0.0-20220628142927-f4160bcb943c h1:k3y2XtIffIk230a+e0d7vbs5ebTvH3OcCMKN/jS6IAY=
 github.com/cisco-ie/nx-telemetry-proto v0.0.0-20220628142927-f4160bcb943c/go.mod h1:rJDd05J5hqWVU9MjJ+5jw1CuLn/jRhvU0xtFEzzqjwM=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=


### PR DESCRIPTION
 build(deps): bump github.com/circonus-labs/go-trapmetrics from v0.0.9 to v0.0.10