### PR TITLE
initialize json_v2 parser with logger

### DIFF
--- a/plugins/parsers/registry.go
+++ b/plugins/parsers/registry.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/circonus-labs/circonus-unified-agent/cua"
+	"github.com/circonus-labs/circonus-unified-agent/models"
 	"github.com/circonus-labs/circonus-unified-agent/plugins/parsers/collectd"
 	"github.com/circonus-labs/circonus-unified-agent/plugins/parsers/csv"
 	"github.com/circonus-labs/circonus-unified-agent/plugins/parsers/dropwizard"
@@ -367,5 +368,6 @@ func NewJSONPathParser(jsonv2config []JSONV2Config) (Parser, error) {
 	}
 	return &json_v2.Parser{
 		Configs: configs,
+		Log:     models.NewLogger("parsers", "json_v2", ""),
 	}, nil
 }


### PR DESCRIPTION
This PR initializes the logger as part of the registration process. Without this the code will panic when it hits a reference to the Logger for the parser struct. 