### PR TITLE
[OP-1938] Fixed missing semi-colons for the --apiurl option.

### DIFF
--- a/install/install_linux.sh
+++ b/install/install_linux.sh
@@ -99,6 +99,7 @@ __parse_parameters() {
             else
                 fail "--url must be followed by an api url."
             fi
+            ;;
         (--arch)
             if [[ -n "${1:-}" ]]; then
                 pkg_arch="$1"


### PR DESCRIPTION
This fixes a small bug in the linux install script.